### PR TITLE
chore: streamline Dockerfile

### DIFF
--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.10.0-alpine
 
-LABEL org.opencontainers.image.title="ssr-boost"
+LABEL org.opencontainers.image.title="vite-ssr-boost"
 LABEL org.opencontainers.image.description="Container to run pre-built 'ssr-boost' Vike SSR applications"
 LABEL org.opencontainers.image.authors="Yarmaliuk Mikhail <mikhail.yarmaliuk@lomray.com>"
 LABEL org.opencontainers.image.url="https://github.com/Lomray-Software/vite-ssr-boost"

--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:20.10.0-alpine
 
-MAINTAINER Yarmaliuk Mikhail <mikhail.yarmaliuk@lomray.com>
+LABEL org.opencontainers.image.title="ssr-boost"
+LABEL org.opencontainers.image.description="Container to run pre-built 'ssr-boost' Vike SSR applications"
+LABEL org.opencontainers.image.authors="Yarmaliuk Mikhail <mikhail.yarmaliuk@lomray.com>"
+LABEL org.opencontainers.image.url="https://github.com/Lomray-Software/vite-ssr-boost"
+LABEL org.opencontainers.image.vendor="Lomray Software"
+LABEL org.opencontainers.image.licenses=MIT
 
 ARG BUILD_PATH
 ARG RUN_TYPE=ssr
@@ -15,10 +20,13 @@ RUN mkdir -p $WEB_PATH
 
 WORKDIR $WEB_PATH
 
-COPY ${BUILD_PATH} $WEB_PATH/build
-COPY ./package.json $WEB_PATH/package.json
-COPY package-lock.json* yarn.lock* pnpm-lock.yaml* $WEB_PATH
+COPY package.json ./
+COPY package-lock.json* ./
+COPY yarn.lock* ./
+COPY pnpm-lock.yaml* ./
 
 RUN ${INSTALL_COMMAND}
+
+COPY ${BUILD_PATH} $WEB_PATH/build
 
 CMD npm run start:${TYPE} -- --host

--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.10.0-alpine
 
 LABEL org.opencontainers.image.title="vite-ssr-boost"
-LABEL org.opencontainers.image.description="Container to run pre-built 'ssr-boost' Vike SSR applications"
+LABEL org.opencontainers.image.description="Container to run pre-built 'vite-ssr-boost' applications"
 LABEL org.opencontainers.image.authors="Yarmaliuk Mikhail <mikhail.yarmaliuk@lomray.com>"
 LABEL org.opencontainers.image.url="https://github.com/Lomray-Software/vite-ssr-boost"
 LABEL org.opencontainers.image.vendor="Lomray Software"


### PR DESCRIPTION
* Replaced 'MAINTAINER' designation with 'LABEL' designation due to [deprecation notice](https://docs.docker.com/reference/dockerfile/#maintainer-deprecated).
* Moved 'COPY' of built code to penultimate line to take advantage of layer caching 
   * Before: <img width="1187" alt="before" src="https://github.com/Lomray-Software/vite-ssr-boost/assets/2438061/7c65b90d-06f2-43cc-abcd-539c6c326f25">
   * After: <img width="1173" alt="after" src="https://github.com/Lomray-Software/vite-ssr-boost/assets/2438061/9544981b-14c6-43ff-a688-2c5e93d435a5">
* Guessed at values for other recommended LABELs, please feel free to request change or removal.

