### PR TITLE
docs: link the free performance audit from README and docs footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ npm i @lomray/vite-ssr-boost
 
 Full documentation lives here: [lomray-software.github.io/vite-ssr-boost](https://lomray-software.github.io/vite-ssr-boost/)
 
+## Check a deployed app
+
+Already running this in production? Point our [free performance audit](https://audit.lomray.com/?utm_source=github&utm_medium=readme-vite-ssr-boost&utm_campaign=owned-surface-github) at the URL. It reports Core Web Vitals, JavaScript bundle weight and whether the HTML really arrives server-rendered. No signup.
+
 ## License
 
 Made with 💚

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -66,7 +66,8 @@ export default defineConfig({
       { icon: 'github', link: 'https://github.com/Lomray-Software/vite-ssr-boost' },
     ],
     footer: {
-      message: 'Released under the MIT License.',
+      message:
+        'Released under the MIT License. &middot; <a href="https://audit.lomray.com/?utm_source=github-pages&amp;utm_medium=docs-vite-ssr-boost&amp;utm_campaign=owned-surface-github" target="_blank" rel="noopener">Free performance audit for your deployed app</a>',
       copyright: 'Copyright © Lomray Software',
     },
   },


### PR DESCRIPTION
Adds one tagged link to audit.lomray.com from the two surfaces this repo owns:

- `README.md` — a short section after Documentation (`utm_medium=readme-vite-ssr-boost`)
- `docs/.vitepress/config.ts` — the VitePress footer, which renders on every docs page (`utm_medium=docs-vite-ssr-boost`)

Both carry `utm_campaign=owned-surface-github`, so the audit funnel reader classifies these arrivals as owned-surface by prefix and they never inflate the external cohort. Docs-only, no version bump.