### PR TITLE
fix: pre-bundle browser entry dependencies for cold development starts

### DIFF
--- a/__tests__/plugin-config-branches.ts
+++ b/__tests__/plugin-config-branches.ts
@@ -54,6 +54,106 @@ describe('ViteSsrBoostPlugin branches', () => {
     expect(names).toContain('@lomray/vite-ssr-boost-create-spa-entrypoint');
     expect(names).toContain('@lomray/vite-ssr-boost-handle-custom-entrypoint');
   });
+
+  it('should pre-bundle browser imports and preserve user optimization options in development', () => {
+    process.env.SSR_BOOST_ACTION = CliActions.dev;
+    const plugin = ViteSsrBoostPlugin()[0]!;
+    const exclude = ['custom-excluded'];
+    const ssr = { optimizeDeps: { include: ['server-only'] } };
+    const config = getConfigHook(plugin)(
+      {
+        optimizeDeps: { include: ['custom-included', 'react'], exclude, entries: ['custom.html'] },
+        ssr,
+      },
+      { command: 'serve', isSsrBuild: false },
+    );
+
+    expect(config.optimizeDeps.include).toEqual(
+      expect.arrayContaining([
+        'custom-included',
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react-router',
+        'hoist-non-react-statics',
+        `${PLUGIN_NAME}/browser/entry`,
+        `${PLUGIN_NAME}/browser/entry.js`,
+        `${PLUGIN_NAME}/helpers/import-route`,
+        `${PLUGIN_NAME}/helpers/get-server-state`,
+        `${PLUGIN_NAME}/components/only-client`,
+        `${PLUGIN_NAME}/constants/common`,
+        `${PLUGIN_NAME}/context/server`,
+      ]),
+    );
+    expect(config.optimizeDeps.include.filter((id: string) => id === 'react')).toHaveLength(1);
+    expect(config.optimizeDeps.exclude).toBe(exclude);
+    expect(config.optimizeDeps.entries).toEqual(['custom.html']);
+    expect(config.ssr).toBe(ssr);
+    expect(ssr).toEqual({ optimizeDeps: { include: ['server-only'] } });
+  });
+
+  it('should respect excluded packages, subpaths and both public extension spellings', () => {
+    const plugin = ViteSsrBoostPlugin()[0]!;
+    const exclude = [
+      'react-dom',
+      `${PLUGIN_NAME}/components`,
+      `${PLUGIN_NAME}/helpers/import-route.js`,
+      `${PLUGIN_NAME}/browser/entry`,
+      'custom-excluded',
+    ];
+    const config = getConfigHook(plugin)(
+      {
+        optimizeDeps: {
+          include: ['custom-included', 'custom-excluded', 'react-dom/client'],
+          exclude,
+        },
+      },
+      { command: 'serve', isSsrBuild: false },
+    );
+
+    expect(config.optimizeDeps.exclude).toBe(exclude);
+    expect(config.optimizeDeps.include).toContain('custom-included');
+    expect(config.optimizeDeps.include).toContain('react');
+    expect(config.optimizeDeps.include).toContain(`${PLUGIN_NAME}/helpers/get-server-state`);
+    expect(config.optimizeDeps.include).not.toContain('custom-excluded');
+    expect(config.optimizeDeps.include).not.toContain('react-dom');
+    expect(config.optimizeDeps.include).not.toContain('react-dom/client');
+    expect(config.optimizeDeps.include).not.toContain(`${PLUGIN_NAME}/helpers/import-route`);
+    expect(config.optimizeDeps.include).not.toContain(`${PLUGIN_NAME}/helpers/import-route.js`);
+    expect(config.optimizeDeps.include).not.toContain(`${PLUGIN_NAME}/browser/entry`);
+    expect(config.optimizeDeps.include).not.toContain(`${PLUGIN_NAME}/browser/entry.js`);
+    expect(config.optimizeDeps.include.some((id: string) => id.includes('/components/'))).toBe(
+      false,
+    );
+  });
+
+  it('should allow excluding all package browser imports', () => {
+    const config = getConfigHook(ViteSsrBoostPlugin()[0]!)(
+      { optimizeDeps: { exclude: [PLUGIN_NAME] } },
+      { command: 'serve', isSsrBuild: false },
+    );
+
+    expect(config.optimizeDeps.include.some((id: string) => id.startsWith(PLUGIN_NAME))).toBe(
+      false,
+    );
+    expect(config.optimizeDeps.include).toContain('react');
+  });
+
+  it.each([false, true])(
+    'should leave optimization untouched during build (SSR: %s)',
+    (isSsrBuild) => {
+      process.env.SSR_BOOST_ACTION = CliActions.build;
+      const optimizeDeps = { include: ['user-dependency'], exclude: ['react'] };
+      const ssr = { optimizeDeps: { include: ['server-only'] } };
+      const hook = getConfigHook(ViteSsrBoostPlugin()[0]!);
+      const config = hook({ optimizeDeps, ssr }, { command: 'build', isSsrBuild });
+
+      expect(config.optimizeDeps).toBe(optimizeDeps);
+      expect(optimizeDeps).toEqual({ include: ['user-dependency'], exclude: ['react'] });
+      expect(config.ssr).toBe(ssr);
+      expect(hook({}, { command: 'build', isSsrBuild })).not.toHaveProperty('optimizeDeps');
+    },
+  );
 });
 const getConfigHook = (plugin: ReturnType<typeof ViteSsrBoostPlugin>[number]) =>
   (typeof plugin.config === 'function' ? plugin.config : plugin.config?.handler) as any;

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,6 +99,14 @@ Run `build:spa` before `start:spa`. For SSR, use `build` followed by `start:ssr`
 npm run develop
 ```
 
+### Development cold start
+
+On an empty Vite cache, dependencies discovered during the first page load can cause an
+`Invalid hook call` or a `useContext` error until Vite reloads the page. The plugin pre-bundles
+its browser entry, components and route helpers with their React dependencies before that
+first load. Existing optimization options are preserved. Use `optimizeDeps.exclude` to opt
+out for a package or a specific deep import.
+
 ## Recommended project shape
 
 ```txt

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -7,6 +7,8 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { once } from 'node:events';
 import assert from 'node:assert/strict';
 import { createGunzip } from 'node:zlib';
+import { stripVTControlCharacters } from 'node:util';
+import { parse } from '@babel/parser';
 
 const projectRoot = process.cwd();
 const source = resolve(process.argv[2] ?? join(projectRoot, '..', 'vite-template'));
@@ -239,6 +241,121 @@ const verify = async (origin, mode, base = '') => {
   );
 };
 
+const crawlModules = async (origin) => {
+  const response = await fetch(origin, { signal: AbortSignal.timeout(20_000) });
+  assert.equal(response.status, 200, 'cold development HTML status');
+  const html = await response.text();
+  const queue = [];
+  const seen = new Set();
+  const enqueue = (specifier, importer = origin) => {
+    if (!/^(?:https?:\/\/|\/|\.\.?\/)/.test(specifier)) return;
+    const url = new URL(specifier, importer);
+    if (url.origin !== origin || seen.has(url.href)) return;
+    assert.ok(seen.size < 600, 'cold development crawl exceeded 600 modules');
+    seen.add(url.href);
+    queue.push(url.href);
+  };
+
+  for (const [tag] of html.matchAll(/<(?:script|link)\b[^>]*>/gi)) {
+    const attributes = Object.fromEntries(
+      [...tag.matchAll(/([\w-]+)\s*=\s*["']([^"']*)["']/g)].map(([, name, value]) => [
+        name.toLowerCase(),
+        value,
+      ]),
+    );
+    if (/^<script\b/i.test(tag) && attributes.type === 'module' && attributes.src) {
+      enqueue(attributes.src);
+    } else if (/^<link\b/i.test(tag) && attributes.rel === 'modulepreload' && attributes.href) {
+      enqueue(attributes.href);
+    }
+  }
+  assert.ok(queue.length, 'cold development HTML has no module entries');
+
+  // Process each breadth before requesting dependencies discovered in it.
+  for (let index = 0; index < queue.length; index += 1) {
+    const url = queue[index];
+    let module = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+    // An optimizer reload can invalidate URLs already queued by the first response.
+    // Keep crawling for diagnostics; the caller still rejects the reload log.
+    if (module.status === 504 && new URL(url).searchParams.has('v')) {
+      await module.arrayBuffer();
+      const current = new URL(url);
+      current.searchParams.delete('v');
+      module = await fetch(current, { signal: AbortSignal.timeout(20_000) });
+    }
+    assert.equal(module.status, 200, `cold development module ${url}`);
+    assert.match(
+      module.headers.get('content-type') ?? '',
+      /javascript/,
+      `cold development module type ${url}`,
+    );
+    const nodes = [
+      parse(await module.text(), { sourceType: 'module', createImportExpressions: true }),
+    ];
+    while (nodes.length) {
+      const node = nodes.pop();
+      if (!node || typeof node !== 'object') continue;
+      if (
+        [
+          'ImportDeclaration',
+          'ExportNamedDeclaration',
+          'ExportAllDeclaration',
+          'ImportExpression',
+        ].includes(node.type) &&
+        node.source?.type === 'StringLiteral'
+      ) {
+        enqueue(node.source.value, url);
+      }
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) nodes.push(...value);
+        else if (value && typeof value === 'object' && 'type' in value) nodes.push(value);
+      }
+    }
+  }
+  console.info(`development cold start: crawled ${seen.size} modules`);
+};
+
+const verifyColdStart = async () => {
+  await rm(join(directory, 'node_modules', '.vite'), { force: true, recursive: true });
+
+  const port = await getPort();
+  await writeFile(join(directory, '.env.development.local'), `VITE_PORT=${port}\n`);
+  const child = spawn(process.execPath, [cli, 'dev', '--port', String(port)], {
+    cwd: directory,
+    env: { ...process.env, PATH: runtimePath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const closed = once(child, 'close');
+  let output = '';
+  const capture = (chunk) => {
+    output += chunk;
+  };
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+
+  try {
+    const origin = `http://127.0.0.1:${port}`;
+    await waitUntilReady(origin, child);
+    await crawlModules(origin);
+    await new Promise((resolveTimeout) => {
+      setTimeout(resolveTimeout, 5_000);
+    });
+    assert.ok(!hasExited(child), 'Cold development server exited during the crawl.');
+  } finally {
+    await stop(child);
+    await closed;
+    output = stripVTControlCharacters(output);
+    console.info(output);
+  }
+
+  assert.doesNotMatch(
+    output,
+    /new dependencies optimized|optimized dependencies changed|\bdependenc(?:y|ies) optimized:/,
+    'Cold development discovered dependencies after startup.',
+  );
+  console.info('development cold start: no late dependency optimization or reload');
+};
+
 const verifySpa = async (origin) => {
   for (const pathname of ['/', '/details', '/missing']) {
     const response = await fetch(`${origin}${pathname}`);
@@ -399,6 +516,8 @@ try {
   } finally {
     await stop(dev);
   }
+
+  await verifyColdStart();
 
   await run(['build']);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,6 +13,7 @@ import {
 import type { IPluginOptions as IMakeAliasesPluginOptions } from '@plugins/make-aliases';
 import ViteMakeAliasesPlugin from '@plugins/make-aliases';
 import ViteNormalizeRouterPlugin from '@plugins/normalize-route';
+import optimizeBrowserDependencies from '@plugins/optimize-browser-dependencies';
 import type { IBuildEntrypoint } from '@services/build';
 
 export interface IPluginOptions {
@@ -71,7 +72,7 @@ function ViteSsrBoostPlugin(options: IPluginOptions = {}): Plugin[] {
         isDev: action === CliActions.dev,
       },
 
-      config(config, { isSsrBuild }) {
+      config(config, { command, isSsrBuild }) {
         config.define = {
           ...(config.define ?? {}),
           __IS_SSR__: entrypointConfig ? entrypointConfig.type === 'ssr' : isSSR,
@@ -82,6 +83,10 @@ function ViteSsrBoostPlugin(options: IPluginOptions = {}): Plugin[] {
         };
 
         if (!isSsrBuild) {
+          if (command === 'serve') {
+            config.optimizeDeps = optimizeBrowserDependencies(config.optimizeDeps);
+          }
+
           if (isSSR && isBuild) {
             config.build.manifest = true;
           }

--- a/src/plugins/optimize-browser-dependencies.ts
+++ b/src/plugins/optimize-browser-dependencies.ts
@@ -1,0 +1,52 @@
+import type { DepOptimizationOptions } from 'vite';
+import PLUGIN_NAME from '@constants/plugin-name';
+
+// Enumerate deep imports so individual exclusions work without expanding a glob.
+// Both public spellings are exported by the package.
+const browserImports = [
+  'browser/entry',
+  'components/navigate',
+  'components/only-client',
+  'components/render-client',
+  'components/response-status',
+  'components/scroll-to-top',
+  'components/with-suspense',
+  'constants/common',
+  'context/server',
+  'helpers/get-server-state',
+  'helpers/import-route',
+  'interfaces/fc-route',
+].flatMap((id) => [`${PLUGIN_NAME}/${id}`, `${PLUGIN_NAME}/${id}.js`]);
+
+const browserDependencies = [
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react-router',
+  'hoist-non-react-statics',
+  ...browserImports,
+];
+
+const normalizeImport = (id: string): string =>
+  id.startsWith(`${PLUGIN_NAME}/`) ? id.replace(/\.js$/, '') : id;
+
+/**
+ * Include imports injected by route normalization before the first browser request.
+ */
+const optimizeBrowserDependencies = (
+  options: DepOptimizationOptions = {},
+): DepOptimizationOptions => ({
+  ...options,
+  include: [...new Set([...(options.include ?? []), ...browserDependencies])].filter(
+    (id) =>
+      !(options.exclude ?? []).some((excluded) => {
+        const dependency = normalizeImport(id);
+        const exclusion = normalizeImport(excluded).replace(/\/$/, '');
+
+        // Match Vite's package/subpath exclusions, including our .js aliases.
+        return dependency === exclusion || dependency.startsWith(`${exclusion}/`);
+      }),
+  ),
+});
+
+export default optimizeBrowserDependencies;


### PR DESCRIPTION
## Goal

Complete T9: prevent the cold-development dependency optimizer reload that can leave duplicate React copies on the first page load. Work is on `fix/dev-cold-start-optimize-deps`, based on `staging` at `ee08ece`, with `staging` as the intended PR target.

## Changes

- `src/plugin.ts` and `src/plugins/optimize-browser-dependencies.ts`: add development-only pre-bundling for React, React DOM/client, React Router, hoist-non-react-statics, and all browser runtime deep imports, including the transform-injected `helpers/import-route`; support extensionless and `.js` imports, preserve user options, and give package/subpath exclusions priority over includes.
- `__tests__/plugin-config-branches.ts`: cover preserved user includes/options, exclusion precedence, deep-import aliases, whole-package exclusions, and unchanged client/SSR build optimization configuration.
- `scripts/test-template.mjs`: after existing development checks, start a second server with an empty cache, crawl module scripts and modulepreloads breadth-first using the existing Babel parser, follow static/re-export/dynamic imports up to 600 modules, wait five seconds, and reject late optimization/reload messages; capture pipes only for this phase and stop the child in `finally`.
- `docs/guide/getting-started.md`: add the cold-start symptom, automatic pre-bundling behavior, and `optimizeDeps.exclude` escape hatch.

`include` is appropriate because route normalization injects `helpers/import-route` during transformation, after the initial dependency scan. Vite documents explicit includes for imports introduced by transforms. [Dependency pre-bundling](https://vite.dev/guide/dep-pre-bundling).

Changing `entries` would replace the app's default entry discovery. `holdUntilCrawlEnd` already defaults to true and controls waiting for static imports. Both settings remain under user control. Explicit deep-import entries also allow individual exclusions without relying on experimental include globs. [Dependency optimization options](https://vite.dev/config/dep-optimization-options).

## Verification

Commands ran on Node `v22.23.2`. CLI commands used `env -u NO_COLOR` because this sandbox otherwise conflicts with the CLI's `FORCE_COLOR`. Log excerpts below have terminal color escapes removed.

- Before the fix: `npm run build`, then `env -u NO_COLOR node /tmp/t9-diagnose.mjs before` → exit 0. The temporary driver copied tracked template files and `node_modules` using the acceptance script's copy procedure, ran `npm pack ./lib --ignore-scripts --pack-destination <copy>` and `npm install --no-save --ignore-scripts <archive>`, deleted the copy's `node_modules/.vite`, wrote `VITE_PORT`, and ran the CLI development server. It used the same crawl now in the acceptance script and waited five seconds before capturing the log.

Culprit list: `@lomray/vite-ssr-boost/helpers/import-route`.

Vite 8.2.2 uses `dependency optimized:` for this single dependency rather than `✨ new dependencies optimized:`. The check recognizes both formats.

```text
development cold start: crawled 84 modules
Starting the development server...

  SSR-BOOST v1.0.0  ready in 342 ms

  ➜  Mode:    development
  ➜  Type:    SSR
  ➜  Local:   http://127.0.0.1:56870/
  ➜  Network: use --host to expose
  ➜  press h to show help
12:09:29 AM [vite] (client) dependency optimized: @lomray/vite-ssr-boost/helpers/import-route
12:09:29 AM [vite] (client) optimized dependencies changed. reloading
```

- After rebuilding: `env -u NO_COLOR node /tmp/t9-diagnose.mjs after` → exit 0, using another fresh template copy and packed build. The complete captured server log contains neither `new dependencies optimized` nor `optimized dependencies changed`, and no Vite 8 `dependency optimized:` message.

```text
development cold start: crawled 78 modules
Starting the development server...

  SSR-BOOST v1.0.0  ready in 394 ms

  ➜  Mode:    development
  ➜  Type:    SSR
  ➜  Local:   http://127.0.0.1:58264/
  ➜  Network: use --host to expose
  ➜  press h to show help
```

- `npm run lint:check` → exit 0.

```text
> @lomray/vite-ssr-boost@1.0.0 lint:check
> eslint . --max-warnings=0
```

- `npm run ts:check` → exit 0.

```text
> @lomray/vite-ssr-boost@1.0.0 ts:check
> tsc --project ./tsconfig.json --skipLibCheck --noemit
```

- `npm test` → exit 0.

```text
Not implemented: navigation to another Document
Not implemented: navigation to another Document

 Test Files  75 passed (75)
      Tests  407 passed (407)
   Start at  00:11:44
   Duration  9.32s (environment 72%, tests 10%, import 8%, transform 6%, setup 3%, worker 1%)

Environment  jsdom was created 75 times · 64.91s total, 72% of tracked time
             create it once per worker with pool: 'vmThreads' (keeps per-file isolation) or isolate: false (shares it across files)
             learn more: https://vitest.dev/guide/improving-performance#test-environments
```

- `npm run build` → exit 0.

```text
> @lomray/vite-ssr-boost@1.0.0 build
> rollup -c


src/**/*.ts* → lib...
(!) Generated empty chunks
"core/types", "interfaces/fc", "interfaces/route-object", "node/http" and "cli/interfaces/actions"
created lib in 1.9s
```

- `env -u NO_COLOR node scripts/test-template.mjs /Users/mikhail/work/lomray/agent/vite-template-t3` → exit 0. Final runs were sequential. Runtime: Vite 8.2.2, React/React DOM 19.1.1, React Router 7.18.3. Cold-start result:

```text
development cold start: crawled 78 modules
development cold start: no late dependency optimization or reload
```

Last 20 lines:

```text
build/client/assets/nested-suspense-D6Hz3Naj.js         1.71 kB │ gzip:  0.83 kB
build/client/assets/index-Ct0aBwNb.js                   4.07 kB │ gzip:  1.82 kB
build/client/assets/home-Dya9kTpx.js                    5.01 kB │ gzip:  1.98 kB
build/client/assets/axios-Cwt1K6go.js                  49.95 kB │ gzip: 18.75 kB
build/client/assets/chunk-BV7QT456-C9HmpVyk.js        100.69 kB │ gzip: 33.33 kB
build/client/assets/index-BRuGTPeq.js                 300.74 kB │ gzip: 93.63 kB

✓ built in 173ms

  SSR-BOOST  client built in 426 ms 


  SSR-BOOST v1.0.0  ready in 4 ms

  ➜  Mode:    production
  ➜  Type:    SPA
  ➜  Local:   http://127.0.0.1:59080/


SPA: root, deep links, fallback and client assets passed
```

- `env -u NO_COLOR SSR_BOOST_TEMPLATE_CURRENT=1 node scripts/test-template.mjs /Users/mikhail/work/lomray/agent/vite-template-t3` → exit 0. Final runs were sequential. Runtime: Vite 8.2.2, React/React DOM 19.2.8, React Router 8.3.1. Cold-start result:

```text
development cold start: crawled 78 modules
development cold start: no late dependency optimization or reload
```

Last 20 lines:

```text
build/client/assets/nested-suspense-vWcGXH_f.js         1.70 kB │ gzip:   0.82 kB
build/client/assets/index-DsIEKUyV.js                   4.06 kB │ gzip:   1.81 kB
build/client/assets/home-BhScHk19.js                    4.99 kB │ gzip:   1.96 kB
build/client/assets/axios-Cwt1K6go.js                  49.95 kB │ gzip:  18.75 kB
build/client/assets/hooks-CXncDowC.js                  79.38 kB │ gzip:  26.44 kB
build/client/assets/index-yMm-xDDW.js                 328.90 kB │ gzip: 102.64 kB

✓ built in 175ms

  SSR-BOOST  client built in 370 ms 


  SSR-BOOST v1.0.0  ready in 4 ms

  ➜  Mode:    production
  ➜  Type:    SPA
  ➜  Local:   http://127.0.0.1:59513/


SPA: root, deep links, fallback and client assets passed
```

- `npm run docs:build` → exit 0.

```text
> @lomray/vite-ssr-boost@1.0.0 docs:build
> vitepress build docs


  vitepress v1.6.4

- building client + server bundles...
✓ building client + server bundles...
- rendering pages...
✓ rendering pages...
- generating sitemap...
✓ generating sitemap...
build complete in 2.43s.
```

- `node --check scripts/test-template.mjs` and `git diff --check` → exit 0, no output. Restricted runtime directories and dependency manifests are unchanged. All started servers were stopped.

- `git commit -m 'fix: pre-bundle browser entry dependencies for cold development starts'` → exit 0 with lint-staged and commitlint hooks enabled. `PR_DESCRIPTION.md` remains uncommitted.

```text
[fix/dev-cold-start-optimize-deps 7f54927] fix: pre-bundle browser entry dependencies for cold development starts
 5 files changed, 285 insertions(+), 1 deletion(-)
 create mode 100644 src/plugins/optimize-browser-dependencies.ts
```

## Not run

- Browser check: **Not run**. No browser is available; to be verified separately: first-load console errors and hydration.
- Vite 7: **Not run**. Both requested acceptance modes use the supplied Vite 8.2.2 installation.

## Open questions / Gap report

- The supplied template is actually `feature/example-branch-ci` at `da68063b25efe1b1b9676ac9d5d3d8ea1bdaec07`, not `prod` at `5b8d688`. It uses boost 8.0.0-beta.2. Its tracked files and installed dependencies were copied as supplied; the source checkout was not modified.
- Initial parallel acceptance attempts shared Vite's HMR port 24678. One current-dependency attempt also logged `TypeError: Cannot read properties of null (reading 'id')` from the template's `src/pages/details/index/components/user/index.tsx`. Neither message recurred in the final sequential runs, which both passed.
- Non-failing output: Vitest reports existing extensionless config imports and jsdom navigation notices; Rollup reports existing empty type-only chunks. The diagnostic copy's `npm install` reports 2 vulnerabilities (1 moderate, 1 high). No dependency changes were made for T9.
- No library API gap was found. Browser verification remains with the reviewer. Nothing was pushed and no PR was opened.
