### PR TITLE
test: pin the migrated template and drop the entry rewrite

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: fbbd65524ceb95764bebc39da67af7d9c5737f80
+          ref: 922db6703a1f5baabec9288d9fa35ff787f6454f
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: fbbd65524ceb95764bebc39da67af7d9c5737f80
+          ref: 922db6703a1f5baabec9288d9fa35ff787f6454f
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ Check develop progress in any test repo:
 npm run test:template
 ```
 
-The acceptance script copies the template to a temporary directory, installs the locally packed library with its dependencies and
-migrates its server entry import to `adapters/express/entry`. To retain that copy for browser checks, run
+The acceptance script copies the template to a temporary directory and installs the locally packed library with its dependencies.
+To retain that copy for browser checks, run
 `SSR_BOOST_KEEP_TEMPLATE=1 npm run test:template`; its path is printed at the end.
 Set `SSR_BOOST_TEMPLATE_CURRENT=1` to also upgrade the copy to the library's current Vite, React,
 React Router and Babel versions after measuring the original baseline.

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -13,7 +13,7 @@ Run these before a release. The same checks run in PR and release CI.
 | `npm run test:template` | Template SSR in dev/production, cold styles, SSR module reload, streamed and crawler HTML, gzip, static JS/CSS, redirects, HEAD, 404, subpath deployment, standalone SPA and baseline TTFB comparison |
 | `npm run docs:build` | Documentation build and links |
 
-CI pins `vite-template` to `fbbd65524ceb95764bebc39da67af7d9c5737f80`. Locally, install its dependencies
+CI pins `vite-template` to `922db6703a1f5baabec9288d9fa35ff787f6454f`. Locally, install its dependencies
 in `../vite-template`, or pass its path to `node scripts/test-template.mjs`. The script works on a
 copy; it changes only that copy's configuration for the subpath test.
 

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -373,17 +373,6 @@ const verifySpa = async (origin) => {
   console.info('SPA: root, deep links, fallback and client assets passed');
 };
 
-// Apply the documented major-version migration only to the candidate template.
-const migrateServerEntry = async () => {
-  const filename = join(directory, 'src/server.ts');
-  const sourceText = await readFile(filename, 'utf8');
-  const entrypoint = '@lomray/vite-ssr-boost/adapters/express/entry';
-  const migrated = sourceText.replace('@lomray/vite-ssr-boost/node/entry', entrypoint);
-
-  assert.ok(migrated.includes(entrypoint), 'Template server entry import changed.');
-  await writeFile(filename, migrated);
-};
-
 // Install the publishable package with its dependencies after measuring the original baseline.
 const installCandidate = async () => {
   execFileSync('npm', [
@@ -499,7 +488,6 @@ try {
   }
 
   await installCandidate();
-  await migrateServerEntry();
 
   const devPort = await getPort();
 
@@ -567,7 +555,6 @@ try {
   for (const filename of ['vite.config.ts', 'src/client.ts', 'src/server.ts']) {
     await cp(join(source, filename), join(directory, filename));
   }
-  await migrateServerEntry();
   await run(['build', '--focus-only', 'client']);
   const spaPort = await getPort();
   const spa = start(['start', '--focus-only', 'client', '--port', String(spaPort)]);


### PR DESCRIPTION
## Goal

Pin CI to the migrated template and drop the transitional server-entry rewrite from the acceptance script.

`vite-template` `prod` now imports `@lomray/vite-ssr-boost/adapters/express/entry` on its own (Vite 8, React Router 8, refreshed dependencies), so the acceptance script no longer has to patch the import in its copy.

## Changes

- `.github/workflows/pr-check.yml`, `.github/workflows/release.yml`: template checkout pinned to `922db6703a1f5baabec9288d9fa35ff787f6454f` (vite-template `prod` after the dependency refresh).
- `scripts/test-template.mjs`: `migrateServerEntry` and both call sites removed. `installCandidate`, the `SSR_BOOST_TEMPLATE_CURRENT` mode and the development cold-start crawl are unchanged.
- `docs/reference/acceptance-gates.md`, `CONTRIBUTING.md`: pin and wording updated.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`: clean.
- `npm test`: 75 files, 407 tests passed.
- `npm run build`, `npm run docs:build`: pass.
- `node scripts/test-template.mjs <vite-template at 922db67>`: pass, including `development cold start: no late dependency optimization or reload`.
- Same with `SSR_BOOST_TEMPLATE_CURRENT=1`: pass.
- `grep -rn migrateServerEntry scripts docs CONTRIBUTING.md`: no matches.

## Not run

- Hosted gates run in this PR's CI (React matrix, workerd, Bun, no-optional, template acceptance in both modes).
