### PR TITLE
fix: wait for the serialized state before hydrating

### DIFF
--- a/__tests__/browser/entry.tsx
+++ b/__tests__/browser/entry.tsx
@@ -21,17 +21,38 @@ const App: TApp<{ test: string }> = ({ children, client: { test = '' } = {} }) =
 );
 const pageRoot = document.createElement('div');
 const returnEntry = { isRoot: true };
+const hydrationWindow = window as Window & {
+  __staticRouterHydrationData?: Record<string, unknown>;
+};
 
 describe('browserEntry', () => {
   const sandbox = sinon.createSandbox();
+  let readyStateDescriptor: PropertyDescriptor | undefined;
+  let hydrationDescriptor: PropertyDescriptor | undefined;
+  let getRootStub: sinon.SinonStub;
 
   beforeEach(() => {
-    sandbox.stub(document, 'getElementById').returns(pageRoot);
+    readyStateDescriptor = Object.getOwnPropertyDescriptor(document, 'readyState');
+    hydrationDescriptor = Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData');
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    delete hydrationWindow.__staticRouterHydrationData;
+    getRootStub = sandbox.stub(document, 'getElementById').returns(pageRoot);
   });
 
   afterEach(() => {
     sandbox.restore();
     cleanup();
+    delete pageRoot.dataset['forceSpa'];
+    if (readyStateDescriptor) {
+      Object.defineProperty(document, 'readyState', readyStateDescriptor);
+    } else {
+      Reflect.deleteProperty(document, 'readyState');
+    }
+    if (hydrationDescriptor) {
+      Object.defineProperty(window, '__staticRouterHydrationData', hydrationDescriptor);
+    } else {
+      delete hydrationWindow.__staticRouterHydrationData;
+    }
   });
 
   it('should hydrate the app on the client side in SSR mode', async () => {
@@ -109,4 +130,183 @@ describe('browserEntry', () => {
     expect(localRoutes[0].lazy).toBeUndefined();
     expect(typeof (localRoutes[0] as Record<string, unknown>).default).toBe('function');
   });
+
+  it('waits for serialized state before reading the root, creating the router or hydrating', async () => {
+    sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(true);
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    const state = { loaderData: { root: ['one', 'two', 'three'] } };
+    const createRouter = sandbox.stub().callsFake(() => {
+      expect(hydrationWindow.__staticRouterHydrationData).toBe(state);
+      return {} as DataRouter;
+    });
+    const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot').returns(returnEntry as never);
+    const init = sandbox.stub();
+    const pending = entry(App, routes, { createRouter, init });
+
+    await Promise.resolve();
+    expect(hydrationWindow.__staticRouterHydrationData).toBeUndefined();
+    expect(getRootStub.called).toBe(false);
+    expect(createRouter.called).toBe(false);
+    expect(init.called).toBe(false);
+    expect(hydrateStub.called).toBe(false);
+
+    hydrationWindow.__staticRouterHydrationData = state;
+
+    expect(Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData')).toEqual({
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: state,
+    });
+    expect(await pending).toBe(returnEntry);
+    expect(createRouter.calledOnceWith(routes, undefined)).toBe(true);
+    expect(getRootStub.calledOnceWith('root')).toBe(true);
+    expect(init.calledOnce).toBe(true);
+    expect(hydrateStub.calledOnce).toBe(true);
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    expect(hydrationWindow.__staticRouterHydrationData).toBe(state);
+    hydrationWindow.__staticRouterHydrationData = { loaderData: {} };
+    expect(hydrationWindow.__staticRouterHydrationData).toEqual({ loaderData: {} });
+    expect(createRouter.calledOnce).toBe(true);
+  });
+
+  it('falls back to DOMContentLoaded when no state is assigned', async () => {
+    sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(true);
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    const createRouter = sandbox.stub().returns({} as DataRouter);
+    const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot');
+    const pending = entry(App, routes, { createRouter });
+
+    await Promise.resolve();
+    expect(getRootStub.called).toBe(false);
+    expect(createRouter.called).toBe(false);
+    expect(hydrateStub.called).toBe(false);
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await pending;
+
+    expect(createRouter.calledOnce).toBe(true);
+    expect(hydrateStub.calledOnce).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData')).toBeUndefined();
+  });
+
+  it.each(['interactive', 'complete'])(
+    'creates the router immediately when the document is %s',
+    async (readyState) => {
+      sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(true);
+      Object.defineProperty(document, 'readyState', { value: readyState, configurable: true });
+      const createRouter = sandbox.stub().returns({} as DataRouter);
+      const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot');
+      const pending = entry(App, routes, { createRouter });
+
+      expect(createRouter.calledOnce).toBe(true);
+      expect(getRootStub.calledOnce).toBe(true);
+      expect(
+        Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData'),
+      ).toBeUndefined();
+      await pending;
+      expect(hydrateStub.calledOnce).toBe(true);
+    },
+  );
+
+  it('continues immediately when serialized state is already defined', async () => {
+    sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(true);
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    hydrationWindow.__staticRouterHydrationData = { loaderData: {} };
+    const descriptor = Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData');
+    const createRouter = sandbox.stub().returns({} as DataRouter);
+    const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot');
+    const pending = entry(App, routes, { createRouter });
+
+    expect(createRouter.calledOnce).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData')).toEqual(
+      descriptor,
+    );
+    await pending;
+    expect(hydrateStub.calledOnce).toBe(true);
+  });
+
+  it.each([false, true])(
+    'waits for DOMContentLoaded before mounting SPA output with SSR mode %s',
+    async (isSSRMode) => {
+      sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(isSSRMode);
+      Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+      if (isSSRMode) {
+        pageRoot.dataset['forceSpa'] = '1';
+      }
+      const createRouter = sandbox.stub().returns({} as DataRouter);
+      const renderStub = sandbox.stub().returns(returnEntry);
+      const createRootStub = sandbox.stub(ReactDOM, 'createRoot').returns({
+        render: renderStub,
+        unmount: sandbox.stub(),
+      });
+      const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot');
+      const pending = entry(App, routes, { createRouter });
+
+      if (!isSSRMode) {
+        expect(
+          Object.getOwnPropertyDescriptor(window, '__staticRouterHydrationData'),
+        ).toBeUndefined();
+        hydrationWindow.__staticRouterHydrationData = { loaderData: {} };
+      }
+      await Promise.resolve();
+      expect(getRootStub.called).toBe(false);
+      expect(createRouter.called).toBe(false);
+      expect(createRootStub.called).toBe(false);
+
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      expect(await pending).toBe(returnEntry);
+      expect(createRouter.calledOnce).toBe(true);
+      expect(createRootStub.calledOnceWith(pageRoot)).toBe(true);
+      expect(renderStub.calledOnce).toBe(true);
+      expect(hydrateStub.called).toBe(false);
+    },
+  );
+
+  it.each(['state', 'lazy route'])(
+    'preloads lazy routes in parallel and waits for both when %s arrives first',
+    async (first) => {
+      sandbox.stub(COMMON_CONSTANTS, 'IS_SSR_MODE').value(true);
+      Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+      let resolveLazy!: (value: { Component: () => null }) => void;
+      const lazy = sandbox.stub().returns(
+        new Promise<{ Component: () => null }>((resolve) => {
+          resolveLazy = resolve;
+        }),
+      );
+      const Component = () => null;
+      const localRoutes: TRouteObject[] = [{ path: '/', lazy }];
+      const createRouter = sandbox.stub().returns({} as DataRouter);
+      const hydrateStub = sandbox.stub(ReactDOM, 'hydrateRoot');
+      const pending = entry(App, localRoutes, { createRouter });
+
+      expect(lazy.calledOnce).toBe(true);
+      expect(createRouter.called).toBe(false);
+
+      if (first === 'state') {
+        hydrationWindow.__staticRouterHydrationData = { loaderData: {} };
+      } else {
+        resolveLazy({ Component });
+      }
+      await Promise.resolve();
+      expect(createRouter.called).toBe(false);
+      expect(getRootStub.called).toBe(false);
+      expect(hydrateStub.called).toBe(false);
+
+      if (first === 'state') {
+        resolveLazy({ Component });
+      } else {
+        expect(localRoutes[0].lazy).toBeUndefined();
+        hydrationWindow.__staticRouterHydrationData = { loaderData: {} };
+      }
+      await pending;
+
+      expect(localRoutes[0].lazy).toBeUndefined();
+      expect(localRoutes[0].Component).toBe(Component);
+      expect(createRouter.calledOnceWith(localRoutes, undefined)).toBe(true);
+      expect(hydrateStub.calledOnce).toBe(true);
+    },
+  );
 });

--- a/__tests__/core/render.tsx
+++ b/__tests__/core/render.tsx
@@ -165,6 +165,36 @@ describe('core render', () => {
     expect(renderer.output.start).toHaveBeenCalledOnce();
   });
 
+  it.each([undefined, '-CUSTOM-FOOTER'])(
+    'emits custom state before router state and footer %s',
+    async (footer) => {
+      const renderer = createRenderer();
+      const pending = render(
+        {
+          createApp,
+          handler: createRouter() as never,
+          renderToStream: renderer.renderToStream,
+        },
+        createContext(),
+        {
+          getState: () => ({ app: { ready: true }, store: { items: [1, 2, 3] } }),
+          onShellReady: () => ({ footer }),
+        },
+      );
+
+      await vi.waitFor(() => expect(renderer.renderToStream).toHaveBeenCalledOnce());
+      renderer.shellReady();
+      renderer.allReady();
+
+      const html = await (await pending).text();
+
+      expect(html).toMatch(
+        /^HEADER-BODY<script[^>]*>window\.app = .*<\/script><script[^>]*>window\.store = .*<\/script><script[^>]*>window\.__staticRouterHydrationData = .*<\/script>/,
+      );
+      expect(html.endsWith(footer ?? '-FOOTER')).toBe(true);
+    },
+  );
+
   it('returns redirects without starting React rendering', async () => {
     const renderer = createRenderer();
     const redirect = new Response(null, {

--- a/docs/api/browser-entry.md
+++ b/docs/api/browser-entry.md
@@ -28,6 +28,8 @@ interface IEntryClientOptions<T> {
 
 ## What it does
 
+While the document is loading, the entry waits for serialized router state (SSR only) or `DOMContentLoaded` before creating the router and rendering.
+
 The browser entry:
 
 - resolves currently matched lazy routes before router creation

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -61,8 +61,9 @@ metadata or crawler-specific rendering. For a custom HTTP server, see [runtime a
 
 ## HTML shell
 
-Place this in `src/index.html`. The outlet marks where the React stream goes; keep the client
-entry after it so serialized state arrives before hydration.
+Place this in `src/index.html`. The outlet marks where the React stream goes. The browser entry
+waits for the serialized state (or `DOMContentLoaded`) before creating the router and hydrating,
+so the client script may be `async` and Vite may hoist it into `<head>`.
 
 ```html
 <!doctype html>

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -77,7 +77,8 @@ This is the place to switch between streaming and full-document rendering based 
 ## `onShellReady`
 
 Replaces the template header or footer around the React stream. Generated hydration state is
-preserved when replacing the footer.
+preserved when replacing the footer. Custom state scripts from `getState` come first, followed by
+router state and then the footer, so custom state is available when router state unblocks hydration.
 
 Return:
 

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -25,6 +25,50 @@ export interface IEntryClientOptions<T> {
 }
 
 /**
+ * Wait for the shell and state when an async entry runs before HTML parsing finishes.
+ */
+const waitForDocument = (): Promise<void> | void => {
+  const hydrationKey = '__staticRouterHydrationData';
+
+  if (
+    document.readyState !== 'loading' ||
+    (IS_SSR_MODE && Reflect.get(window, hydrationKey) !== undefined)
+  ) {
+    return;
+  }
+
+  return new Promise<void>((resolve) => {
+    const onReady = () => {
+      if (IS_SSR_MODE) {
+        Reflect.deleteProperty(window, hydrationKey);
+      }
+
+      resolve();
+    };
+
+    document.addEventListener('DOMContentLoaded', onReady, { once: true });
+
+    if (IS_SSR_MODE) {
+      Object.defineProperty(window, hydrationKey, {
+        configurable: true,
+        enumerable: true,
+        get: () => undefined,
+        set: (value: unknown) => {
+          Object.defineProperty(window, hydrationKey, {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value,
+          });
+          document.removeEventListener('DOMContentLoaded', onReady);
+          resolve();
+        },
+      });
+    }
+  });
+};
+
+/**
  * Render client side application
  */
 async function entry<TAppProps>(
@@ -37,6 +81,7 @@ async function entry<TAppProps>(
     rootId = 'root',
   }: IEntryClientOptions<TAppProps> = {},
 ): Promise<ReactDOM.Root | void> {
+  const documentReady = waitForDocument();
   const lazyMatches = matchRoutes(
     routes as RouteObject[],
     window.location,
@@ -45,9 +90,10 @@ async function entry<TAppProps>(
 
   // Load the lazy matches and update the routes before creating router,
   // so we can hydrate the SSR-rendered content synchronously
-  if (lazyMatches && lazyMatches?.length > 0) {
-    await Promise.all(
-      lazyMatches.map(async (m) => {
+  if (documentReady || lazyMatches?.length) {
+    await Promise.all([
+      documentReady,
+      ...(lazyMatches ?? []).map(async (m) => {
         const { lazy } = m.route;
 
         if (typeof lazy === 'function') {
@@ -61,7 +107,7 @@ async function entry<TAppProps>(
           }
         }
       }),
-    );
+    ]);
   }
 
   const router = createRouter(routes as RouteObject[], routerOptions);

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -169,7 +169,8 @@ const prepareHtmlResponse = <TAppProps,>(
   const routerState = buildRouterState(context.routerContext!);
   const customState = buildCustomState(getState?.({ context }));
   const header = shell.header || context.html.header;
-  const footer = routerState + customState + (shell.footer || context.html.footer);
+  // Router state unblocks the browser entry, so custom state must already be available.
+  const footer = customState + routerState + (shell.footer || context.html.footer);
   const headers = new Headers(context.response.headers);
 
   return { header, footer, headers, status: context.response.status };


### PR DESCRIPTION
## Goal

The browser entry could create the router and hydrate before the server-rendered shell and the serialized state were parsed.

Vite hoists the client module into `<head>` in production builds and the template marks it `async`. With a cached bundle the module runs as soon as the first HTML chunk is parsed, while `window.__staticRouterHydrationData` is emitted in the footer after the shell. When the footer chunk arrives later (any network gap between stream chunks), `createBrowserRouter` starts without hydration data: React Router warns "No `HydrateFallback` element provided to render during initial hydration", re-runs the loaders in the browser, `hydrateRoot` fails with React error #418, and once the delayed shell chunk is parsed the browser appends the server HTML next to the client-rendered tree. A three-item list rendered six items.

Reproduced deterministically in Chrome against a production build of the `example/minimal` template through a proxy that delays every HTML chunk after the module tag by 400 ms.

## Changes

- `src/browser/entry.tsx`: while `document.readyState === 'loading'`, wait for the earliest of the `window.__staticRouterHydrationData` assignment (an accessor installed on `window` whose setter restores a plain writable data property, so React Router reads it as before) or `DOMContentLoaded`. Lazy-route preloading runs in parallel with the wait. Nothing changes when the document is already parsed (development, deferred scripts) or when the state is already present.
- `src/core/render.tsx`: custom state scripts from `getState` are emitted before the router state, so every custom value is on `window` when the router state unblocks the entry.
- Tests: entry waits and resumes on state assignment, falls back to `DOMContentLoaded`, continues immediately when parsed or when the state exists, SPA output waits for `DOMContentLoaded`; footer order.
- Docs: the "keep the client entry after the outlet" claim in getting-started was not true for production builds; replaced with the actual behavior. `server-lifecycle` documents the footer order; `api/browser-entry` gains one sentence.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`: clean.
- `npm test`: 75 files, 418 tests passed.
- `npm run build`, `npm run docs:build`: pass.
- `node scripts/test-template.mjs <vite-template prod at 922db67>`: pass in both modes, including the development cold-start gate.
- Browser proof (Chrome, production build of the template with the packed library from this branch, served through the chunk-delaying proxy, cached bundle): `/`, `/not-lazy` and the streamed `/details` hydrate with no console output, the DOM matches the direct load (same link count and text length), `window.__staticRouterHydrationData` is a plain data property afterwards and `window._metaState_` is present.
- Control with the unpatched library through the same proxy: React Router `HydrateFallback` warning, React error #418 and duplicated content.

## Not run

- Hosted gates run in this PR's CI.
