### PR TITLE
fix: parse routes wrapped in satisfies, as and parentheses

### DIFF
--- a/__tests__/services/parse-routes.ts
+++ b/__tests__/services/parse-routes.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'node:path';
+import { parse } from '@babel/parser';
 import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
@@ -21,6 +22,23 @@ void entryClient(App, routes, {});
 const notLazyImport = '@pages/not-lazy';
 const rootDir = '/src';
 const clientFile = 'client.tsx';
+const arrayWrappers = [
+  ['plain array', '', ''],
+  ['satisfies', '', ' satisfies TRouteObject[]'],
+  ['as', '', ' as TRouteObject[]'],
+  ['as const', '', ' as const'],
+  ['parentheses', '(', ')'],
+  ['non-null assertion', '(', ')!'],
+  ['combined wrappers', '((', ' as const) satisfies TRouteObject[])!'],
+];
+const routeImports = `
+import type { TRouteObject } from '@lomray/vite-ssr-boost/interfaces/route-object';
+import NotLazyPage from '@pages/not-lazy';
+`;
+const childRoutes = `[
+  { Component: NotLazyPage },
+  { lazy: () => import('@pages/home') },
+]`;
 
 describe('parse-routes', () => {
   const sandbox = sinon.createSandbox();
@@ -187,5 +205,166 @@ describe('parse-routes', () => {
     const tree = routesService.parse();
 
     expect(tree).to.deep.equal([{ index: 0, import: '@pages/not-lazy', children: [] }]);
+  });
+
+  describe.each(arrayWrappers)('%s', (_name, prefix, suffix) => {
+    it.each(['variable', 'named', 'default'])(
+      'should parse a %s export and nested children',
+      (kind) => {
+        stubExistFiles();
+        const array = `${prefix}[
+        { Component: NotLazyPage },
+        { children: ${prefix}${childRoutes}${suffix} },
+      ]${suffix}`;
+        const declaration =
+          kind === 'default'
+            ? `export default ${array};`
+            : `const routes = ${array}; export ${kind === 'named' ? '{ routes }' : 'default routes'};`;
+        sandbox
+          .stub(fs, 'readFileSync')
+          .onFirstCall()
+          .returns(clientEntrypoint(false, kind === 'named'))
+          .onSecondCall()
+          .returns(`${routeImports}${declaration}`);
+
+        expect(JSON.stringify(routesService.parse())).toBe(
+          JSON.stringify([
+            { index: 0, import: notLazyImport, children: [] },
+            {
+              index: 1,
+              import: '',
+              children: [
+                { index: 0, import: notLazyImport, children: [] },
+                { index: 1, import: '@pages/home', children: [] },
+              ],
+            },
+          ]),
+        );
+      },
+    );
+
+    it.each([true, false])(
+      'should preserve route transforms with path IDs enabled: %s',
+      (withPathId) => {
+        const plain = `${routeImports}const routes = [{ children: ${childRoutes} }];`;
+        const wrapped = `${routeImports}const routes = ${prefix}[
+        { children: ${prefix}${childRoutes}${suffix} }
+      ]${suffix};`;
+        const expected = ParseRoutes.handleRoutes(plain, withPathId);
+        const actual = ParseRoutes.handleRoutes(wrapped, withPathId);
+
+        expect(actual.match(/pathId: "[^"]+"/g)).toEqual(expected.match(/pathId: "[^"]+"/g));
+        expect(actual.match(/lazy: n\(\(\) => import\('[^']+'\)\)/g)).toEqual([
+          "lazy: n(() => import('@pages/home'))",
+        ]);
+        expect(actual.match(/import n from/g)).toHaveLength(1);
+      },
+    );
+  });
+
+  it.each([
+    ['TSTypeAssertion', '<TRouteObject[]>'],
+    ['ParenthesizedExpression', ''],
+  ])('should parse an explicit %s AST node', (nodeType, assertion) => {
+    stubExistFiles();
+    // JSX parsing normally represents parentheses as metadata and disallows angle assertions.
+    const code = `${routeImports}const routes = (${assertion}${childRoutes}); export default routes;`;
+    const ast = parse(code, {
+      sourceType: 'module',
+      createImportExpressions: true,
+      createParenthesizedExpressions: true,
+      plugins: ['typescript'],
+    });
+    const initializer = ast.program.body.find((node) => node.type === 'VariableDeclaration')
+      ?.declarations[0].init;
+    expect(initializer?.type).toBe('ParenthesizedExpression');
+    if (initializer?.type === 'ParenthesizedExpression') {
+      expect(initializer.expression.type).toBe(assertion ? nodeType : 'ArrayExpression');
+    }
+    const routesParser = routesService as unknown as {
+      parseFile: (filename: string) => ReturnType<typeof parse> | null;
+    };
+    sandbox
+      .stub(routesParser, 'parseFile')
+      .onFirstCall()
+      .returns(parse(clientEntrypoint(), { sourceType: 'module' }))
+      .onSecondCall()
+      .returns(ast);
+
+    expect(routesService.parse()).toEqual([
+      { index: 0, import: notLazyImport, children: [] },
+      { index: 1, import: '@pages/home', children: [] },
+    ]);
+  });
+
+  it('should parse wrappers in imported children route files', () => {
+    stubExistFiles();
+    sandbox
+      .stub(fs, 'readFileSync')
+      .onFirstCall()
+      .returns(clientEntrypoint())
+      .onSecondCall()
+      .returns(
+        `
+        import children from './details';
+        const routes = [{ children }] satisfies TRouteObject[];
+        export default routes;
+      `,
+      )
+      .onThirdCall()
+      .returns(`${routeImports}export default (${childRoutes} as const);`);
+
+    expect(routesService.parse()).toEqual([
+      {
+        index: 0,
+        import: '',
+        children: [
+          { index: 0, import: notLazyImport, children: [] },
+          { index: 1, import: '@pages/home', children: [] },
+        ],
+      },
+    ]);
+  });
+
+  it.each([
+    ['const routes = makeRoutes(); export default routes;', 'CallExpression'],
+    ['const routes = ({} as TRouteObject[])!; export default routes;', 'ObjectExpression'],
+    ['const routes = otherRoutes satisfies TRouteObject[]; export default routes;', 'Identifier'],
+    ['let routes; export default routes;', 'undefined'],
+  ])('should report the file and unwrapped node type for %s', (code, nodeType) => {
+    stubExistFiles();
+    const warnStub = sandbox.stub(serverConfig.getLogger(), 'warn');
+    sandbox
+      .stub(fs, 'readFileSync')
+      .onFirstCall()
+      .returns(clientEntrypoint())
+      .onSecondCall()
+      .returns(code);
+
+    expect(() => routesService.parse()).toThrow(
+      `Expected routes array in /src/routes/index.js, received ${nodeType}.`,
+    );
+    expect(warnStub.called).toBe(false);
+  });
+
+  it.each([
+    ['export default createRoutes();', 'CallExpression'],
+    ['export default {} satisfies TRouteObject[];', 'ObjectExpression'],
+  ])('should warn once and return an empty result for %s', (code, nodeType) => {
+    stubExistFiles();
+    const warnStub = sandbox.stub(serverConfig.getLogger(), 'warn');
+    sandbox
+      .stub(fs, 'readFileSync')
+      .onFirstCall()
+      .returns(clientEntrypoint())
+      .onSecondCall()
+      .returns(code);
+
+    expect(routesService.parse()).toEqual([]);
+    expect(
+      warnStub.calledOnceWithExactly(
+        `Routes manifest: default export of /src/routes/index.js is a ${nodeType} and cannot be analyzed; lazy route assets will not be injected.`,
+      ),
+    ).toBe(true);
   });
 });

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -41,6 +41,8 @@ const routes: RouteObject[] = [
 ];
 ```
 
+The routes array may be typed with `satisfies TRouteObject[]` or `as TRouteObject[]`.
+
 Not recommended for route analysis:
 
 ```tsx

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -426,6 +426,21 @@ const configureBasename = async () => {
   );
 };
 
+const configureTypedRoutes = async () => {
+  const filename = join(directory, 'src', 'routes', 'index.ts');
+  const original = await readFile(filename, 'utf8');
+  const declaration = 'const routes: TRouteObject[] = [';
+  const declarationIndex = original.indexOf(declaration);
+  const arrayEnd = original.lastIndexOf('];');
+
+  assert.match(original, /import type \{ TRouteObject \} from '@lomray\/vite-ssr-boost\/interfaces\/route-object'/);
+  assert.ok(declarationIndex !== -1, 'Template routes declaration changed.');
+  assert.ok(arrayEnd > declarationIndex, 'Template routes array terminator must follow its declaration.');
+  const typedRoutes = `${original.slice(0, arrayEnd)}] satisfies TRouteObject[];${original.slice(arrayEnd + 2)}`;
+  await writeFile(filename, typedRoutes.replace(declaration, 'const routes = ['));
+  console.info('Template routes: satisfies TRouteObject[] enabled for candidate acceptance');
+};
+
 const verifyHmr = async (origin) => {
   const filename = join(directory, 'src', 'pages', 'home', 'index.tsx');
   const original = await readFile(filename, 'utf8');
@@ -488,6 +503,7 @@ try {
   }
 
   await installCandidate();
+  await configureTypedRoutes();
 
   const devPort = await getPort();
 

--- a/src/services/parse-routes.ts
+++ b/src/services/parse-routes.ts
@@ -12,6 +12,7 @@ import type {
   Node as BabelNode,
   File as BabelFile,
   VariableDeclaration,
+  ExportDefaultDeclaration,
   ObjectExpression,
 } from '@babel/types';
 import {
@@ -59,6 +60,24 @@ export type TRoutesTree = {
  * Parse react router routes array
  */
 class ParseRoutes {
+  /**
+   * Unwrap expression-only TypeScript syntax and parentheses.
+   */
+  private static unwrapExpression(
+    node: BabelNode | null | undefined,
+  ): BabelNode | null | undefined {
+    switch (node?.type) {
+      case 'TSSatisfiesExpression':
+      case 'TSAsExpression':
+      case 'TSTypeAssertion':
+      case 'TSNonNullExpression':
+      case 'ParenthesizedExpression':
+        return ParseRoutes.unwrapExpression(node.expression);
+      default:
+        return node;
+    }
+  }
+
   /**
    * Path normalize service
    */
@@ -148,8 +167,9 @@ class ParseRoutes {
   private findRoutesDefinition(
     ast: ParseResult<BabelFile>,
     exportName: string | null,
-  ): null | VariableDeclaration {
+  ): null | VariableDeclaration | ExportDefaultDeclaration {
     let exportNameResolved = exportName;
+    let defaultExportNode: ExportDefaultDeclaration | null = null;
 
     // noinspection JSUnusedGlobalSymbols
     traverse(ast, {
@@ -173,6 +193,8 @@ class ParseRoutes {
       },
       ExportDefaultDeclaration({ node }) {
         if (exportName === null) {
+          defaultExportNode = node;
+
           if (node.declaration.type === 'Identifier') {
             exportNameResolved = node.declaration.name;
             // @ts-expect-error missing in types
@@ -202,7 +224,7 @@ class ParseRoutes {
       return variableNode;
     }
 
-    return null;
+    return defaultExportNode;
   }
 
   /**
@@ -268,12 +290,16 @@ class ParseRoutes {
             value: { type: string; elements: BabelNode[] };
           };
 
-          if (objectProp.key.name === 'children' && objectProp.value.type === 'ArrayExpression') {
-            routeInfo.children = this.parseRoutesArray(
-              objectProp.value.elements,
-              importsMap,
-              relativeFile,
-            );
+          if (objectProp.key.name === 'children') {
+            const children = ParseRoutes.unwrapExpression(objectProp.value as BabelNode);
+
+            if (isArrayExpression(children)) {
+              routeInfo.children = this.parseRoutesArray(
+                children.elements as BabelNode[],
+                importsMap,
+                relativeFile,
+              );
+            }
           }
 
           // async routes
@@ -391,10 +417,31 @@ class ParseRoutes {
 
     const importsMap = ParseRoutes.parseImportsMap(ast);
 
-    // @ts-expect-error missing types
-    const elements = routesNode.declarations[0].init?.elements as BabelNode[];
+    const routesArray = ParseRoutes.unwrapExpression(
+      routesNode.type === 'VariableDeclaration'
+        ? routesNode.declarations[0].init
+        : routesNode.declaration,
+    );
 
-    results.push(...this.parseRoutesArray(elements, importsMap, filename));
+    if (!isArrayExpression(routesArray)) {
+      if (routesNode.type === 'ExportDefaultDeclaration') {
+        const Logger = this.config.getLogger();
+
+        Logger.warn(
+          `Routes manifest: default export of ${filename} is a ${routesArray?.type} and cannot be analyzed; lazy route assets will not be injected.`,
+        );
+
+        return results;
+      }
+
+      throw new Error(
+        `Expected routes array in ${filename}, received ${routesArray?.type ?? 'undefined'}.`,
+      );
+    }
+
+    results.push(
+      ...this.parseRoutesArray(routesArray.elements as BabelNode[], importsMap, filename),
+    );
 
     return results;
   }
@@ -446,7 +493,9 @@ class ParseRoutes {
           if (importCall.type === 'ImportExpression') {
             const importArg = importCall.source;
             // current object has part of array (inside array)
-            const parent = nodePath.findParent?.((p) => isArrayExpression(p.node));
+            const parent = nodePath.findParent?.((p) =>
+              isArrayExpression(ParseRoutes.unwrapExpression(p.node)),
+            );
 
             if (
               parent &&
@@ -479,7 +528,9 @@ class ParseRoutes {
           }
 
           // current object has part of array (inside array)
-          const parent = nodePath.findParent?.((p) => isArrayExpression(p.node));
+          const parent = nodePath.findParent?.((p) =>
+            isArrayExpression(ParseRoutes.unwrapExpression(p.node)),
+          );
           const importName = importsMap[componentName]?.path;
 
           if (parent && importName && shouldAddPathId) {
@@ -494,9 +545,11 @@ class ParseRoutes {
           }
         }
 
-        if (property.key.name === 'children' && isArrayExpression(property.value)) {
+        const children = ParseRoutes.unwrapExpression(property.value);
+
+        if (property.key.name === 'children' && isArrayExpression(children)) {
           // Process each object in the children array recursively
-          property.value.elements.forEach((element) => {
+          children.elements.forEach((element) => {
             if (isObjectExpression(element)) {
               ParseRoutes.processRouteFileCode(
                 { node: element } as TraverseTypes.NodePath<ObjectExpression>,


### PR DESCRIPTION
## Goal

`ssr-boost build` failed in the routes manifest step with `Cannot read properties of undefined (reading 'forEach')` when the routes array was typed with `satisfies TRouteObject[]` (found while writing the `example/minimal` template). The parser read `.elements` straight from the initializer and did not unwrap TypeScript expression wrappers.

## Changes

- `src/services/parse-routes.ts`: one helper unwraps `TSSatisfiesExpression`, `TSAsExpression` (including `as const`), `TSTypeAssertion`, `TSNonNullExpression` and `ParenthesizedExpression` recursively; used for the top-level routes initializer, `export default [...] satisfies ...`, nested `children` arrays and the parent lookups. Plain arrays produce the same manifest as before.
- A variable initializer that is still not an array after unwrapping (`const routes = makeRoutes()`, `let routes;`) fails with `Expected routes array in <file>, received <NodeType>.` instead of a TypeError. A default export that cannot be analyzed (`export default createRoutes()`) keeps the previous outcome, an empty manifest, and now logs one warning saying lazy route assets will not be injected.
- Tests for every wrapper, nested wrappers, imported children files, the error path and the warning path.
- `scripts/test-template.mjs`: the candidate acceptance run rewrites the template's routes declaration to `const routes = [...] satisfies TRouteObject[]` (anchored on the last `];`), so the whole acceptance path runs on a wrapped array.
- `docs/guide/routing.md`: one sentence.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`: clean.
- `npm test`: 75 files, all tests passed (450+ with the new cases).
- `npm run build`, `npm run docs:build`: pass.
- `node scripts/test-template.mjs <vite-template prod at 922db67>`: pass, with `Template routes: satisfies TRouteObject[] enabled for candidate acceptance` in the log.
- Manual: template copy with `satisfies TRouteObject[]` builds and serves `/not-lazy` with its styles.

## Not run

- Hosted gates run in this PR's CI.
