### PR TITLE
feat: expose the fetch request on managed hook contexts

### DIFF
--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -3,17 +3,25 @@ import type { PropsWithChildren } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import render from '@adapters/express/render';
+import type { IRequestContext } from '@adapters/express/render';
 
 const { coreRenderMock, createFetchRequestMock, injectAssetsMock, writeFetchResponseMock } =
   vi.hoisted(() => ({
     coreRenderMock: vi.fn(),
-    createFetchRequestMock: vi.fn(() => new Request('http://localhost/test')),
+    createFetchRequestMock: vi.fn(),
     injectAssetsMock: vi.fn(),
     writeFetchResponseMock: vi.fn(),
   }));
 
 vi.mock('@core/render', () => ({ default: coreRenderMock }));
-vi.mock('@adapters/express/create-request', () => ({ default: createFetchRequestMock }));
+vi.mock('@adapters/express/create-request', async (importOriginal) => {
+  const { default: createFetchRequest } =
+    await importOriginal<typeof import('@adapters/express/create-request')>();
+
+  createFetchRequestMock.mockImplementation(createFetchRequest);
+
+  return { default: createFetchRequestMock };
+});
 vi.mock('@node/write-fetch-response', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@node/write-fetch-response')>()),
   default: writeFetchResponseMock,
@@ -61,7 +69,20 @@ describe('legacy Express render adapter', () => {
     const context: Record<string, any> = {
       appProps: { value: 'app' },
       html: { footer: '</html>', header: '<html>' },
-      req: { off: vi.fn(), once: vi.fn(), request: true },
+      req: {
+        get: vi.fn((name: string) => context.req.headers[name.toLowerCase()]),
+        headers: {
+          host: 'example.test',
+          'user-agent': 'Googlebot',
+          cookie: 'isCrawler=1; session=test',
+        },
+        method: 'GET',
+        off: vi.fn(),
+        once: vi.fn(),
+        originalUrl: '/details?source=hook',
+        protocol: 'https',
+        url: '/details',
+      },
       res,
     };
 
@@ -72,62 +93,119 @@ describe('legacy Express render adapter', () => {
     vi.clearAllMocks();
   });
 
-  it('maps legacy hooks to the Fetch core and writes its Response', async () => {
-    const { config, context } = createContext();
-    const onError = vi.fn();
-    const onResponse = vi.fn(({ html }) => html);
-    const onRouterReady = vi.fn(() => ({ isStream: true }));
-    const onShellReady = vi.fn(() => ({ header: '<head>' }));
-    const getState = vi.fn(() => ({ app: { value: 1 } }));
-    const response = new Response('rendered');
+  it.each(['GET', 'POST'])(
+    'shares the Fetch %s request across all render hooks',
+    async (method) => {
+      const { config, context } = createContext();
+      context.req.method = method;
+      let coreRequest: Request;
+      const requests: Request[] = [];
+      const inspectContext = ({ context: hookContext }: { context: IRequestContext }) => {
+        expect(hookContext).toBe(context);
+        expect(hookContext.req).toBe(context.req);
+        expect(hookContext.res).toBe(context.res);
+        expect(hookContext.request).toBeInstanceOf(Request);
+        expect(hookContext.request).toBe(coreRequest);
+        expect(hookContext.request.url).toBe('https://example.test/details?source=hook');
+        expect(hookContext.request.method).toBe(method);
+        expect(hookContext.request.headers.get('user-agent')).toBe(
+          context.req.headers['user-agent'],
+        );
+        expect(hookContext.request.headers.get('cookie')).toBe(context.req.headers.cookie);
+        requests.push(hookContext.request);
+      };
+      const onError = vi.fn(inspectContext);
+      const onShellError = vi.fn(inspectContext);
+      const onResponse = vi.fn((params) => {
+        inspectContext(params);
+        return params.html;
+      });
+      const onRouterReady = vi.fn((params) => {
+        inspectContext(params);
+        return { isStream: true };
+      });
+      const onShellReady = vi.fn((params) => {
+        inspectContext(params);
+        return { header: '<head>' };
+      });
+      const getState = vi.fn((params) => {
+        inspectContext(params);
+        return { app: { value: 1 } };
+      });
+      const getBody = vi.fn(() => 'request body');
+      const response = new Response('rendered');
+      const shellError = new Error('shell failed');
 
-    coreRenderMock.mockImplementation(async (_, coreContext, options) => {
-      coreContext.routerContext = { basename: '/base' };
-      coreContext.serverContext = { isServer: true, response: null };
-      await options.prepare({ context: coreContext });
-      await options.onRouterReady({ context: coreContext });
-      options.onShellReady({ context: coreContext });
-      options.onResponse({ context: coreContext, html: 'chunk' });
-      options.getState({ context: coreContext });
-      options.onError({
-        context: coreContext,
-        error: {
-          code: StreamError.Unknown,
-          message: 'broken',
-          original: new Error('broken'),
-        },
+      coreRenderMock.mockImplementation(async (_, coreContext, options) => {
+        coreRequest = coreContext.request;
+        // Router loaders can see the context before any hook synchronizes it.
+        expect(options.routerRequestContext).toBe(context);
+        expect(context.request).toBe(coreRequest);
+        coreContext.routerContext = { basename: '/base' };
+        coreContext.serverContext = { isServer: true, response: null };
+        await options.prepare({ context: coreContext });
+        await options.onRouterReady({ context: coreContext });
+        options.onShellReady({ context: coreContext });
+        options.onResponse({ context: coreContext, html: 'chunk' });
+        options.getState({ context: coreContext });
+        options.onError({
+          context: coreContext,
+          error: {
+            code: StreamError.Unknown,
+            message: 'broken',
+            original: new Error('broken'),
+          },
+        });
+        options.onShellError({ context: coreContext, error: shellError });
+
+        expect(coreRequest.signal.aborted).toBe(false);
+        const [, abort] = context.req.once.mock.calls.find(
+          ([event]: [string, () => void]) => event === 'aborted',
+        );
+        abort();
+        expect(requests.every((request) => request.signal.aborted)).toBe(true);
+
+        return response;
       });
 
-      return response;
-    });
+      await render(
+        { App: App as never, handler: { handler: true } as never },
+        config as never,
+        context as never,
+        {
+          getBody,
+          getState,
+          onError,
+          onResponse,
+          onRouterReady,
+          onShellError,
+          onShellReady,
+        },
+      );
 
-    await render(
-      { App: App as never, handler: { handler: true } as never },
-      config as never,
-      context as never,
-      {
-        getState,
-        onError,
-        onResponse,
-        onRouterReady,
-        onShellReady,
-      },
-    );
-
-    expect(createFetchRequestMock).toHaveBeenCalledWith(context.req, {
-      signal: expect.any(AbortSignal),
-    });
-    expect(injectAssetsMock).toHaveBeenCalledWith(context);
-    expect(onRouterReady).toHaveBeenCalledWith({ context });
-    expect(onShellReady).toHaveBeenCalledWith({ context });
-    expect(onResponse).toHaveBeenCalledWith({ context, html: 'chunk' });
-    expect(getState).toHaveBeenCalledWith({ context });
-    expect(onError).toHaveBeenCalledWith({
-      context,
-      error: expect.objectContaining({ code: StreamError.Unknown }),
-    });
-    expect(writeFetchResponseMock).toHaveBeenCalledWith(context.res, response);
-  });
+      expect(createFetchRequestMock).toHaveBeenCalledWith(context.req, {
+        signal: expect.any(AbortSignal),
+        ...(method === 'POST' ? { body: 'request body' } : {}),
+      });
+      expect(createFetchRequestMock).toHaveBeenCalledOnce();
+      expect(getBody).toHaveBeenCalledTimes(method === 'POST' ? 1 : 0);
+      expect(requests).toHaveLength(6);
+      expect(new Set(requests).size).toBe(1);
+      expect(injectAssetsMock).toHaveBeenCalledWith(context);
+      expect(onRouterReady).toHaveBeenCalledWith({ context });
+      expect(onShellReady).toHaveBeenCalledWith({ context });
+      expect(onShellError).toHaveBeenCalledWith({ context, error: shellError });
+      expect(onResponse).toHaveBeenCalledWith({ context, html: 'chunk' });
+      expect(getState).toHaveBeenCalledWith({ context });
+      expect(onError).toHaveBeenCalledWith({
+        context,
+        error: expect.objectContaining({ code: StreamError.Unknown }),
+      });
+      expect(writeFetchResponseMock).toHaveBeenCalledWith(context.res, response);
+      expect(context.req.off).toHaveBeenCalledWith('aborted', expect.any(Function));
+      expect(context.res.off).toHaveBeenCalledWith('close', expect.any(Function));
+    },
+  );
 
   it('keeps Express redirect behavior for legacy consumers', async () => {
     const { config, context, res } = createContext();

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -60,9 +60,31 @@ interface IEntrypointOptions<TAppProps> {
 
 See [Server Lifecycle](/guide/server-lifecycle) for the flow and intent of each hook.
 
+## Hook context
+
+`onRouterReady`, `onShellReady`, `onShellError`, `onError`, `onResponse` and `getState`
+receive `{ context }`, with these fields:
+
+- `request`: the Fetch `Request` built from the Express request; use it for headers, URL and method so hooks stay portable to other adapters.
+- `req` / `res`: the live Express request and response.
+- `appProps`: request-scoped props returned by `onRequest`.
+- `html`: the template `header` and `footer`.
+- `routerContext` / `serverContext`: router and SSR metadata, once available.
+- `isStream`, `hasEarlyHints` and `didError`: rendering mode, early-hints preference and error metadata.
+
+`request` is the same object used by the Fetch core throughout a render; its `signal` tracks request cancellation.
+
+```ts
+onRouterReady: ({ context: { request } }) => ({
+  isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+}),
+```
+
 ## `onRequest`
 
 The most important request hook.
+
+It receives `(req, res)` before the render context is created.
 
 It can return:
 

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -15,6 +15,8 @@ At runtime the package:
 
 That is where the customization hooks fit.
 
+Render hooks receive a [context](/api/server-entry#hook-context) with the shared Fetch `request` and live Express `req` / `res`; `onRequest` receives `(req, res)` before that context is created.
+
 ## `onServerCreated`
 
 Called once after the Express app exists.

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -21,6 +21,7 @@ import SsrManifest from '@services/ssr-manifest';
 export interface IRequestContext<TAppProps = Record<any, any>> {
   req: ExpressRequest;
   res: ExpressResponse;
+  request: Request;
   appProps: NonNullable<TAppProps>;
   html: { header: string; footer: string };
   routerContext?: StaticHandlerContext;
@@ -32,7 +33,7 @@ export interface IRequestContext<TAppProps = Record<any, any>> {
 
 export type TRender<TAppProps = Record<any, any>> = (
   config: ServerConfig,
-  context: IRequestContext<TAppProps>,
+  context: Omit<IRequestContext<TAppProps>, 'request'>,
   options: IRenderOptions,
 ) => Promise<void>;
 
@@ -162,7 +163,7 @@ const writeResponse = async (res: ExpressResponse, response: Response): Promise<
 async function render(
   { App, handler }: IRenderParams,
   config: ServerConfig,
-  context: IRequestContext,
+  initialContext: Omit<IRequestContext, 'request'>,
   {
     onRouterReady,
     onShellReady,
@@ -174,14 +175,17 @@ async function render(
     abortDelay = 15000,
   }: IRenderOptions,
 ): Promise<void> {
-  const { appProps, html: shellHtml, req, res } = context;
+  const { appProps, html: shellHtml, req, res } = initialContext;
   const Logger = config.getLogger();
   const requestSignal = createRequestSignal(req, res);
   try {
+    const context: IRequestContext = Object.assign(initialContext, {
+      request: createRenderRequest(req, requestSignal.signal, getBody),
+    });
     const coreContext: ISsrRequestContext = {
       appProps,
       html: shellHtml,
-      request: createRenderRequest(req, requestSignal.signal, getBody),
+      request: context.request,
       response: {
         headers: new Headers(),
       },
@@ -191,6 +195,7 @@ async function render(
      * Keep legacy hooks attached to their original mutable request context.
      */
     const syncContext = (updated: ISsrRequestContext): IRequestContext => {
+      context.request = updated.request;
       context.didError = updated.didError;
       context.html = updated.html;
       context.isStream = updated.isStream;

--- a/src/adapters/express/server.ts
+++ b/src/adapters/express/server.ts
@@ -6,7 +6,7 @@ import compression from 'compression';
 import type { Express } from 'express';
 import express from 'express';
 import PrepareServer from '@adapters/express/prepare-server';
-import type { IRequestContext } from '@adapters/express/render';
+import type { TRender } from '@adapters/express/render';
 import printServerInfo from '@helpers/print-server-info';
 import ServerApi from '@services/server-api';
 import type ServerConfig from '@services/server-config';
@@ -127,7 +127,7 @@ async function createServer(config: ServerConfig): Promise<ICreateServerOut> {
             return next();
           }
 
-          const context: IRequestContext = {
+          const renderInput: Parameters<TRender>[1] = {
             req,
             res,
             hasEarlyHints,
@@ -135,7 +135,7 @@ async function createServer(config: ServerConfig): Promise<ICreateServerOut> {
             html: { header, footer },
           };
 
-          await render(config, context, renderParams);
+          await render(config, renderInput, renderParams);
         } catch (e) {
           config
             .getLogger()


### PR DESCRIPTION
## Goal

Hooks on the managed Express entry (`adapters/express/entry`) received only the Express `req`/`res`, although the core already builds a Fetch `Request` for every render. An application that wants to read `user-agent` or `cookie` in `onRouterReady` had to depend on `@types/express` or declare a local header type, while every Fetch-adapter user writes `request.headers.get(...)`. Found while writing the `example/minimal` template.

## Changes

- `IRequestContext` (`src/adapters/express/render.tsx`) gains `request: Request`. It is created once per render, is the same object the core uses (so `request.signal` is the request abort signal) and is kept in sync for every hook: `onRouterReady`, `onShellReady`, `onShellError`, `onError`, `onResponse`, `getState`. `req`/`res` stay.
- `onRequest` keeps its `(req, res)` signature; it runs before the render context exists.
- `TRender` takes the context without `request`; `src/adapters/express/server.ts` adjusted accordingly.
- Tests: URL, method, `user-agent` and `cookie` for GET and POST, shared identity across hooks, abort propagation and listener cleanup.
- Docs: `api/server-entry.md` gets a "Hook context" section listing every field with a portable `onRouterReady` example; `guide/server-lifecycle.md` links to it.

No dependency changes, no changes to the Fetch core or other adapters.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`: clean.
- `npm test`: 75 files, 419 tests passed.
- `npm run build`, `npm run docs:build`: pass.
- `node scripts/test-template.mjs <vite-template prod at 922db67>`: pass.
- Template copy with the packed build and `onRouterReady` reading `context.request.headers.get('user-agent')` / `get('cookie')`: `ts:check` clean without `@types/express`; `/details` with a browser user agent streams (`<!--$?-->` present), with `Cookie: isCrawler=1` or a `Googlebot` user agent it is buffered (none).

## Not run

- Hosted gates run in this PR's CI.
