### PR TITLE
fix: honor empty transform output and flush onResponse at stream end

### DIFF
--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment node
 import type { PropsWithChildren } from 'react';
+import { createStaticHandler } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import render from '@adapters/express/render';
-import type { IRequestContext } from '@adapters/express/render';
+import type { IRenderOptions, IRequestContext } from '@adapters/express/render';
 
 const { coreRenderMock, createFetchRequestMock, injectAssetsMock, writeFetchResponseMock } =
   vi.hoisted(() => ({
@@ -146,7 +147,7 @@ describe('legacy Express render adapter', () => {
         await options.prepare({ context: coreContext });
         await options.onRouterReady({ context: coreContext });
         options.onShellReady({ context: coreContext });
-        options.onResponse({ context: coreContext, html: 'chunk' });
+        options.onResponse({ context: coreContext, html: 'chunk', isEnd: false });
         options.getState({ context: coreContext });
         options.onError({
           context: coreContext,
@@ -195,7 +196,7 @@ describe('legacy Express render adapter', () => {
       expect(onRouterReady).toHaveBeenCalledWith({ context });
       expect(onShellReady).toHaveBeenCalledWith({ context });
       expect(onShellError).toHaveBeenCalledWith({ context, error: shellError });
-      expect(onResponse).toHaveBeenCalledWith({ context, html: 'chunk' });
+      expect(onResponse).toHaveBeenCalledWith({ context, html: 'chunk', isEnd: false });
       expect(getState).toHaveBeenCalledWith({ context });
       expect(onError).toHaveBeenCalledWith({
         context,
@@ -204,6 +205,56 @@ describe('legacy Express render adapter', () => {
       expect(writeFetchResponseMock).toHaveBeenCalledWith(context.res, response);
       expect(context.req.off).toHaveBeenCalledWith('aborted', expect.any(Function));
       expect(context.res.off).toHaveBeenCalledWith('close', expect.any(Function));
+    },
+  );
+
+  it.each([true, false])(
+    'transforms chunks and flushes after the footer with isStream=%s',
+    async (isStream) => {
+      const { default: coreRender } =
+        await vi.importActual<typeof import('@core/render')>('@core/render');
+      const { config, context } = createContext();
+      const handler = createStaticHandler([{ path: '*', Component: () => 'BODY' }]);
+      const onResponse = vi.fn<NonNullable<IRenderOptions['onResponse']>>(({ html, isEnd }) => {
+        if (isEnd) {
+          return 'FLUSHED';
+        }
+
+        return html === context.html.header ? '' : undefined;
+      });
+      let output = '';
+
+      coreRenderMock.mockImplementationOnce(coreRender);
+      writeFetchResponseMock.mockImplementationOnce(async (_, response: Response) => {
+        output = await response.text();
+      });
+
+      await render({ App: App as never, handler }, config as never, context as never, {
+        onResponse,
+        onRouterReady: () => ({ isStream }),
+      });
+
+      const calls = onResponse.mock.calls.map(([params]) => params);
+      const chunks = calls.slice(0, -1);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      expect(chunks.every((params) => params.context === context && params.isEnd === false)).toBe(
+        true,
+      );
+      expect(chunks[0].html).toBe(context.html.header);
+      expect(chunks.at(-1)?.html).toContain(context.html.footer);
+      expect(calls.filter(({ isEnd }) => isEnd)).toEqual([{ context, html: '', isEnd: true }]);
+      expect(calls.at(-1)).toEqual({ context, html: '', isEnd: true });
+      expect(context.isStream).toBe(isStream);
+      expect(output).toBe(
+        `${chunks
+          .slice(1)
+          .map(({ html }) => html)
+          .join('')}FLUSHED`,
+      );
+      expect(output).toContain('BODY');
+      expect(output).toContain('window.__staticRouterHydrationData');
+      expect(output.endsWith(`${context.html.footer}FLUSHED`)).toBe(true);
     },
   );
 

--- a/__tests__/core/transform-html.ts
+++ b/__tests__/core/transform-html.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import transformHtml from '@core/transform-html';
 
 const createStream = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
@@ -31,9 +31,73 @@ describe('transformHtml', () => {
     expect(transformHtml(stream)).toBe(stream);
   });
 
-  it('preserves legacy empty-string behavior', async () => {
+  it('honors empty-string output', async () => {
     const stream = createStream(new TextEncoder().encode('content'));
 
-    await expect(new Response(transformHtml(stream, () => '')).text()).resolves.toBe('content');
+    await expect(new Response(transformHtml(stream, () => '')).text()).resolves.toBe('');
+  });
+
+  it('keeps the original chunk when the transform returns undefined', async () => {
+    const stream = createStream(new TextEncoder().encode('content'));
+    const transform = vi.fn(() => undefined);
+
+    await expect(new Response(transformHtml(stream, transform)).text()).resolves.toBe('content');
+    expect(transform.mock.calls).toEqual([
+      ['content', false],
+      ['', true],
+    ]);
+  });
+
+  it('combines withheld chunks and flushes remaining content once at the end', async () => {
+    const encoder = new TextEncoder();
+    const stream = createStream(
+      encoder.encode('<scr'),
+      encoder.encode('ipt>value</script>'),
+      encoder.encode('<unfinished'),
+    );
+    let pending = '';
+    const transform = vi.fn((html: string, isEnd: boolean) => {
+      pending += html;
+
+      if (!isEnd && !pending.endsWith('>')) {
+        return '';
+      }
+
+      const output = pending;
+      pending = '';
+
+      return output;
+    });
+
+    await expect(new Response(transformHtml(stream, transform)).text()).resolves.toBe(
+      '<script>value</script><unfinished',
+    );
+    expect(transform.mock.calls).toEqual([
+      ['<scr', false],
+      ['ipt>value</script>', false],
+      ['<unfinished', false],
+      ['', true],
+    ]);
+  });
+
+  it('flushes the UTF-8 decoder before signaling the end', async () => {
+    const emoji = new TextEncoder().encode('🙂');
+    const stream = createStream(emoji.slice(0, 2));
+    const transform = vi.fn((html: string, isEnd: boolean) => (isEnd ? '-END' : html));
+
+    await expect(new Response(transformHtml(stream, transform)).text()).resolves.toBe('�-END');
+    expect(transform.mock.calls).toEqual([
+      ['�', false],
+      ['', true],
+    ]);
+  });
+
+  it('signals the end of an empty stream', async () => {
+    const transform = vi.fn(() => 'END');
+
+    await expect(new Response(transformHtml(createStream(), transform)).text()).resolves.toBe(
+      'END',
+    );
+    expect(transform.mock.calls).toEqual([['', true]]);
   });
 });

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -99,6 +99,34 @@ It can return:
 
 That lets you shape app props, skip a request, or stop the rendering path entirely.
 
+## `onResponse`
+
+```ts
+onResponse?: (params: {
+  context: IRequestContext<TAppProps>;
+  html: string;
+  isEnd: boolean;
+}) => string | undefined | void;
+```
+
+Regular HTML chunks arrive with `isEnd: false`. Returning `undefined` (or nothing) keeps the
+original chunk; a string replaces it. Returning `''` withholds the chunk, allowing an
+incremental transform to retain unfinished tokens.
+
+After the composed body stream finishes, including the footer, the hook receives one final
+call with `html: ''` and `isEnd: true`. Its returned string is appended to the response;
+`undefined` or `''` appends nothing. This also applies to buffered rendering (`isStream: false`).
+Hooks that ignore `isEnd` remain supported.
+
+For example, using `@lomray/consistent-suspense`:
+
+```ts
+onResponse: ({ context: { appProps: { streamSuspense }, isStream }, html, isEnd }) => {
+  if (!isStream) return;
+  return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
+},
+```
+
 ## Middleware config
 
 Production middleware can be configured without replacing the whole server pipeline:

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -99,9 +99,27 @@ Typical uses:
 
 ## `onResponse`
 
-Runs on HTML chunks as they are written.
+Receives `{ context, html, isEnd }` for HTML chunks as they are written, with `isEnd: false`.
 
 Use it when you need to mutate generated HTML in transit, for example to inject payloads or patch chunks before they leave the server.
+
+Return `undefined` (or return nothing) to keep the original chunk. A string replaces the chunk,
+including `''`, which withholds it so an incremental transform can retain an unfinished token
+until more HTML arrives.
+
+After the composed body stream finishes, including its footer, the hook runs once more with
+`html: ''` and `isEnd: true`. Return a string to append any retained content to the response;
+`undefined` or `''` appends nothing. The same contract applies when `isStream` is `false`.
+Existing hooks can ignore `isEnd`.
+
+For example, with an `@lomray/consistent-suspense` stream transform stored in `appProps`:
+
+```ts
+onResponse: ({ context: { appProps: { streamSuspense }, isStream }, html, isEnd }) => {
+  if (!isStream) return;
+  return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
+},
+```
 
 ## `getState`
 

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -57,6 +57,7 @@ export interface IRenderOptions<TAppProps = Record<string, any>> {
   onResponse?: (params: {
     context: IRequestContext<TAppProps>;
     html: string;
+    isEnd: boolean;
   }) => string | undefined | void;
   getState?: (params: {
     context: IRequestContext<TAppProps>;
@@ -253,10 +254,11 @@ async function render(
         },
 
         /**
-         * Transform streamed HTML using the existing legacy hook signature.
+         * Forward HTML chunks and the end signal through the legacy request context.
          */
         onResponse: onResponse
-          ? ({ context: updated, html }) => onResponse({ context: syncContext(updated), html })
+          ? ({ context: updated, html, isEnd }) =>
+              onResponse({ context: syncContext(updated), html, isEnd })
           : undefined,
 
         /**

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -91,6 +91,7 @@ export interface ICoreRenderOptions<TAppProps = Record<string, any>> {
   onResponse?: (params: {
     context: ISsrRequestContext<TAppProps>;
     html: string;
+    isEnd: boolean;
   }) => string | undefined | void;
   onRouterReady?: (params: {
     context: ISsrRequestContext<TAppProps>;
@@ -354,7 +355,7 @@ const render = async <TAppProps,>(
     const body = composeHtml(header, output.stream, footer, abort, cleanup);
     const transformed = transformHtml(
       body,
-      onResponse ? (html) => onResponse({ context, html }) : undefined,
+      onResponse ? (html, isEnd) => onResponse({ context, html, isEnd }) : undefined,
     );
 
     output.start();

--- a/src/core/transform-html.ts
+++ b/src/core/transform-html.ts
@@ -1,4 +1,4 @@
-type TTransformHtml = (html: string) => string | undefined | void;
+type TTransformHtml = (html: string, isEnd: boolean) => string | undefined | void;
 
 /**
  * Apply response hooks to decoded text without splitting UTF-8 characters.
@@ -22,15 +22,23 @@ const transformHtml = (
       return;
     }
 
-    controller.enqueue(encoder.encode(transform(html) || html));
+    controller.enqueue(encoder.encode(transform(html, false) ?? html));
   };
 
   return stream.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
       /**
-       * Flush any final characters retained by the streaming decoder.
+       * Flush the decoder before letting the response hook emit any retained content.
        */
-      flush: (controller) => apply(decoder.decode(), controller),
+      flush: (controller) => {
+        apply(decoder.decode(), controller);
+
+        const html = transform('', true);
+
+        if (html) {
+          controller.enqueue(encoder.encode(html));
+        }
+      },
 
       /**
        * Decode successive chunks using the same UTF-8 state.


### PR DESCRIPTION
## Goal

Give the `onResponse` stream transform a precise contract. The core applied hook results with `transform(html) || html`, so a hook that legitimately returned an empty string (it withheld an unfinished tag or script to combine it with the next chunk) got the original chunk emitted instead, and the withheld bytes were emitted again later. Nothing told the hook that the stream had ended, so retained content could not be flushed. `@lomray/consistent-suspense` 2.0.9 parses React's stream incrementally and relies on both.

## Changes

- `src/core/transform-html.ts`: `transform(html, false) ?? html`. `undefined` keeps the chunk; any string, including `''`, is the output. After the composed body (including the footer) finishes, the transform is called once more with `('', true)` and its string result is appended.
- `src/core/render.tsx`, `src/adapters/express/render.tsx`: `onResponse` receives `isEnd: boolean` on both the Fetch core and the managed Express entry. Hooks that ignore it keep working; the pinned template does.
- Tests: empty output is emitted as empty, `undefined` keeps the chunk, the final `isEnd` call arrives after the last chunk and its output is appended; the Express path forwards `isEnd`.
- Docs: `api/server-entry.md` gains an `onResponse` section with the return contract and the consistent-suspense example (`isEnd ? streamSuspense.end() : streamSuspense.analyze(html)`); `guide/server-lifecycle.md` updated.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`: clean.
- `npm test`: 75 files, 469 tests passed.
- `npm run build`, `npm run docs:build`: pass.
- `node scripts/test-template.mjs <vite-template prod at 922db67>`: pass (its `onResponse` ignores `isEnd`).

## Not run

- Hosted gates run in this PR's CI.
