### PR TITLE
feat: release 8.1.0 with node production helpers

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Boot the built edge package in workerd
         run: npm run test:edge:packed
 
-      - name: Prove core works without optional adapters
+      - name: Prove public exports (including node/production) and core without optional adapters
         run: npm run test:core:no-optional
 
       - uses: oven-sh/setup-bun@v2

--- a/__mocks__/production-build/client/index.html
+++ b/__mocks__/production-build/client/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><title>Fixture</title></head><body><div id="root"><!--ssr-outlet--></div></body></html>

--- a/__mocks__/production-build/server/assets-manifest.json
+++ b/__mocks__/production-build/server/assets-manifest.json
@@ -1,0 +1,27 @@
+{
+  "0": [
+    {
+      "type": "script",
+      "url": "/assets/home.js",
+      "weight": 2,
+      "isNested": false,
+      "isPreload": true
+    }
+  ],
+  "1": [
+    {
+      "type": "style",
+      "url": "/assets/about.css",
+      "weight": 1,
+      "isNested": false,
+      "isPreload": true
+    },
+    {
+      "type": "script",
+      "url": "/assets/about.js",
+      "weight": 2,
+      "isNested": false,
+      "isPreload": true
+    }
+  ]
+}

--- a/__tests__/node/production.ts
+++ b/__tests__/node/production.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createStaticHandler } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ISsrRequestContext } from '@core/render';
+import { createRouteAssetPreparer, loadHtmlShell } from '@node/production';
+import ServerConfig from '@services/server-config';
+import SsrManifest from '@services/ssr-manifest';
+
+const fixtureDir = fileURLToPath(new URL('../../__mocks__/production-build/', import.meta.url));
+const originalCwd = process.cwd();
+let directory: string;
+let buildDir: string;
+let indexFile: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'ssr-production-'));
+  buildDir = join(directory, 'build');
+  indexFile = join(buildDir, 'client/index.html');
+  await cp(fixtureDir, buildDir, { recursive: true });
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(directory, { recursive: true, force: true });
+  (SsrManifest as unknown as { instance: unknown }).instance = null;
+});
+
+describe('loadHtmlShell', () => {
+  it('reads once and returns fresh shells after the file is removed', async () => {
+    const getHtml = await loadHtmlShell({ indexFile });
+    const first = getHtml();
+    const second = getHtml();
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(first.header).toContain('<div id="root">');
+    expect(first.footer).toBe('</div></body></html>\n');
+    first.header = 'changed by one request';
+    first.footer = 'changed footer';
+    await rm(indexFile);
+    expect(getHtml()).toEqual(second);
+  });
+
+  it.each(['no outlet', '<!--ssr-outlet--><!--ssr-outlet-->'])(
+    'rejects invalid outlet counts in %s and names the file',
+    async (html) => {
+      await writeFile(indexFile, html);
+      await expect(loadHtmlShell({ indexFile })).rejects.toThrow(indexFile);
+      await expect(loadHtmlShell({ indexFile })).rejects.toThrow('expected exactly one');
+    },
+  );
+
+  it('supports a custom outlet and empty shell halves', async () => {
+    await writeFile(indexFile, '{{app}}');
+    const getHtml = await loadHtmlShell({ indexFile, outlet: '{{app}}' });
+    expect(getHtml()).toEqual({ header: '', footer: '' });
+    await writeFile(indexFile, '{{app}}{{app}}');
+    await expect(loadHtmlShell({ indexFile, outlet: '{{app}}' })).rejects.toThrow(indexFile);
+  });
+
+  it('rejects an empty outlet', async () => {
+    await writeFile(indexFile, 'ab');
+    await expect(loadHtmlShell({ indexFile, outlet: '' })).rejects.toThrow(indexFile);
+  });
+
+  it('reports an unreadable file', async () => {
+    await rm(indexFile);
+    await expect(loadHtmlShell({ indexFile })).rejects.toThrow(indexFile);
+  });
+});
+
+describe('createRouteAssetPreparer', () => {
+  const createContext = async (
+    pathname = '/about',
+  ): Promise<ISsrRequestContext<{ app: string }>> => {
+    const router = createStaticHandler([
+      { path: '/', Component: () => null },
+      { path: '/about', lazy: async () => ({ Component: () => null }) },
+    ]);
+    const request = new Request(`http://localhost${pathname}`);
+    const routerContext = await router.query(request);
+    if (routerContext instanceof Response) {
+      throw new Error('Expected a matched route');
+    }
+    return {
+      appProps: { app: 'fixture' },
+      html: (await loadHtmlShell({ indexFile }))(),
+      request,
+      response: { headers: new Headers() },
+      routerContext,
+    };
+  };
+
+  it('injects lazy route styles and forwards Early Hints before resolving', async () => {
+    const prepare = createRouteAssetPreparer<{ app: string }>({ buildDir });
+    const context = await createContext();
+    const footer = context.html.footer;
+    let release: () => void = () => undefined;
+    const onEarlyHints = vi.fn<(headers: Headers) => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const prepared = prepare({ context, executionContext: { onEarlyHints } });
+    expect(context.html.header).toContain(
+      '<link rel="stylesheet" href="/assets/about.css"></head>',
+    );
+    expect(context.html.header).not.toContain('modulepreload');
+    expect(context.html.header).not.toContain('/assets/home.js');
+    expect(context.html.footer).toBe(footer);
+    expect(onEarlyHints).toHaveBeenCalledOnce();
+    const [hints] = onEarlyHints.mock.calls[0];
+    expect(hints.get('Link')).toBe(
+      '</assets/about.css>; rel=preload; as=style, </assets/about.js>; rel=preload; as=script',
+    );
+    let completed = false;
+    void Promise.resolve(prepared).then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+    release();
+    await prepared;
+    expect(completed).toBe(true);
+  });
+
+  it('enables module preload without requiring an Early Hints callback', async () => {
+    const context = await createContext();
+    await createRouteAssetPreparer({ buildDir, modulePreload: true })({ context });
+    expect(context.html.header).toContain(
+      '<link rel="modulepreload" as="script" crossorigin href="/assets/about.js">',
+    );
+  });
+
+  it('does not forward empty hints or inject unmatched route assets', async () => {
+    const context = await createContext();
+    context.routerContext = undefined;
+    const shell = { ...context.html };
+    const onEarlyHints = vi.fn();
+    await createRouteAssetPreparer({ buildDir })({ context, executionContext: { onEarlyHints } });
+    expect(context.html).toEqual(shell);
+    expect(onEarlyHints).not.toHaveBeenCalled();
+  });
+
+  it('leaves the shell unchanged when the manifest is missing', async () => {
+    await rm(join(buildDir, 'server/assets-manifest.json'));
+    const context = await createContext();
+    const shell = { ...context.html };
+    const onEarlyHints = vi.fn();
+    await createRouteAssetPreparer({ buildDir })({ context, executionContext: { onEarlyHints } });
+    expect(context.html).toEqual(shell);
+    expect(onEarlyHints).not.toHaveBeenCalled();
+  });
+
+  it('propagates invalid manifest JSON', async () => {
+    await writeFile(join(buildDir, 'server/assets-manifest.json'), '{invalid');
+    const context = await createContext();
+    await expect(createRouteAssetPreparer({ buildDir })({ context })).rejects.toThrow(SyntaxError);
+  });
+
+  it('keeps requests and build caches independent of the managed singleton', async () => {
+    const otherBuild = join(directory, 'other-build');
+    await cp(buildDir, otherBuild, { recursive: true });
+    const manifestFile = join(otherBuild, 'server/assets-manifest.json');
+    await writeFile(
+      manifestFile,
+      (await readFile(manifestFile, 'utf8')).replaceAll('/assets/', '/other/'),
+    );
+    const managed = SsrManifest.get(ServerConfig.init({ isProd: true }, { root: buildDir }));
+    managed.injectAssets(await createContext());
+    const first = createRouteAssetPreparer({ buildDir });
+    const second = createRouteAssetPreparer({ buildDir: otherBuild });
+    const firstContext = await createContext();
+    const secondContext = await createContext();
+    await Promise.all([first({ context: firstContext }), second({ context: secondContext })]);
+    expect(firstContext.html.header).toContain('/assets/about.css');
+    expect(secondContext.html.header).toContain('/other/about.css');
+    expect(secondContext.html.header).not.toContain('/assets/about.css');
+    await rm(manifestFile);
+    const cachedContext = await createContext();
+    await second({ context: cachedContext });
+    expect(cachedContext.html).toEqual(secondContext.html);
+    const home = await createContext('/');
+    await first({ context: home });
+    expect(home.html.header).not.toContain('/assets/about.css');
+    const managedContext = await createContext();
+    managed.injectAssets(managedContext);
+    expect(managedContext.html).toEqual(firstContext.html);
+  });
+
+  it('uses explicit paths from another working directory and pins relative build paths', async () => {
+    process.chdir(directory);
+    const absolute = createRouteAssetPreparer({ buildDir });
+    const relative = createRouteAssetPreparer({ buildDir: 'build' });
+    process.chdir(tmpdir());
+    expect(process.cwd()).not.toBe(originalCwd);
+    const context = await createContext();
+    const otherContext = await createContext();
+    await absolute({ context });
+    await relative({ context: otherContext });
+    expect(context.html.header).toContain('/assets/about.css');
+    expect(otherContext.html).toEqual(context.html);
+  });
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
           { text: 'Plugin', link: '/api/plugin' },
           { text: 'Browser Entry', link: '/api/browser-entry' },
           { text: 'Server Entry', link: '/api/server-entry' },
+          { text: 'Node Production', link: '/api/node-production' },
           { text: 'Components And Helpers', link: '/api/components-and-helpers' },
           { text: 'CLI', link: '/api/cli' },
         ],

--- a/docs/api/node-production.md
+++ b/docs/api/node-production.md
@@ -1,0 +1,79 @@
+# Node production helpers
+
+Use these helpers when your application owns its Node HTTP server and serves a build produced by
+the SSR BOOST CLI. They supply the `getHtml` and `prepare` options for `core/handler`.
+
+```ts
+import {
+  createRouteAssetPreparer,
+  loadHtmlShell,
+} from '@lomray/vite-ssr-boost/node/production';
+import type {
+  IHtmlShell,
+  ILoadHtmlShellOptions,
+  IRouteAssetPreparerOptions,
+} from '@lomray/vite-ssr-boost/node/production';
+```
+
+The explicit `.js` import path also works. These helpers use Node's filesystem APIs.
+
+## `loadHtmlShell`
+
+```ts
+interface ILoadHtmlShellOptions {
+  indexFile: string;
+  outlet?: string; // Default: '<!--ssr-outlet-->'
+}
+
+function loadHtmlShell(options: ILoadHtmlShellOptions): Promise<() => IHtmlShell>;
+
+interface IHtmlShell {
+  header: string;
+  footer: string;
+}
+```
+
+Reads the UTF-8 file once and splits it at the outlet. The file must contain exactly one outlet;
+an empty outlet, missing outlet or repeated outlet throws an error naming the file. Filesystem
+read errors propagate to the caller.
+
+The returned function creates a new `{ header, footer }` object each time, so request hooks can
+change the shell without affecting other requests. It can be passed directly as `getHtml`.
+Load a new shell when deploying a new build.
+
+## `createRouteAssetPreparer`
+
+```ts
+interface IRouteAssetPreparerOptions {
+  buildDir: string;
+  modulePreload?: boolean; // Default: false
+}
+
+function createRouteAssetPreparer<TAppProps>(
+  options: IRouteAssetPreparerOptions,
+): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']>;
+```
+
+`ICreateHandlerOptions` is the type exported by `core/handler`.
+
+Pass the build directory containing `client/` and `server/`. The preparer resolves this path when
+created, then reads `server/assets-manifest.json` when a request first has matched routes. Each
+preparer caches its own manifest and shares the managed server's asset injection logic. It does
+not discover builds from the working directory or use the managed server's manifest singleton.
+Relative paths resolve against the working directory at creation; use an absolute path to start
+the application from any directory.
+
+The hook runs after React Router matches the request. It inserts matching route styles and scripts
+before `</head>` in `context.html.header`; the shell must contain that closing tag. Lazy route IDs
+must match the routes used for the build. `modulePreload: true` also inserts module preload links.
+Asset URLs come from the manifest, including any base path configured during the build.
+
+When the assets produce `Link` headers, the hook awaits `executionContext.onEarlyHints` if provided.
+It works without that callback. The Node and Fastify adapters send these headers as HTTP 103 Early
+Hints when the transport supports them. They are separate from the final response headers.
+
+A missing manifest or a route without assets adds nothing, matching the managed server. Invalid
+manifest JSON and read errors propagate. Create a new preparer when deploying a new build.
+
+See the [Fastify launcher](/guide/runtime-adapters#adapters) for the complete server setup,
+including static files and compression.

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -100,8 +100,9 @@ explicit `.js` imports remain supported.
 
 ## Adapters
 
-The managed CLI is the default path. A custom transport owns the development server, static assets
-and route-asset injection. The [custom-server example](https://github.com/Lomray-Software/vite-template/tree/example/custom-server)
+The managed CLI is the default path. A custom transport owns the development server and static assets.
+For Node production servers, the production helpers supply the HTML shell and matched route assets.
+The [custom-server example](https://github.com/Lomray-Software/vite-template/tree/example/custom-server)
 demonstrates this integration with the managed CLI in development and Fastify in production.
 
 Native Node or connect-style:
@@ -124,13 +125,64 @@ import adapterExpress from '@lomray/vite-ssr-boost/adapters/express';
 app.use(adapterExpress(handler));
 ```
 
-Fastify:
+Fastify production launcher (`server/index.mjs`):
 
-```ts
+The built server in the custom-server example exports `handler` and `configureHandler`. The latter
+passes `getHtml` and `prepare` to its Fetch handler before Fastify starts accepting requests.
+Run `npm run build` first, then start this launcher with `node server/index.mjs`.
+
+```js
+import { join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fastifyStatic from '@fastify/static';
 import adapterFastify from '@lomray/vite-ssr-boost/adapters/fastify';
+import { createRouteAssetPreparer, loadHtmlShell } from '@lomray/vite-ssr-boost/node/production';
+import Fastify from 'fastify';
+import { configureHandler, handler } from '../build/server/server.js';
 
-app.all('/*', adapterFastify(handler));
+const buildDir = fileURLToPath(new URL('../build/', import.meta.url));
+const clientDir = join(buildDir, 'client');
+
+configureHandler({
+  getHtml: await loadHtmlShell({ indexFile: join(clientDir, 'index.html') }),
+  prepare: createRouteAssetPreparer({ buildDir }),
+});
+
+const app = Fastify();
+
+await app.register(fastifyStatic, {
+  root: clientDir,
+  index: false,
+  wildcard: false,
+  immutable: true,
+  maxAge: '1y',
+  setHeaders: (reply, filePath) => {
+    if (!filePath.startsWith(`${join(clientDir, 'assets')}${sep}`)) {
+      reply.header('Cache-Control', 'public, max-age=0');
+    }
+  },
+});
+app.all('/*', adapterFastify(handler, { compression: true }));
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    void app.close().catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  });
+}
+
+const address = await app.listen({ port: Number(process.env.PORT ?? 3000), host: '0.0.0.0' });
+
+console.info(`Fastify listening at ${address}`);
 ```
+
+`loadHtmlShell` reads the built HTML once and returns a fresh shell per request.
+`createRouteAssetPreparer` reads `build/server/assets-manifest.json` when a request first matches
+routes, caches it for that preparer, and forwards Early Hints through the adapter. Paths resolved
+from `import.meta.url` let the launcher start from any working directory. See the
+[Node production API](/api/node-production) for options.
 
 Fastify request hooks and their response headers are preserved. The adapter uses `reply.hijack()`
 to stream through the raw transport, so Fastify serialization and `onSend` hooks are bypassed.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Vite plugin for create awesome SSR or SPA applications on React.",
   "type": "module",
   "exports": {
+    "./node/production": {
+      "types": "./node/production.d.ts",
+      "default": "./node/production.js"
+    },
+    "./node/production.js": {
+      "types": "./node/production.d.ts",
+      "default": "./node/production.js"
+    },
     "./*.js": {
       "types": "./*.d.ts",
       "default": "./*.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,6 +40,7 @@ export default {
     'node:process',
     'node:child_process',
     'node:fs',
+    'node:fs/promises',
     'node:stream',
     'node:zlib',
     'node:url',

--- a/scripts/test-core-no-optional.mjs
+++ b/scripts/test-core-no-optional.mjs
@@ -168,6 +168,12 @@ try {
     const { default: createHandler } = await import('@lomray/vite-ssr-boost/core/handler');
     const { default: adapterEdge } = await import('@lomray/vite-ssr-boost/adapters/edge');
     const { default: adapterNode } = await import('@lomray/vite-ssr-boost/adapters/node');
+    const production = await import('@lomray/vite-ssr-boost/node/production');
+    const productionJs = await import('@lomray/vite-ssr-boost/node/production.js');
+    for (const name of ['loadHtmlShell', 'createRouteAssetPreparer']) {
+      assert.equal(typeof production[name], 'function', name);
+      assert.equal(production[name], productionJs[name], name);
+    }
     assert.equal(createHandler, (await import('@lomray/vite-ssr-boost/core/handler.js')).default);
     assert.equal(adapterEdge, (await import('@lomray/vite-ssr-boost/adapters/edge.js')).default);
     assert.equal(adapterNode, (await import('@lomray/vite-ssr-boost/adapters/node.js')).default);
@@ -198,6 +204,23 @@ try {
     import adapterEdgeJs from '@lomray/vite-ssr-boost/adapters/edge.js';
     import type { TSsrHandler } from '@lomray/vite-ssr-boost/core/types';
     import type { TSsrHandler as TSsrHandlerJs } from '@lomray/vite-ssr-boost/core/types.js';
+
+    import { loadHtmlShell, createRouteAssetPreparer } from '@lomray/vite-ssr-boost/node/production';
+    import { loadHtmlShell as loadHtmlShellJs, createRouteAssetPreparer as createRouteAssetPreparerJs } from '@lomray/vite-ssr-boost/node/production.js';
+    import type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions } from '@lomray/vite-ssr-boost/node/production';
+    import type { IHtmlShell as IHtmlShellJs } from '@lomray/vite-ssr-boost/node/production.js';
+    import type { ICreateHandlerOptions } from '@lomray/vite-ssr-boost/core/handler';
+
+    const shellOptions: ILoadHtmlShellOptions = { indexFile: '/app/build/client/index.html' };
+    const assetOptions: IRouteAssetPreparerOptions = { buildDir: '/app/build', modulePreload: true };
+    const shell: IHtmlShell = (await loadHtmlShell(shellOptions))();
+    const shellJs: IHtmlShellJs = (await loadHtmlShellJs(shellOptions))();
+    const prepare: NonNullable<ICreateHandlerOptions<{ app: string }>['prepare']> = createRouteAssetPreparer<{ app: string }>(assetOptions);
+    const prepareJs: typeof prepare = createRouteAssetPreparerJs<{ app: string }>(assetOptions);
+    // @ts-expect-error The build directory is required.
+    createRouteAssetPreparer({});
+    // @ts-expect-error The index file must be a string.
+    loadHtmlShell({ indexFile: new URL('file:///app/index.html') });
 
     const handler: TSsrHandler = async (request) => new Response(request.url);
     const handlerJs: TSsrHandlerJs = handler;
@@ -240,7 +263,7 @@ try {
     }
   }
 
-  process.stdout.write('Packed exports, NodeNext/Bundler declarations and optional-free core passed.\n');
+  process.stdout.write('Packed exports (including node/production), NodeNext/Bundler declarations and optional-free core passed.\n');
 } finally {
   await rm(directory, { force: true, recursive: true });
 }

--- a/src/node/production.ts
+++ b/src/node/production.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import type { ICreateHandlerOptions, IHtmlShell } from '@core/handler';
+import RouteAssets from '@services/route-assets';
+
+interface ILoadHtmlShellOptions {
+  indexFile: string;
+  outlet?: string;
+}
+
+interface IRouteAssetPreparerOptions {
+  buildDir: string;
+  modulePreload?: boolean;
+}
+
+/**
+ * Read a built document once and supply a fresh shell for each request.
+ */
+const loadHtmlShell = async ({
+  indexFile,
+  outlet = '<!--ssr-outlet-->',
+}: ILoadHtmlShellOptions): Promise<() => IHtmlShell> => {
+  const html = await readFile(indexFile, 'utf8');
+  const parts = html.split(outlet);
+
+  if (!outlet || parts.length !== 2) {
+    throw new Error(
+      `Invalid HTML shell in "${indexFile}": expected exactly one non-empty outlet ${JSON.stringify(outlet)}.`,
+    );
+  }
+
+  const [header, footer] = parts;
+
+  return () => ({ header, footer });
+};
+
+/**
+ * Inject matched route assets using a manifest cache owned by this preparer.
+ */
+const createRouteAssetPreparer = <TAppProps = Record<string, any>>({
+  buildDir,
+  modulePreload = false,
+}: IRouteAssetPreparerOptions): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
+  const assets = new RouteAssets(buildDir, modulePreload);
+
+  return async ({ context, executionContext }) => {
+    const hints = assets.injectAssets(context);
+
+    if (hints.has('Link')) {
+      await executionContext?.onEarlyHints?.(hints);
+    }
+  };
+};
+
+export { createRouteAssetPreparer, loadHtmlShell };
+
+export type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions };

--- a/src/services/route-assets.ts
+++ b/src/services/route-assets.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RouterState, StaticHandlerContext } from 'react-router';
+
+enum AssetType {
+  style = 'style',
+  script = 'script',
+  image = 'image',
+  font = 'font',
+}
+
+interface IAsset {
+  type: AssetType;
+  url: string;
+  weight: number;
+  isNested: boolean;
+  isPreload: boolean;
+  content?: string;
+}
+
+type TAssets = { [id: string]: IAsset };
+
+interface IInjectAssetsContext {
+  html: {
+    header: string;
+  };
+  routerContext?: StaticHandlerContext;
+}
+
+/**
+ * Load and inject route assets with an independent cache for one build.
+ */
+class RouteAssets {
+  protected readonly outputDir: string;
+
+  protected readonly modulePreload: boolean;
+
+  protected routesAssets: Record<string, IAsset[]> | null = null;
+
+  constructor(buildDir: string, modulePreload = false) {
+    this.outputDir = path.resolve(buildDir);
+    this.modulePreload = modulePreload;
+  }
+
+  /**
+   * Development manifests override this to inject inline styles.
+   */
+  protected get isDev(): boolean {
+    return false;
+  }
+
+  /**
+   * Get assets manifest file name.
+   */
+  protected getAssetsManifestFile(): string {
+    return path.join(this.outputDir, 'server', 'assets-manifest.json');
+  }
+
+  /**
+   * Load assets manifest
+   */
+  protected loadAssetsManifest(): Record<string, IAsset[]> {
+    if (this.routesAssets !== null) {
+      return this.routesAssets;
+    }
+
+    const manifestFile = this.getAssetsManifestFile();
+
+    if (!fs.existsSync(manifestFile)) {
+      return {};
+    }
+
+    this.routesAssets = JSON.parse(fs.readFileSync(manifestFile, { encoding: 'utf-8' })) as Record<
+      string,
+      IAsset[]
+    >;
+
+    return this.routesAssets;
+  }
+
+  /**
+   * Sort assets
+   */
+  protected sortAssets(assets: IAsset[]): IAsset[] {
+    return assets.sort((a, b) =>
+      a.weight === b.weight ? Number(a.isNested) - Number(b.isNested) : a.weight - b.weight,
+    );
+  }
+
+  /**
+   * Get route assets
+   */
+  protected getAssets(routes?: RouterState['matches']): IAsset[] {
+    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
+
+    if (!routeIds.length) {
+      return [];
+    }
+
+    const routesAssets = this.loadAssetsManifest();
+
+    return this.sortAssets(
+      routeIds
+        .map((routeId) => routesAssets[routeId])
+        .flat()
+        .filter(Boolean),
+    );
+  }
+
+  /**
+   * Build preload hints without depending on a particular HTTP transport.
+   */
+  public getEarlyHints(assets: IAsset[]): Headers {
+    const headers = new Headers();
+
+    assets.forEach(({ type, url }) => {
+      if (!type || !['style', 'script'].includes(type)) {
+        return;
+      }
+
+      headers.append('Link', `<${url}>; rel=preload; as=${type}`);
+    });
+
+    return headers;
+  }
+
+  /**
+   * Inject route assets to head html
+   */
+  public injectAssets({ routerContext, html }: IInjectAssetsContext): Headers {
+    const assets = this.getAssets(routerContext?.matches);
+    const htmlAssets = assets
+      .map(({ type, url, isPreload, content = '' }) => {
+        switch (type) {
+          case AssetType.style:
+            return this.isDev
+              ? `<style data-vite-dev-id="${url}">${content}</style>`
+              : `<link rel="stylesheet" href="${url}">`;
+
+          case AssetType.script:
+            return isPreload
+              ? this.modulePreload
+                ? // can reduce lighthouse performance
+                  `<link rel="modulepreload" as="script" crossorigin href="${url}">`
+                : null
+              : `<script async type="module" crossorigin src="${url}"></script>`;
+        }
+
+        return null;
+      })
+      .filter(Boolean);
+
+    html.header = html.header.replace('</head>', `${htmlAssets.join('\n')}</head>`);
+
+    return this.getEarlyHints(assets);
+  }
+}
+
+export { AssetType };
+
+export type { IAsset, TAssets };
+
+export default RouteAssets;

--- a/src/services/ssr-manifest.ts
+++ b/src/services/ssr-manifest.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
-import type { RouterState, StaticHandlerContext } from 'react-router';
+import type { RouterState } from 'react-router';
 import type { Alias, ModuleNode, RenderBuiltAssetUrl } from 'vite';
 import type { IAsyncRoute } from '@helpers/import-route';
 import type { TRoutesTree } from '@services/parse-routes';
 import ParseRoutes from '@services/parse-routes';
 import PathNormalize from '@services/path-normalize';
+import type { IAsset, TAssets } from '@services/route-assets';
+import RouteAssets, { AssetType } from '@services/route-assets';
 import type ServerConfig from '@services/server-config';
 
 interface ISsrManifestParams {
@@ -26,35 +28,10 @@ interface IManifest {
   };
 }
 
-enum AssetType {
-  style = 'style',
-  script = 'script',
-  image = 'image',
-  font = 'font',
-}
-
-interface IAsset {
-  type: AssetType;
-  url: string;
-  weight: number;
-  isNested: boolean;
-  isPreload: boolean;
-  content?: string;
-}
-
-type TAssets = { [id: string]: IAsset };
-
-interface IInjectAssetsContext {
-  html: {
-    header: string;
-  };
-  routerContext?: StaticHandlerContext;
-}
-
 /**
  * Working with SSR Manifest file
  */
-class SsrManifest {
+class SsrManifest extends RouteAssets {
   /**
    * Singleton
    */
@@ -86,11 +63,6 @@ class SsrManifest {
   protected readonly manifestName = 'manifest.json';
 
   /**
-   * Assets manifest file name
-   */
-  protected readonly assetsManifest = 'assets-manifest.json';
-
-  /**
    * Vite resolve aliases
    */
   protected readonly viteAliases?: Alias[];
@@ -106,17 +78,14 @@ class SsrManifest {
   protected readonly renderBuiltUrl?: RenderBuiltAssetUrl;
 
   /**
-   * Loaded assets manifest file
-   */
-  protected routesAssets: Record<string, IAsset[]> | null = null;
-
-  /**
    * @constructor
    */
   protected constructor(
     config: ServerConfig,
     { buildDir, viteAliases, basename, renderBuiltUrl }: ISsrManifestParams = {},
   ) {
+    super(path.resolve(config.getParams().root, buildDir || ''), config.isModulePreload);
+
     this.config = config;
     this.root = config.getParams().root;
     this.buildDir = buildDir;
@@ -138,17 +107,24 @@ class SsrManifest {
   }
 
   /**
-   * Get output dir
+   * Use inline styles while the managed Vite server is running.
    */
-  protected getOutDir() {
+  protected get isDev(): boolean {
+    return Boolean(this.config.getVite());
+  }
+
+  /**
+   * Get output dir.
+   */
+  protected getOutDir(): string {
     return path.resolve(this.root, this.buildDir || '');
   }
 
   /**
-   * Get assets manifest file name
+   * Keep the managed server's build path resolution.
    */
   protected getAssetsManifestFile(): string {
-    return `${this.getOutDir()}/server/${this.assetsManifest}`;
+    return `${this.getOutDir()}/server/assets-manifest.json`;
   }
 
   /**
@@ -177,28 +153,6 @@ class SsrManifest {
   }
 
   /**
-   * Load assets manifest
-   */
-  protected loadAssetsManifest(): Record<string, IAsset[]> {
-    if (this.routesAssets !== null) {
-      return this.routesAssets;
-    }
-
-    const manifestFile = this.getAssetsManifestFile();
-
-    if (!fs.existsSync(manifestFile)) {
-      return {};
-    }
-
-    this.routesAssets = JSON.parse(fs.readFileSync(manifestFile, { encoding: 'utf-8' })) as Record<
-      string,
-      IAsset[]
-    >;
-
-    return this.routesAssets;
-  }
-
-  /**
    * Same as 'getAsyncRoutesIds' but for routes tree from 'ParseRoutes'
    */
   protected getRoutesTreeIds(
@@ -220,15 +174,6 @@ class SsrManifest {
     });
 
     return result;
-  }
-
-  /**
-   * Sort assets
-   */
-  protected sortAssets(assets: IAsset[]): IAsset[] {
-    return assets.sort((a, b) =>
-      a.weight === b.weight ? Number(a.isNested) - Number(b.isNested) : a.weight - b.weight,
-    );
   }
 
   /**
@@ -316,27 +261,10 @@ class SsrManifest {
   }
 
   /**
-   * Get route assets
+   * Get route assets from Vite in development or the built manifest in production.
    */
   protected getAssets(routes?: RouterState['matches']): IAsset[] {
-    if (this.config.getVite()) {
-      return this.getAssetsDev(routes);
-    }
-
-    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
-
-    if (!routeIds.length) {
-      return [];
-    }
-
-    const routesAssets = this.loadAssetsManifest();
-
-    return this.sortAssets(
-      routeIds
-        .map((routeId) => routesAssets[routeId])
-        .flat()
-        .filter(Boolean),
-    );
+    return this.isDev ? this.getAssetsDev(routes) : super.getAssets(routes);
   }
 
   /**
@@ -515,54 +443,6 @@ class SsrManifest {
       default:
         return null;
     }
-  }
-
-  /**
-   * Build preload hints without depending on a particular HTTP transport.
-   */
-  public getEarlyHints(assets: IAsset[]): Headers {
-    const headers = new Headers();
-
-    assets.forEach(({ type, url }) => {
-      if (!type || !['style', 'script'].includes(type)) {
-        return;
-      }
-
-      headers.append('Link', `<${url}>; rel=preload; as=${type}`);
-    });
-
-    return headers;
-  }
-
-  /**
-   * Inject route assets to head html
-   */
-  public injectAssets({ routerContext, html }: IInjectAssetsContext): Headers {
-    const assets = this.getAssets(routerContext?.matches);
-    const htmlAssets = assets
-      .map(({ type, url, isPreload, content = '' }) => {
-        switch (type) {
-          case AssetType.style:
-            return this.config.getVite()
-              ? `<style data-vite-dev-id="${url}">${content}</style>`
-              : `<link rel="stylesheet" href="${url}">`;
-
-          case AssetType.script:
-            return isPreload
-              ? this.config.isModulePreload
-                ? // can reduce lighthouse performance
-                  `<link rel="modulepreload" as="script" crossorigin href="${url}">`
-                : null
-              : `<script async type="module" crossorigin src="${url}"></script>`;
-        }
-
-        return null;
-      })
-      .filter(Boolean);
-
-    html.header = html.header.replace('</head>', `${htmlAssets.join('\n')}</head>`);
-
-    return this.getEarlyHints(assets);
   }
 }
 


### PR DESCRIPTION
Promotes staging to prod: the node/production helpers (loadHtmlShell, createRouteAssetPreparer) for application-owned servers, with the RouteAssets extraction, tests, docs and the packed-exports proof. The custom-server template example will move to the helpers once 8.1.0 is on npm.