### PR TITLE
ci: enforce browser size budgets and record acceptance timings

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -58,6 +58,9 @@ jobs:
           npm pkg delete scripts.prepare
           npm run build
 
+      - name: Enforce browser size budgets
+        run: npm run test:size
+
       - name: Boot the built edge package in workerd
         run: npm run test:edge:packed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
           npm pkg delete scripts.prepare
           npm run build
 
+      - name: Enforce browser size budgets
+        run: npm run test:size
+
       - name: Boot the built edge package in workerd
         run: npm run test:edge:packed
 

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -7,10 +7,11 @@ Run these before a release. The same checks run in PR and release CI.
 | `npm test` | Shared React SSR tests across Node, Express, Fastify, Hono and edge; real React cancellation before/after shell; HTTP/2, redirects, cookies, HEAD/statuses, bounded buffering and compressed shell delivery |
 | `npm run lint:check` / `npm run ts:check` | Lint and public/internal TypeScript contracts |
 | `npm run build` | Published JavaScript and declaration output |
+| `npm run test:size` | Browser public-entry and combined gzip budgets; rejects server dependencies in browser bundles (requires `lib/`) |
 | `npm run test:edge:packed` | Built edge output running in Miniflare/workerd |
 | `npm run test:bun` | Built Fetch SSR served by Bun, including cookies, HEAD, redirects and POST (requires Bun) |
 | `npm run test:core:no-optional` | Packed installation with `--omit=optional`; core and edge run without Express or compression |
-| `npm run test:template` | Template SSR in dev/production, cold styles, SSR module reload, streamed and crawler HTML, gzip, static JS/CSS, redirects, HEAD, 404, subpath deployment, standalone SPA and baseline TTFB comparison |
+| `npm run test:template` | Template SSR in dev/production, cold styles, SSR module reload, streamed and crawler HTML, gzip, static JS/CSS, redirects, HEAD, 404, subpath deployment, standalone SPA, client gzip budget and baseline TTFB comparison |
 | `npm run docs:build` | Documentation build and links |
 
 CI pins `vite-template` to `922db6703a1f5baabec9288d9fa35ff787f6454f`. Locally, install its dependencies
@@ -25,3 +26,65 @@ PR and release CI run the full suite on React/React DOM 18.2.0 and 19.2.8. The r
 both versions. Template TTFB comparisons are advisory; early-stream checks retry up to three times
 to tolerate shared-runner scheduling. Crawler rendering is checked through Suspense completion
 markers instead of comparing timings between separate requests.
+
+## Size budgets
+
+PR and release CI run `npm run test:size` immediately after the library build. The script expands
+the JavaScript targets in `package.json`'s exports map against `lib/` and deduplicates extensionless
+and `.js` aliases. It excludes server/core/edge/Node runtimes, adapters, CLI, plugins, build services,
+their server/tooling helper and constant paths, and declaration-only stubs. The precise exclusions
+are documented in `scripts/test-browser-size.mjs`; shared browser modules such as `context/server`
+and `helpers/get-server-state` remain covered. New browser entries fail until they have a budget.
+
+Each entry is bundled and minified with esbuild as browser ESM. React, React DOM (including
+`react-dom/client` and `react/jsx-runtime`) and React Router stay external. All other dependencies,
+including the client HOCs' `hoist-non-react-statics`, count toward size. The combined bundle imports
+and re-exports every entry's namespace to retain all public APIs while sharing dependencies.
+Any import of `node:`, `express`, `chalk`, `commander` or `json5` (including package subpaths) fails
+the gate, even when the size is within budget.
+
+All sizes below use gzip level 9 and **KB = 1024 bytes**. Comparisons use unrounded byte counts.
+
+| Browser entry | Measured gzip KB | Budget KB |
+| --- | ---: | ---: |
+| `browser/entry` | 0.669 | 1.00 |
+| `components/navigate` | 0.334 | 0.50 |
+| `components/only-client` | 0.324 | 0.50 |
+| `components/render-client` | 1.705 | 2.25 |
+| `components/response-status` | 0.172 | 0.25 |
+| `components/scroll-to-top` | 0.203 | 0.50 |
+| `components/with-suspense` | 1.628 | 2.25 |
+| `constants/common` | 0.094 | 0.25 |
+| `context/server` | 0.175 | 0.25 |
+| `helpers/get-server-state` | 0.101 | 0.25 |
+| `helpers/import-route` | 1.937 | 2.50 |
+| `interfaces/fc-route` | 0.091 | 0.25 |
+| Combined | 3.307 (3386 bytes) | 4.307 (4410 bytes) |
+| Template client total | 146.563 | 154 |
+
+The template gate sums the gzip size of each `build/client/assets/*.js` file after the candidate's
+production SSR build, including lazy chunks and framework/application dependencies. It excludes
+CSS, images, source maps and server output. This is the full pinned acceptance template, so its total
+is larger than the minimal example's bundle. Both pinned and current dependency acceptance runs
+use the same 154 KB limit.
+
+The browser table is printed and appended to `GITHUB_STEP_SUMMARY` when set. Template acceptance
+also prints and appends its client size/budget, production server readiness (process start through
+the first successful HTTP response, including readiness polling), baseline/candidate median TTFB,
+and development/production/subpath chunk counts. Decoded gzip chunks count HTML payload rather
+than gzip headers. Available measurements are reported even if a later acceptance check fails;
+unreached timings are marked `not measured`. Readiness and TTFB remain advisory.
+
+For an intentional increase:
+
+1. Run `npm run build`, `npm run test:size` and template acceptance with the pinned template and
+   current dependencies. Review the added code/dependencies and record the measured before/after
+   sizes and the reason in the PR.
+2. Update the table at the top of `scripts/test-browser-size.mjs`: each entry's budget is
+   `Math.ceil(measuredGzipKB * 1.25 * 4) / 4` (25% headroom, rounded up to 0.25 KB). The combined
+   budget is the measured combined gzip size plus exactly 1 KB; retain byte precision.
+3. Set `TEMPLATE_CLIENT_GZIP_BUDGET_KB` near the top of `scripts/test-template.mjs` to
+   `Math.ceil(measuredGzipKB * 1.05)` using the pinned template (5% headroom, rounded up to a whole
+   KB). Confirm the current-dependency run also fits; investigate any difference before raising it.
+4. Update this table, rerun the gates, and temporarily lower a budget to prove that CI would fail.
+   Restore the reviewed budget before committing. Never update limits automatically on failure.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lint:format": "eslint . --fix",
     "ts:check": "tsc --project ./tsconfig.json --skipLibCheck --noemit",
     "test": "vitest run",
+    "test:size": "node scripts/test-browser-size.mjs",
     "test:core:no-optional": "node scripts/test-core-no-optional.mjs",
     "test:edge:packed": "node scripts/test-packed-edge.mjs",
     "test:bun": "bun scripts/test-bun.mjs",

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -1,0 +1,139 @@
+import { appendFile, readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { build } from 'esbuild';
+
+// KB means 1024 bytes throughout. Recalibrate only for an intentional size change:
+// per entry = ceil(measured KB * 1.25 * 4) / 4; combined = measured KB + 1.
+const BROWSER_GZIP_BUDGETS_KB = {
+  'browser/entry': 1,
+  'components/navigate': 0.5,
+  'components/only-client': 0.5,
+  'components/render-client': 2.25,
+  'components/response-status': 0.25,
+  'components/scroll-to-top': 0.5,
+  'components/with-suspense': 2.25,
+  'constants/common': 0.25,
+  'context/server': 0.25,
+  'helpers/get-server-state': 0.25,
+  'helpers/import-route': 2.5,
+  'interfaces/fc-route': 0.25,
+};
+const COMBINED_GZIP_BUDGET_KB = 4410 / 1024; // 3386 measured bytes + 1024 bytes.
+
+const projectRoot = process.cwd();
+const lib = resolve(projectRoot, 'lib');
+const { exports: publicExports } = JSON.parse(await readFile(resolve(projectRoot, 'package.json'), 'utf8'));
+
+// Expand JavaScript runtime targets in the exports map against lib, deduplicating
+// extensionless/.js aliases. Exclude server runtimes (server, core, edge, node,
+// adapters), CLI/plugin/build services and their helper/constant paths. Shared
+// context/server and helpers/get-server-state ARE browser entries despite their names.
+// Everything else is covered automatically; a new entry needs an explicit budget.
+const excludedPaths = [
+  /^(?:server|core|edge|node|adapters?|cli|plugins?|services|workflow)(?:\/|\.js$)/,
+  /^constants\/(?:cli-|plugin-|stream-error\.js$)/,
+  /^helpers\/(?:build-(?:custom|router)-state|create-focus-only|dev-marker|html-escape|is-route-file|obtain-stream-error|plugin-config|print-server-(?:info|urls)|process-stop|resolve-server-urls|serialize-errors|vite-aliases)\.js$/,
+  // These exports have declarations but no browser runtime.
+  /^interfaces\/(?:fc|route-object)\.js$/,
+];
+
+const runtimeTarget = (target) => {
+  if (typeof target === 'string' || target === null) return target;
+  for (const [condition, value] of Object.entries(target)) {
+    if (['browser', 'import', 'default'].includes(condition)) {
+      const selected = runtimeTarget(value);
+      if (selected !== undefined) return selected;
+    }
+  }
+};
+
+const files = (await readdir(lib, { recursive: true })).filter((file) => file.endsWith('.js'));
+const entries = new Set();
+
+for (const target of Object.values(publicExports).map(runtimeTarget)) {
+  if (!target?.endsWith('.js')) continue;
+  const [prefix, suffix] = target.slice(2).split('*');
+  const matches = suffix === undefined
+    ? [prefix]
+    : files.filter((file) => file.startsWith(prefix) && file.endsWith(suffix));
+  for (const file of matches) {
+    if (!excludedPaths.some((pattern) => pattern.test(file))) entries.add(file.slice(0, -3));
+  }
+}
+
+if (!entries.size) throw new Error('No browser exports found. Run npm run build first.');
+
+const options = {
+  absWorkingDir: projectRoot,
+  bundle: true,
+  minify: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime', 'react-router'],
+  write: false,
+  logLevel: 'silent',
+  plugins: [{
+    name: 'reject-server-dependencies',
+    setup(builder) {
+      builder.onResolve({ filter: /^(?:node:|(?:express|chalk|commander|json5)(?:\/|$))/ }, ({ path, importer }) => ({
+        errors: [{ text: `Forbidden browser dependency ${path} imported by ${importer}` }],
+      }));
+    },
+  }],
+};
+
+const rows = [];
+let failed = false;
+const measure = async (name, input, budget) => {
+  const budgetLabel = budget?.toFixed(3) ?? 'missing';
+  try {
+    const { outputFiles } = await build({ ...options, ...input });
+    const bytes = gzipSync(outputFiles[0].contents, { level: 9 }).length;
+    const passed = Number.isFinite(budget) && budget > 0 && bytes <= budget * 1024;
+    rows.push(`| ${name} | ${bytes} | ${(bytes / 1024).toFixed(3)} | ${budgetLabel} | ${passed ? 'PASS' : 'FAIL'} |`);
+    if (!passed) failed = true;
+  } catch (error) {
+    failed = true;
+    rows.push(`| ${name} | — | — | ${budgetLabel} | FAIL (bundle) |`);
+    console.error(`${name}: ${error.message}`);
+  }
+};
+
+const sortedEntries = [...entries].sort();
+for (const entry of sortedEntries) {
+  await measure(entry, { entryPoints: [resolve(lib, `${entry}.js`)] }, BROWSER_GZIP_BUDGETS_KB[entry]);
+}
+
+await measure('Combined', {
+  stdin: {
+    // Re-export each imported namespace so tree shaking cannot erase unused APIs.
+    contents: sortedEntries.map((entry, index) =>
+      `import * as entry${index} from './${entry}.js'; export { entry${index} };`).join('\n'),
+    resolveDir: lib,
+    sourcefile: 'browser-size-combined.js',
+    loader: 'js',
+  },
+}, COMBINED_GZIP_BUDGET_KB);
+
+for (const entry of Object.keys(BROWSER_GZIP_BUDGETS_KB)) {
+  if (!entries.has(entry)) {
+    failed = true;
+    console.error(`Stale browser size budget: ${entry}`);
+  }
+}
+
+const markdown = [
+  '## Browser size budgets',
+  '',
+  'Minified ESM; gzip level 9; KB = 1024 bytes. React, React DOM and React Router are external.',
+  '',
+  '| Entry | Gzip bytes | Gzip KB | Budget KB | Result |',
+  '| --- | ---: | ---: | ---: | --- |',
+  ...rows,
+  '',
+].join('\n');
+
+console.info(markdown);
+if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+if (failed) process.exitCode = 1;

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -1,20 +1,31 @@
 import { execFileSync, spawn } from 'node:child_process';
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { appendFile, cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { once } from 'node:events';
 import assert from 'node:assert/strict';
-import { createGunzip } from 'node:zlib';
+import { createGunzip, gzipSync } from 'node:zlib';
 import { stripVTControlCharacters } from 'node:util';
 import { parse } from '@babel/parser';
+
+// KB = 1024 bytes. For intentional growth, measure the pinned template again and
+// set this to Math.ceil(measured gzip KB * 1.05); document the reason and new size.
+const TEMPLATE_CLIENT_GZIP_BUDGET_KB = 154;
 
 const projectRoot = process.cwd();
 const source = resolve(process.argv[2] ?? join(projectRoot, '..', 'vite-template'));
 const directory = await mkdtemp(join(tmpdir(), 'vite-ssr-boost-template-'));
 const keepTemplate = process.env.SSR_BOOST_KEEP_TEMPLATE === '1';
 const useCurrentDependencies = process.env.SSR_BOOST_TEMPLATE_CURRENT === '1';
+const acceptance = {
+  clientGzipKb: undefined,
+  productionReadyMs: undefined,
+  baselineTtfb: undefined,
+  candidateTtfb: undefined,
+  chunks: [],
+};
 const cli = join(directory, 'node_modules', '@lomray', 'vite-ssr-boost', 'cli.js');
 const runtimePath = [
   join(directory, 'node_modules', '.bin'),
@@ -99,6 +110,7 @@ const waitUntilReady = async (origin, child) => {
     try {
       const response = await fetch(origin, { signal: AbortSignal.timeout(5_000) });
       await response.arrayBuffer();
+      if (!response.ok) throw new Error(`Server responded with ${response.status}.`);
 
       return;
     } catch {
@@ -223,12 +235,14 @@ const verify = async (origin, mode, base = '') => {
   // A fully rendered tree has no pending Suspense boundaries; compare content, not two clocks.
   assert.doesNotMatch(buffered.html, /<!--\$\?-->/, `${mode} crawler has pending content`);
 
+  let gzipChunks;
   if (mode !== 'development') {
     const compressed = await inspectEarlyStream(origin, `${base}/details`, `${mode} gzip`, {
       'Accept-Encoding': 'gzip',
     });
     assert.equal(compressed.encoding, 'gzip');
     assert.match(compressed.html, /<\/html>/);
+    gzipChunks = compressed.chunks;
     console.info(
       `${mode}: gzip HTML shell ${Math.round(compressed.firstChunkMs)}ms / complete ${Math.round(compressed.totalMs)}ms`,
     );
@@ -239,6 +253,39 @@ const verify = async (origin, mode, base = '') => {
       streamed.firstChunkMs,
     )}ms/${Math.round(streamed.totalMs)}ms); buffered=${buffered.chunks} chunks`,
   );
+  acceptance.chunks.push({ mode, streamed: streamed.chunks, buffered: buffered.chunks, gzip: gzipChunks });
+};
+
+const measureClientGzip = async () => {
+  const assets = join(directory, 'build', 'client', 'assets');
+  const scripts = (await readdir(assets, { withFileTypes: true }))
+    .filter((file) => file.isFile() && file.name.endsWith('.js'));
+  assert.ok(scripts.length, 'Template production build has no client JavaScript assets.');
+  const sizes = await Promise.all(scripts.map(async (file) =>
+    gzipSync(await readFile(join(assets, file.name)), { level: 9 }).length));
+  acceptance.clientGzipKb = sizes.reduce((total, bytes) => total + bytes, 0) / 1024;
+  console.info(`template client gzip total: ${acceptance.clientGzipKb.toFixed(3)} KB / ${TEMPLATE_CLIENT_GZIP_BUDGET_KB} KB budget (${scripts.length} JS assets)`);
+  assert.ok(acceptance.clientGzipKb <= TEMPLATE_CLIENT_GZIP_BUDGET_KB,
+    `Template client gzip size exceeds ${TEMPLATE_CLIENT_GZIP_BUDGET_KB} KB budget.`);
+};
+
+const reportAcceptance = async () => {
+  const milliseconds = (value) => value === undefined ? 'not measured' : `${Math.round(value)} ms`;
+  const markdown = [
+    `## Template acceptance (${useCurrentDependencies ? 'current' : 'pinned'} runtime dependencies)`,
+    '',
+    '| Metric | Measured | Budget |',
+    '| --- | ---: | ---: |',
+    `| Template client gzip total (KB, 1024 bytes) | ${acceptance.clientGzipKb?.toFixed(3) ?? 'not measured'} | ${TEMPLATE_CLIENT_GZIP_BUDGET_KB} |`,
+    `| Production server ready (process start to successful response) | ${milliseconds(acceptance.productionReadyMs)} | advisory |`,
+    `| Baseline median TTFB | ${milliseconds(acceptance.baselineTtfb)} | advisory |`,
+    `| Candidate median TTFB | ${milliseconds(acceptance.candidateTtfb)} | advisory |`,
+    ...acceptance.chunks.map(({ mode, streamed, buffered, gzip }) =>
+      `| ${mode} chunks (streamed / buffered / decoded gzip) | ${streamed} / ${buffered} / ${gzip ?? 'n/a'} | — |`),
+    '',
+  ].join('\n');
+  console.info(markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
 };
 
 const crawlModules = async (origin) => {
@@ -497,6 +544,7 @@ try {
 
     await waitUntilReady(origin, baseline);
     baselineTtfb = await measureTtfb(origin);
+    acceptance.baselineTtfb = baselineTtfb;
     console.info(`baseline production median TTFB: ${Math.round(baselineTtfb)}ms`);
   } finally {
     await stop(baseline);
@@ -524,17 +572,21 @@ try {
   await verifyColdStart();
 
   await run(['build']);
+  await measureClientGzip();
 
   const prodPort = await getPort();
+  const prodStarted = performance.now();
   const prod = start(['start', '--port', String(prodPort)]);
 
   try {
     const origin = `http://127.0.0.1:${prodPort}`;
 
     await waitUntilReady(origin, prod);
+    acceptance.productionReadyMs = performance.now() - prodStarted;
     await verify(origin, 'production');
 
     const candidateTtfb = await measureTtfb(origin);
+    acceptance.candidateTtfb = candidateTtfb;
     const allowedTtfb = baselineTtfb + Math.max(35, baselineTtfb * 0.5);
 
     if (candidateTtfb > allowedTtfb) {
@@ -587,4 +639,5 @@ try {
   } else if (isAbsolute(directory) && directory.startsWith(tmpdir())) {
     await rm(directory, { force: true, recursive: true });
   }
+  await reportAcceptance();
 }


### PR DESCRIPTION
## Goal

Turn bundle size into a hard CI gate and make the acceptance timings visible in every run, so a regression fails the build instead of being noticed months later.

## Changes

- `scripts/test-browser-size.mjs` (`npm run test:size`): bundles every browser-facing public entry from `lib/` with esbuild (minified browser ESM, React/React DOM/React Router external), measures gzip level 9 per entry and for a combined bundle, and fails when a budget is exceeded, when a browser entry pulls in `node:`, `express`, `chalk`, `commander` or `json5`, or when a new browser export has no budget. Entries are discovered from the `exports` map; the exclusion rules for server, adapter, CLI and plugin paths are documented in the script.
- Budgets: measured gzip plus 25 percent rounded up to 0.25 KB per entry; combined bundle 3386 bytes measured, budget 4410 bytes. The markdown table goes to stdout and to `GITHUB_STEP_SUMMARY`.
- `scripts/test-template.mjs`: sums the gzip size of the template's `build/client/assets/*.js` (146.6 KB measured for the pinned `prod` template, budget 154 KB) and fails above the budget; writes a summary table with the client size, production server ready time, baseline/candidate median TTFB and streamed chunk counts. The TTFB comparison stays advisory. Readiness now requires a 2xx response.
- `pr-check.yml` and `release.yml` run `npm run test:size` right after the library build.
- `docs/reference/acceptance-gates.md`: a "Size budgets" section with the table and the procedure for an intentional increase.

No changes under `src/`, no new dependencies (esbuild comes with Vite).

## Verification

- `npm run build`, `npm run test:size` (12 entries + combined, all PASS), `npm run lint:check`, `npm run ts:check`, `npm test` (482 passed), `npm run docs:build`, `npm run test:core:no-optional`.
- `node scripts/test-template.mjs <pinned template>` exit 0 with the new size line and the summary table (also with `SSR_BOOST_TEMPLATE_CURRENT=1`).
- Negative proof: lowering the `browser/entry` budget to 0.1 KB makes `test:size` exit 1; fixtures importing `node:fs`, `express`, `chalk`, `commander`, `json5` fail the gate.
