### PR TITLE
feat: add development diagnostics with documented codes

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: 922db6703a1f5baabec9288d9fa35ff787f6454f
+          ref: 71d859cb1a6faae030fa0a561681a7de4aead810
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: 922db6703a1f5baabec9288d9fa35ff787f6454f
+          ref: 71d859cb1a6faae030fa0a561681a7de4aead810
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies

--- a/__helpers__/react-cancellation.tsx
+++ b/__helpers__/react-cancellation.tsx
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import Navigate from '@components/navigate';
 import StreamError from '@constants/stream-error';
 import createHandler from '@core/handler';
-import type { ICoreRenderOptions, TRenderToStream } from '@core/render';
+import type { ICreateHandlerOptions } from '@core/handler';
+import type { TRenderToStream } from '@core/render';
 
 const pending = new Promise<never>(() => undefined);
 const Pending = (): never => {
@@ -18,7 +19,7 @@ const Page = () => (
 
 const fixture = (
   renderToStream: TRenderToStream,
-  options: ICoreRenderOptions = {},
+  options: Partial<ICreateHandlerOptions<Record<string, any>>> = {},
   root = false,
 ) => {
   const onError = vi.fn();
@@ -67,11 +68,25 @@ const testReactCancellation = (renderer: TRenderToStream): void => {
       ).toBe(true);
     });
 
-    it.each([undefined, new Error('client disconnected')])(
-      'reports cancellation with reason %s',
-      async (reason) => {
+    it.each(
+      [false, true].flatMap((diagnostics) =>
+        [false, true].flatMap((withHook) =>
+          [undefined, new Error('client disconnected')].map((reason) => ({
+            diagnostics,
+            withHook,
+            reason,
+          })),
+        ),
+      ),
+    )(
+      'reports cancellation with reason $reason, diagnostics=$diagnostics, onResponse=$withHook',
+      async ({ diagnostics, withHook, reason }) => {
         const controller = new AbortController();
-        const { handler, onError } = fixture(renderer, { abortDelay: 5_000 });
+        const { handler, onError } = fixture(renderer, {
+          abortDelay: 5_000,
+          diagnostics,
+          onResponse: withHook ? ({ html }) => html : undefined,
+        });
         const response = await handler(
           new Request('http://example.com/', { signal: controller.signal }),
         );
@@ -79,12 +94,16 @@ const testReactCancellation = (renderer: TRenderToStream): void => {
 
         await reader.read();
         controller.abort(reason);
-        await reader.cancel().catch(() => undefined);
+        await reader.cancel();
 
-        expect(onError).toHaveBeenCalled();
-        expect(
-          onError.mock.calls.every(([{ error }]) => error.code === StreamError.RenderCancel),
-        ).toBe(true);
+        expect(onError.mock.calls.map(([{ error }]) => error)).toEqual([
+          {
+            code: StreamError.RenderCancel,
+            message: controller.signal.reason.message,
+            original: controller.signal.reason,
+          },
+        ]);
+        expect(onError.mock.calls[0][0].error.original).toBe(controller.signal.reason);
       },
     );
 

--- a/__tests__/adapters/express/prepare-server.ts
+++ b/__tests__/adapters/express/prepare-server.ts
@@ -6,6 +6,7 @@ import PrepareServer from '@adapters/express/prepare-server';
 describe('PrepareServer', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   const createConfig = (isProd = false) => {
@@ -115,6 +116,34 @@ describe('PrepareServer', () => {
     await service.onAppCreated();
 
     expect(onServerCreated).toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'rejects zero and multiple outlets even with diagnostics off (isProd=%s)',
+    async (isProd) => {
+      vi.stubEnv('SSR_BOOST_DIAGNOSTICS', '0');
+      const config = createConfig(isProd);
+      const read = vi.spyOn(fs, 'readFileSync');
+
+      for (const html of ['<html></html>', '<!--ssr-outlet--><!--ssr-outlet-->']) {
+        read.mockReturnValue(html);
+        config.getVite().transformIndexHtml.mockResolvedValue(html);
+        await expect(
+          PrepareServer.init(config as never).loadHtml({ originalUrl: '/' } as never),
+        ).rejects.toThrow(
+          '[ssr-boost] SSR_BOOST_OUTLET_MISSING: Invalid HTML shell in "/root/index.html": expected exactly one non-empty outlet "<!--ssr-outlet-->". See https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics#ssr_boost_outlet_missing',
+        );
+      }
+    },
+  );
+
+  it('validates the shell after Vite transforms it', async () => {
+    const config = createConfig(false);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('<!--ssr-outlet-->');
+    config.getVite().transformIndexHtml.mockResolvedValue('<html></html>');
+    await expect(
+      PrepareServer.init(config as never).loadHtml({ originalUrl: '/' } as never),
+    ).rejects.toThrow('SSR_BOOST_OUTLET_MISSING');
   });
 
   it('should stop process with friendly message when prod build is missing', async () => {

--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import render from '@adapters/express/render';
 import type { IRenderOptions, IRequestContext } from '@adapters/express/render';
+import Diagnostics from '@services/diagnostics';
 
 const { coreRenderMock, createFetchRequestMock, injectAssetsMock, writeFetchResponseMock } =
   vi.hoisted(() => ({
@@ -63,8 +64,10 @@ describe('legacy Express render adapter', () => {
     const logger = {
       error: vi.fn(),
       info: vi.fn(),
+      warn: vi.fn(),
     };
     const config = {
+      isProd: false,
       getLogger: () => logger,
     };
     const context: Record<string, any> = {
@@ -92,7 +95,31 @@ describe('legacy Express render adapter', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
+
+  it.each([
+    [false, 'production', undefined, true],
+    [true, 'development', undefined, false],
+    [false, 'development', '0', false],
+    [true, 'production', '1', true],
+  ] as const)(
+    'uses managed mode isProd=%s over NODE_ENV=%s with override=%s',
+    async (isProd, environment, override, enabled) => {
+      vi.stubEnv('NODE_ENV', environment);
+      vi.stubEnv('SSR_BOOST_DIAGNOSTICS', override);
+      const { config, context, logger } = createContext();
+      config.isProd = isProd;
+      context.req.originalUrl = `/managed-${isProd}-${environment}-${override ?? 'default'}`;
+      coreRenderMock.mockImplementation(async (_, updated) => {
+        expect(updated.diagnostics instanceof Diagnostics).toBe(enabled);
+        updated.diagnostics?.inspectOnResponse(new Set());
+        return new Response('rendered');
+      });
+      await render({ App, handler: {} as never }, config as never, context as never, {});
+      expect(logger.warn).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    },
+  );
 
   it.each(['GET', 'POST'])(
     'shares the Fetch %s request across all render hooks',

--- a/__tests__/core/diagnostics.ts
+++ b/__tests__/core/diagnostics.ts
@@ -1,0 +1,291 @@
+// @vitest-environment node
+import { createStaticHandler } from 'react-router';
+import type { MockInstance } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import createHandler from '@core/handler';
+import type { ICreateHandlerOptions } from '@core/handler';
+import type { TRenderToStream } from '@core/render';
+import Diagnostics, { isDiagnosticsEnabled } from '@services/diagnostics';
+import Logger from '@services/logger';
+
+const docs = 'https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics#';
+const hydration = '<script>window.__staticRouterHydrationData = {};</script>';
+let counter = 0;
+let pathname: string;
+let warn: MockInstance<Logger['warn']>;
+
+const fakeRenderer =
+  (chunks: string[]): TRenderToStream =>
+  () => ({
+    abort: vi.fn(),
+    allReady: Promise.resolve(),
+    shellReady: Promise.resolve(),
+    start: vi.fn(),
+    stream: new ReadableStream({
+      start(controller) {
+        chunks.forEach((chunk) => controller.enqueue(new TextEncoder().encode(chunk)));
+        controller.close();
+      },
+    }),
+  });
+
+const fixture = (
+  options: Partial<ICreateHandlerOptions<Record<string, unknown>>> = {},
+  chunks = ['<main>content</main>'],
+  data: unknown = null,
+) =>
+  createHandler(
+    {
+      createApp: (children) => children,
+      handler: createStaticHandler([
+        {
+          id: pathname.slice(1),
+          path: '*',
+          loader: () => data,
+          action: () => data,
+          Component: () => null,
+        },
+      ]),
+      renderToStream: fakeRenderer(chunks),
+    },
+    {
+      getHtml: () => ({ header: '<html><head></head><body>', footer: '</body></html>' }),
+      ...options,
+    },
+  );
+
+const request = (method = 'GET') => new Request(`https://example.test${pathname}`, { method });
+const messages = (): string[] => warn.mock.calls.map(([message]) => message as string);
+
+beforeEach(() => {
+  pathname = `/diagnostics-${++counter}`;
+  vi.stubEnv('NODE_ENV', 'development');
+  vi.stubEnv('SSR_BOOST_DIAGNOSTICS', undefined);
+  warn = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('createHandler diagnostics', () => {
+  it.each(['GET', 'POST'])('identifies the route and nested %s data path', async (method) => {
+    const handler = fixture({}, undefined, { items: [{ result: Promise.resolve(1) }] });
+    await (await handler(request(method))).text();
+    const kind = method === 'POST' ? 'actionData' : 'loaderData';
+    expect(messages()).toContain(
+      `[ssr-boost] SSR_BOOST_LOADER_NOT_SERIALIZABLE: Route "${pathname.slice(1)}" at ${kind}["${pathname.slice(1)}"].items[0].result: Promise is not JSON-serializable. See ${docs}ssr_boost_loader_not_serializable`,
+    );
+  });
+
+  it('warns about BigInt before JSON serialization throws', async () => {
+    await expect(fixture({}, undefined, { count: 1n })(request())).rejects.toThrow(/BigInt/);
+    expect(messages()[0]).toContain('.count: BigInt is not JSON-serializable');
+  });
+
+  it('checks getState, including values omitted by the state builder', async () => {
+    const handler = fixture({
+      getState: () => ({ app: { nested: [new Date('2026-01-01')] }, emptyMap: new Map() }),
+    });
+    await (await handler(request())).text();
+    expect(messages()).toEqual([
+      `[ssr-boost] SSR_BOOST_STATE_NOT_SERIALIZABLE: getState for route "${pathname}" at $.app.nested[0]: Date hydrates as a string. See ${docs}ssr_boost_state_not_serializable`,
+      `[ssr-boost] SSR_BOOST_STATE_NOT_SERIALIZABLE: getState for route "${pathname}" at $.emptyMap: Map is not JSON-serializable. See ${docs}ssr_boost_state_not_serializable`,
+    ]);
+  });
+
+  it.each([
+    { header: '<html></html>', footer: undefined as never },
+    { header: '<!--ssr-outlet-->', footer: '' },
+    { header: '', footer: '<!--ssr-outlet-->' },
+  ])('reports invalid split shells %j', async (shell) => {
+    await (await fixture({ getHtml: () => shell })(request())).text();
+    expect(messages()).toHaveLength(1);
+    expect(messages()[0]).toContain('SSR_BOOST_OUTLET_MISSING:');
+    expect(messages()[0]).toContain(`route "${pathname}"`);
+  });
+
+  it.each(['withhold', 'transform'])('reports a hydration footer lost by %s', async (mode) => {
+    const handler = fixture({
+      onResponse: ({ html }) =>
+        mode === 'withhold' && html.includes('window.__staticRouterHydrationData')
+          ? ''
+          : html.replace(/<script async>window\.__staticRouterHydrationData.*?<\/script>/, ''),
+    });
+    await (await handler(request())).text();
+    expect(messages()).toEqual([
+      `[ssr-boost] SSR_BOOST_HYDRATION_STATE_MISSING: Completed response for route "${pathname}" has no window.__staticRouterHydrationData script; preserve the hydration footer in onResponse. See ${docs}ssr_boost_hydration_state_missing`,
+    ]);
+  });
+
+  it.each([
+    ['<html>', '<HTML lang="en">'],
+    ['<head>', '<head data-source="manager">'],
+    ['window.__staticRouterHydrationData', hydration],
+    ['id="S:1"', '<div id="S:1"></div><div id="S:1"></div>'],
+    ['id="B:1"', '<template id="B:1"></template><template id="B:1"></template>'],
+    ['$RC("B:1")', '<script>$RC("B:1","S:1");$RC("B:1","S:1");</script>'],
+  ])('reports repeated %s even when split between chunks', async (marker, body) => {
+    const handler = fixture({}, [...body]);
+    await (await handler(request())).text();
+    expect(messages()).toEqual([
+      `[ssr-boost] SSR_BOOST_DUPLICATE_OUTPUT: Completed response for route "${pathname}" repeats ${marker}; onResponse must return undefined to keep a chunk and '' to withhold one. See ${docs}ssr_boost_duplicate_output`,
+    ]);
+  });
+
+  it('diagnoses the output appended by the final hook call', async () => {
+    let retained = '';
+    const handler = fixture({
+      onResponse: ({ html, isEnd }) => {
+        if (isEnd) return retained;
+        retained += html;
+        return undefined;
+      },
+    });
+    await (await handler(request())).text();
+    expect(messages()).toHaveLength(3);
+    expect(messages().every((message) => message.includes('SSR_BOOST_DUPLICATE_OUTPUT:'))).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    [Promise.resolve('chunk'), 'Promise'],
+    [{ html: 'chunk' }, 'Object'],
+    [null, 'null'],
+    [42, 'number'],
+    [false, 'boolean'],
+    [() => 'chunk', 'function'],
+  ])('reports an invalid onResponse return %s as %s', async (value, type) => {
+    const handler = fixture({
+      onResponse: ({ html }) => (html.includes('<main>') ? (value as never) : undefined),
+    });
+    await (await handler(request())).text();
+    expect(messages()).toEqual([
+      `[ssr-boost] SSR_BOOST_ONRESPONSE_INVALID_RETURN: onResponse for route "${pathname}" returned ${type}; return a string or undefined. See ${docs}ssr_boost_onresponse_invalid_return`,
+    ]);
+  });
+
+  it('checks invalid returns on the final hook call too', async () => {
+    await (
+      await fixture({ onResponse: ({ isEnd }) => (isEnd ? ({} as never) : undefined) })(request())
+    ).text();
+    expect(messages()[0]).toContain('SSR_BOOST_ONRESPONSE_INVALID_RETURN:');
+  });
+
+  it('accepts normal React markers, raw text and correctly retained hook output', async () => {
+    let retained = '';
+    const handler = fixture(
+      {
+        getState: () => ({ app: { example: '<html><head>' } }),
+        onResponse: ({ html, isEnd }) => {
+          retained += html;
+          return isEnd ? retained : '';
+        },
+      },
+      [
+        '<!-- <html><head><div id="S:0"> -->',
+        '<script>const example = "<html><head><div id=\'S:0\'>";</script>',
+        '<style>/* <html><head> */</style><textarea><html><head></textarea>',
+        '<div data-example="<html><head>" title=\'id="S:0"\'></div>',
+        '<template id="B:0"></template><div hidden id="S:0"></div>',
+        '<script>$RC("B:0", "S:0");</script>',
+      ],
+    );
+    await (await handler(request())).text();
+    expect(messages()).toEqual([]);
+  });
+
+  it.each(['HEAD', 'redirect', '204', 'shell-error'])(
+    'skips completed-body checks for %s',
+    async (mode) => {
+      const append = vi.spyOn(Diagnostics.prototype, 'append');
+      const handler = fixture({
+        onRequest: () => {
+          if (mode === 'redirect') return Response.redirect('https://example.test/next');
+          return { status: mode === '204' ? 204 : undefined };
+        },
+        onRouterReady: () => {
+          if (mode === 'shell-error') throw new Error('pre-render failure');
+          return {};
+        },
+      });
+      if (mode === 'shell-error') {
+        await expect(handler(request())).rejects.toThrow('pre-render failure');
+      } else {
+        await (await handler(request(mode === 'HEAD' ? 'HEAD' : 'GET'))).text();
+      }
+      expect(append).not.toHaveBeenCalled();
+      expect(messages()).toEqual([]);
+    },
+  );
+
+  it.each([
+    ['production', undefined, undefined, false],
+    ['development', false, undefined, false],
+    ['development', true, '0', false],
+    ['production', true, '0', false],
+    ['production', false, '1', true],
+    ['production', undefined, '1', true],
+    ['production', true, undefined, true],
+    ['development', undefined, undefined, true],
+  ] as const)(
+    'resolves NODE_ENV=%s option=%s override=%s to %s without disabled walks or buffering',
+    async (environment, option, override, enabled) => {
+      vi.stubEnv('NODE_ENV', environment);
+      vi.stubEnv('SSR_BOOST_DIAGNOSTICS', override);
+      const append = vi.spyOn(Diagnostics.prototype, 'append');
+      const routerWalk = vi.spyOn(Diagnostics.prototype, 'inspectRouterState');
+      const stateWalk = vi.spyOn(Diagnostics.prototype, 'inspectState');
+      const handler = fixture(
+        { diagnostics: option, getState: () => ({ app: { map: new Map() } }) },
+        ['<head></head>'],
+        { pending: Promise.resolve(1) },
+      );
+      await (await handler(request())).text();
+      expect(append.mock.calls.length > 0).toBe(enabled);
+      expect(routerWalk.mock.calls.length > 0).toBe(enabled);
+      expect(stateWalk.mock.calls.length > 0).toBe(enabled);
+      expect(messages().length > 0).toBe(enabled);
+    },
+  );
+
+  it('works in Fetch runtimes without process globals', async () => {
+    vi.stubGlobal('process', undefined);
+    try {
+      expect(isDiagnosticsEnabled()).toBe(true);
+      expect(isDiagnosticsEnabled(false)).toBe(false);
+      await (await fixture({ diagnostics: false })(request())).text();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('emits all six documented codes once across requests and handler instances', async () => {
+    pathname = '/diagnostics-proof';
+    const options = {
+      getHtml: () => ({ header: '<html><head></head><body>', footer: undefined as never }),
+      getState: () => ({ app: { cache: new Map() } }),
+      onResponse: ({ html }: { html: string }) => {
+        if (html.includes('window.__staticRouterHydrationData')) return '';
+        if (html.includes('<main>')) return {} as never;
+        return undefined;
+      },
+    };
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const handler = fixture(options, ['<head></head>', '<main>body</main>'], {
+        pending: Promise.resolve(1),
+      });
+      await (await handler(request())).text();
+      await (await handler(request())).text();
+    }
+    expect(messages()).toHaveLength(6);
+    expect(new Set(messages().map((message) => message.match(/SSR_BOOST_[A-Z_]+/)![0])).size).toBe(
+      6,
+    );
+    if (process.env.SSR_BOOST_DIAGNOSTICS_PROOF === '1') {
+      process.stdout.write(`${messages().join('\n')}\n`);
+    }
+  });
+});

--- a/__tests__/core/transform-html.ts
+++ b/__tests__/core/transform-html.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import composeHtml from '@core/compose-html';
 import transformHtml from '@core/transform-html';
+import Diagnostics from '@services/diagnostics';
 
 const createStream = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
   new ReadableStream({
@@ -100,4 +102,140 @@ describe('transformHtml', () => {
     );
     expect(transform.mock.calls).toEqual([['', true]]);
   });
+
+  it('observes split UTF-8 without changing bytes or chunk boundaries when no hook is installed', async () => {
+    const diagnostics = new Diagnostics('/bytes', { warn: vi.fn() });
+    const append = vi.spyOn(diagnostics, 'append');
+    const complete = vi.spyOn(diagnostics, 'complete');
+    const emoji = new TextEncoder().encode('🙂');
+    const chunks = [new Uint8Array(), emoji.slice(0, 2), emoji.slice(2), new Uint8Array([0xff])];
+    const reader = transformHtml(createStream(...chunks), undefined, diagnostics).getReader();
+
+    for (const chunk of chunks) {
+      expect((await reader.read()).value).toBe(chunk);
+      expect(complete).not.toHaveBeenCalled();
+    }
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+    expect(append.mock.calls.map(([html]) => html).join('')).toBe('🙂�');
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  describe.each(
+    [false, true].flatMap((enabled) => [false, true].map((withHook) => ({ enabled, withHook }))),
+  )('stream semantics with diagnostics=$enabled, onResponse=$withHook', ({ enabled, withHook }) => {
+    const observe = (stream: ReadableStream<Uint8Array>) => {
+      const diagnostics = enabled ? new Diagnostics('/stream', { warn: vi.fn() }) : undefined;
+      const complete = diagnostics ? vi.spyOn(diagnostics, 'complete') : undefined;
+      const hook = withHook ? vi.fn((html: string) => html) : undefined;
+      return { stream: transformHtml(stream, hook, diagnostics), complete, hook };
+    };
+
+    it('does not read ahead of the consumer, including across the HTML shell boundary', async () => {
+      const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+        controller.enqueue(new TextEncoder().encode('body'));
+      });
+      const source = new ReadableStream<Uint8Array>({ pull }, { highWaterMark: 0 });
+      const { stream } = observe(composeHtml('header', source, 'footer'));
+      const reader = stream.getReader();
+      await Promise.resolve();
+      expect(pull).not.toHaveBeenCalled();
+
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe('header');
+      await Promise.resolve();
+      expect(pull).not.toHaveBeenCalled();
+
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe('body');
+      await Promise.resolve();
+      expect(pull).toHaveBeenCalledOnce();
+
+      await reader.read();
+      await Promise.resolve();
+      expect(pull).toHaveBeenCalledTimes(2);
+      await reader.cancel();
+    });
+
+    it.each([undefined, new Error('client disconnected')])(
+      'forwards cancel(%s) immediately while a read is pending and skips completion',
+      async (reason) => {
+        let notifyPull!: () => void;
+        const pulling = new Promise<void>((resolve) => {
+          notifyPull = resolve;
+        });
+        const cancel = vi.fn();
+        const source = new ReadableStream<Uint8Array>(
+          { pull: () => notifyPull(), cancel },
+          { highWaterMark: 0 },
+        );
+        const { stream, complete, hook } = observe(source);
+        const reader = stream.getReader();
+        const reading = reader.read();
+        await pulling;
+
+        const cancelled = reader.cancel(reason);
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(cancel.mock.calls[0][0]).toBe(reason);
+        await cancelled;
+        expect(await reading).toEqual({ done: true, value: undefined });
+        expect(complete?.mock.calls ?? []).toEqual([]);
+        expect(hook?.mock.calls ?? []).toEqual([]);
+        reader.releaseLock();
+        expect(source.locked).toBe(false);
+      },
+    );
+
+    it('preserves the source error identity and does not run final hooks or diagnostics', async () => {
+      const error = new Error('source failed');
+      const source = new ReadableStream<Uint8Array>(
+        { pull: (controller) => controller.error(error) },
+        { highWaterMark: 0 },
+      );
+      const { stream, complete, hook } = observe(source);
+      const reader = stream.getReader();
+      await expect(reader.read()).rejects.toBe(error);
+      await expect(reader.closed).rejects.toBe(error);
+      expect(complete?.mock.calls ?? []).toEqual([]);
+      expect(hook?.mock.calls ?? []).toEqual([]);
+      reader.releaseLock();
+    });
+
+    it('preserves a source cancellation rejection', async () => {
+      const reason = new Error('client disconnected');
+      const failure = new Error('cancel failed');
+      const cancel = vi.fn().mockRejectedValue(failure);
+      const source = new ReadableStream<Uint8Array>({ cancel }, { highWaterMark: 0 });
+      const { stream, complete } = observe(source);
+      const reader = stream.getReader();
+      await expect(reader.cancel(reason)).rejects.toBe(failure);
+      expect(cancel.mock.calls[0][0]).toBe(reason);
+      expect(complete?.mock.calls ?? []).toEqual([]);
+      reader.releaseLock();
+      expect(source.locked).toBe(false);
+    });
+  });
+
+  it.each([false, true])(
+    'preserves hook errors and cancels the source (diagnostics=%s)',
+    async (enabled) => {
+      const error = new Error('hook failed');
+      const cancel = vi.fn().mockRejectedValue(new Error('cleanup failed'));
+      const source = new ReadableStream<Uint8Array>({
+        start: (controller) => controller.enqueue(new TextEncoder().encode('body')),
+        cancel,
+      });
+      const diagnostics = enabled ? new Diagnostics('/hook-error', { warn: vi.fn() }) : undefined;
+      const complete = diagnostics ? vi.spyOn(diagnostics, 'complete') : undefined;
+      const reader = transformHtml(
+        source,
+        () => {
+          throw error;
+        },
+        diagnostics,
+      ).getReader();
+
+      await expect(reader.read()).rejects.toBe(error);
+      expect(cancel.mock.calls[0][0]).toBe(error);
+      expect(complete?.mock.calls ?? []).toEqual([]);
+      reader.releaseLock();
+    },
+  );
 });

--- a/__tests__/node/production.ts
+++ b/__tests__/node/production.ts
@@ -48,8 +48,9 @@ describe('loadHtmlShell', () => {
     'rejects invalid outlet counts in %s and names the file',
     async (html) => {
       await writeFile(indexFile, html);
-      await expect(loadHtmlShell({ indexFile })).rejects.toThrow(indexFile);
-      await expect(loadHtmlShell({ indexFile })).rejects.toThrow('expected exactly one');
+      await expect(loadHtmlShell({ indexFile })).rejects.toThrow(
+        `[ssr-boost] SSR_BOOST_OUTLET_MISSING: Invalid HTML shell in "${indexFile}": expected exactly one non-empty outlet "<!--ssr-outlet-->". See https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics#ssr_boost_outlet_missing`,
+      );
     },
   );
 

--- a/__tests__/services/diagnostics.ts
+++ b/__tests__/services/diagnostics.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { walkSerializable } from '@services/diagnostics';
+
+class Example {
+  public value = 1;
+}
+
+class ExampleArray extends Array {}
+
+describe('diagnostics serialization walker', () => {
+  it.each([
+    [Promise.resolve(1), 'Promise'],
+    [() => 1, 'function'],
+    [new Map(), 'Map'],
+    [new Set(), 'Set'],
+    [new WeakMap(), 'WeakMap'],
+    [new WeakSet(), 'WeakSet'],
+    [1n, 'BigInt'],
+    [Symbol('value'), 'Symbol'],
+    [new Example(), 'Example'],
+    [new ExampleArray(), 'ExampleArray'],
+    [new Uint8Array(1), 'Uint8Array'],
+  ])('reports %s as %s with its nested key path', (value, name) => {
+    const issues: unknown[] = [];
+    walkSerializable({ nested: { items: [{ value }] } }, (issue) => issues.push(issue));
+    expect(issues).toEqual([
+      { path: '$.nested.items[0].value', reason: `${name} is not JSON-serializable` },
+    ]);
+  });
+
+  it('explains how a Date hydrates', () => {
+    const issues: unknown[] = [];
+    walkSerializable({ created: new Date('2026-01-01') }, (issue) => issues.push(issue));
+    expect(issues).toEqual([{ path: '$.created', reason: 'Date hydrates as a string' }]);
+  });
+
+  it('accepts plain data, arrays, null prototypes and shared references', () => {
+    const shared = { value: 'same object' };
+    const issues: unknown[] = [];
+    walkSerializable(
+      {
+        a: shared,
+        b: shared,
+        data: [null, undefined, true, false, 0, 1.5, '', 'text', { nested: [1] }],
+        empty: Object.create(null),
+      },
+      (issue) => issues.push(issue),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('quotes ambiguous keys and reports every distinct path to shared values', () => {
+    const shared = { 'a.b': Symbol('value') };
+    const issues: unknown[] = [];
+    walkSerializable([shared, shared, { 'quote"': { '': new Set() } }], (issue) =>
+      issues.push(issue),
+    );
+    expect(issues).toEqual([
+      { path: '$[0]["a.b"]', reason: 'Symbol is not JSON-serializable' },
+      { path: '$[1]["a.b"]', reason: 'Symbol is not JSON-serializable' },
+      { path: '$[2]["quote\\\""][""]', reason: 'Set is not JSON-serializable' },
+    ]);
+  });
+
+  it('reports cycles without recursing forever', () => {
+    const value: { self?: unknown } = {};
+    value.self = value;
+    const issues: unknown[] = [];
+    walkSerializable(value, (issue) => issues.push(issue));
+    expect(issues).toEqual([
+      { path: '$.self', reason: 'a circular reference is not JSON-serializable' },
+    ]);
+  });
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
           { text: 'Talking Points', link: '/reference/talking-points' },
           { text: 'Hydration order and streaming', link: '/reference/hydration-and-streaming' },
           { text: 'FAQ', link: '/reference/faq' },
+          { text: 'Diagnostics', link: '/reference/diagnostics' },
           { text: 'Acceptance Gates', link: '/reference/acceptance-gates' },
           { text: 'Useful Links', link: '/reference/useful-links' },
         ],

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -98,6 +98,14 @@ router and `getState` data before that footer so it is available when the browse
 or a `Response` to bypass rendering. These extensionless imports work directly in Node and bundlers;
 explicit `.js` imports remain supported.
 
+`createHandler` also accepts `diagnostics?: boolean` in its second argument, alongside `getHtml`.
+It defaults to `process.env.NODE_ENV !== 'production'`, or `true` in runtimes without `process`.
+`SSR_BOOST_DIAGNOSTICS=0` or `1` overrides the option wherever environment variables are available.
+Enabled checks warn once per distinct message about state serialization, shell boundaries and
+completed response output; disabled checks do no state walking or HTML accumulation.
+See [Development diagnostics](/reference/diagnostics) for the codes and fixes. For file-backed
+shells, `loadHtmlShell` validates exactly one outlet in every mode before producing `{ header, footer }`.
+
 ## Adapters
 
 The managed CLI is the default path. A custom transport owns the development server and static assets.

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -17,6 +17,13 @@ That is where the customization hooks fit.
 
 Render hooks receive a [context](/api/server-entry#hook-context) with the shared Fetch `request` and live Express `req` / `res`; `onRequest` receives `(req, res)` before that context is created.
 
+Development requests also run [diagnostics](/reference/diagnostics) for non-serializable state,
+invalid `onResponse` returns, missing hydration scripts and duplicate output, with stable warning
+codes emitted once per distinct message. They are enabled for `ssr-boost dev`, disabled for
+`ssr-boost start` and managed serverless, and controlled by the Fetch handler's `diagnostics` option;
+`SSR_BOOST_DIAGNOSTICS=0|1` overrides either setting. Invalid HTML outlet counts always throw for
+file-backed shells, including in production.
+
 ## `onServerCreated`
 
 Called once after the Express app exists.

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -14,7 +14,7 @@ Run these before a release. The same checks run in PR and release CI.
 | `npm run test:template` | Template SSR in dev/production, cold styles, SSR module reload, streamed and crawler HTML, gzip, static JS/CSS, redirects, HEAD, 404, subpath deployment, standalone SPA, client gzip budget and baseline TTFB comparison |
 | `npm run docs:build` | Documentation build and links |
 
-CI pins `vite-template` to `922db6703a1f5baabec9288d9fa35ff787f6454f`. Locally, install its dependencies
+CI pins `vite-template` to `71d859cb1a6faae030fa0a561681a7de4aead810`. Locally, install its dependencies
 in `../vite-template`, or pass its path to `node scripts/test-template.mjs`. The script works on a
 copy; it changes only that copy's configuration for the subpath test.
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -1,0 +1,136 @@
+# Development diagnostics
+
+Diagnostics catch state serialization and response-hook mistakes before they reach the browser.
+Each distinct warning is logged once per process through the existing logger, with a stable code,
+the affected route/key or file, and a link to its section below; managed development uses your
+configured `loggerDev`. Reloading a development module does not reset this deduplication.
+
+Checks are on for `ssr-boost dev` and off for `ssr-boost start` and managed serverless deployments.
+Fetch [`createHandler`](/guide/runtime-adapters#create-a-fetch-handler) accepts `diagnostics?: boolean`,
+defaulting to `process.env.NODE_ENV !== 'production'` (on if `process` is unavailable).
+`SSR_BOOST_DIAGNOSTICS=0` disables the checks and `SSR_BOOST_DIAGNOSTICS=1` enables them, overriding
+both the option and managed CLI mode wherever environment variables are available.
+
+When enabled, diagnostics walk state before serialization and retain a copy of emitted HTML until
+the response finishes, without delaying streamed chunks. When disabled, they neither walk state nor
+accumulate HTML. Completed-output checks skip cancelled or failed streams, redirects, and bodyless
+responses; invalid file-backed shells always throw, even with diagnostics disabled.
+
+## SSR_BOOST_LOADER_NOT_SERIALIZABLE {#ssr_boost_loader_not_serializable}
+
+### When it appears
+
+A loader or action returns a Promise, function, Map, Set, WeakMap, WeakSet, BigInt, Symbol, or class
+instance anywhere inside plain objects or arrays. The warning names the React Router route id and
+key path, such as `loaderData["details"].items[0].result`; Dates are reported as “hydrates as a string”,
+and circular references are reported too.
+
+### Why it matters
+
+Router hydration uses JSON, so a nested Promise or Map becomes `{}` and functions or symbols can
+disappear. BigInts and cycles make serialization throw, while Dates lose their Date methods after
+hydration.
+
+### How to fix
+
+Await loader data needed for the initial page and return plain JSON data at the reported path.
+Convert collections to arrays or objects, class instances to explicit data fields, and BigInts or
+Dates to strings with deliberate client-side reconstruction; keep streamed work in the application's
+Suspense mechanism instead of placing Promises in router hydration data.
+
+## SSR_BOOST_STATE_NOT_SERIALIZABLE {#ssr_boost_state_not_serializable}
+
+### When it appears
+
+The object returned by `getState` contains one of the unsupported values listed above, including
+nested values inside arrays and plain objects. The warning identifies the request route and a path
+such as `$.store.items[0].createdAt`, even when the state builder would otherwise omit the value.
+
+### Why it matters
+
+Custom state is serialized into browser scripts using JSON just like router state. A server store
+containing class instances or collections can therefore hydrate with missing fields or changed types.
+
+### How to fix
+
+Return a plain snapshot of your store from `getState`, with awaited values and explicit fields.
+Convert Dates to ISO strings and collections to plain data, then rebuild the client store from that
+snapshot rather than returning the live store instance.
+
+## SSR_BOOST_OUTLET_MISSING {#ssr_boost_outlet_missing}
+
+### When it appears
+
+The managed server or `loadHtmlShell` finds zero or multiple `<!--ssr-outlet-->` markers (or an invalid
+custom outlet), and throws an Error naming the HTML file in every mode. For Fetch handlers, the
+pre-split `{ header, footer }` shell represents one insertion boundary; diagnostics warn if either
+half is missing or a raw outlet remains in either half.
+
+### Why it matters
+
+The outlet determines where React content goes and where the hydration footer begins. An absent or
+duplicate boundary can put content outside the document or discard the footer entirely.
+
+### How to fix
+
+Place exactly one `<!--ssr-outlet-->` inside the application's root element in `index.html`, and make
+sure HTML transforms preserve it. For file-backed Fetch shells use `loadHtmlShell({ indexFile })`
+to validate the source before splitting it; manually supplied halves must both be strings, which
+may be empty, and must not retain the marker.
+
+## SSR_BOOST_HYDRATION_STATE_MISSING {#ssr_boost_hydration_state_missing}
+
+### When it appears
+
+A completed development response has no script assigning `window.__staticRouterHydrationData`.
+This commonly follows an `onResponse` hook that withholds the footer or removes its hydration script.
+
+### Why it matters
+
+The browser entry needs router hydration data to start with the same loader and action state as the
+server. Removing that script prevents the page from hydrating correctly even if its HTML looks complete.
+
+### How to fix
+
+Preserve the generated hydration script when transforming footer chunks. If your hook retains
+chunks by returning `''`, return the remaining content on the final `isEnd: true` call, including
+the hydration state and document footer.
+
+## SSR_BOOST_DUPLICATE_OUTPUT {#ssr_boost_duplicate_output}
+
+### When it appears
+
+A completed development response repeats an `<html>` or `<head>` opening tag, a router hydration
+script, a React segment/boundary `id="S:…"` or `id="B:…"`, or a `$RC("B:…", …)` call for the same id.
+The warning names the repeated marker; one boundary id and its matching `$RC` call are expected and
+are counted separately.
+
+### Why it matters
+
+Repeated document or hydration output can corrupt the page, and repeated React streaming markers
+can apply Suspense content more than once. A hook that retains a chunk but returns `undefined`
+accidentally emits it now and may emit it again at the end.
+
+### How to fix
+
+`onResponse` must return `undefined` to keep a chunk and `''` to withhold one, then return retained
+content exactly once on the final call. Check head-manager integration too: insert head contents
+into the existing `<head>` rather than adding a second opening tag.
+
+## SSR_BOOST_ONRESPONSE_INVALID_RETURN {#ssr_boost_onresponse_invalid_return}
+
+### When it appears
+
+`onResponse` returns something other than a string or `undefined`, including on its final call.
+The warning names the route and actual return type, such as Promise, Object, number, or null.
+
+### Why it matters
+
+The hook is synchronous and its return value directly controls the outgoing chunk. An async hook
+returns a Promise that is not awaited, so the response can contain `[object Promise]` instead of HTML.
+
+### How to fix
+
+Make `onResponse` synchronous and return a string to replace a chunk, `undefined` to keep it, or `''`
+to withhold it. Do asynchronous preparation in an earlier async lifecycle hook and let the final
+`isEnd: true` call return only any remaining HTML string.

--- a/src/adapters/express/prepare-server.ts
+++ b/src/adapters/express/prepare-server.ts
@@ -7,6 +7,7 @@ import type { Express, Request } from 'express';
 import type { IEntrypointOptions, IPrepareRenderOut } from '@adapters/express/entry';
 import type { TRender } from '@adapters/express/render';
 import type { TRouteObject } from '@interfaces/route-object';
+import { splitHtmlShell } from '@services/diagnostics';
 import ServerApi from '@services/server-api';
 import type ServerConfig from '@services/server-config';
 
@@ -189,7 +190,7 @@ class PrepareServer {
       );
     }
 
-    return modifiedHtml.split('<!--ssr-outlet-->') as [string, string];
+    return splitHtmlShell(modifiedHtml, path.resolve(`${root}/${indexFile}`));
   }
 
   /**

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -15,6 +15,7 @@ import renderToStream from '@node/render-to-stream';
 import createRequestSignal from '@node/request-signal';
 import writeEarlyHints from '@node/write-early-hints';
 import writeFetchResponse, { writeFetchHeaders } from '@node/write-fetch-response';
+import Diagnostics, { isDiagnosticsEnabled } from '@services/diagnostics';
 import type ServerConfig from '@services/server-config';
 import SsrManifest from '@services/ssr-manifest';
 
@@ -185,6 +186,9 @@ async function render(
     });
     const coreContext: ISsrRequestContext = {
       appProps,
+      diagnostics: isDiagnosticsEnabled(!config.isProd)
+        ? new Diagnostics(new URL(context.request.url).pathname, Logger)
+        : undefined,
       html: shellHtml,
       request: context.request,
       response: {

--- a/src/core/compose-html.ts
+++ b/src/core/compose-html.ts
@@ -12,71 +12,75 @@ const composeHtml = (
   const reader = body.getReader();
   let phase: 'body' | 'footer' | 'header' = 'header';
 
-  return new ReadableStream<Uint8Array>({
-    /**
-     * Release the React reader when the response consumer cancels.
-     */
-    cancel: async (reason) => {
-      abort?.(reason);
+  return new ReadableStream<Uint8Array>(
+    {
+      /**
+       * Release the React reader when the response consumer cancels.
+       */
+      cancel: async (reason) => {
+        abort?.(reason);
 
-      if (phase === 'footer') {
-        return;
-      }
-
-      try {
-        await reader.cancel(reason);
-      } finally {
-        reader.releaseLock();
-        onComplete?.();
-      }
-    },
-
-    /**
-     * Emit one available shell or React chunk per downstream pull.
-     */
-    async pull(controller) {
-      if (phase === 'header') {
-        phase = 'body';
-
-        if (header) {
-          controller.enqueue(encoder.encode(header));
-
+        if (phase === 'footer') {
           return;
         }
-      }
-
-      if (phase === 'body') {
-        let chunk: ReadableStreamReadResult<Uint8Array>;
 
         try {
-          chunk = await reader.read();
-        } catch (error) {
-          abort?.(error);
+          await reader.cancel(reason);
+        } finally {
           reader.releaseLock();
           onComplete?.();
-          controller.error(error);
+        }
+      },
 
-          return;
+      /**
+       * Emit one available shell or React chunk per downstream pull.
+       */
+      async pull(controller) {
+        if (phase === 'header') {
+          phase = 'body';
+
+          if (header) {
+            controller.enqueue(encoder.encode(header));
+
+            return;
+          }
         }
 
-        if (!chunk.done) {
-          controller.enqueue(chunk.value);
+        if (phase === 'body') {
+          let chunk: ReadableStreamReadResult<Uint8Array>;
 
-          return;
+          try {
+            chunk = await reader.read();
+          } catch (error) {
+            abort?.(error);
+            reader.releaseLock();
+            onComplete?.();
+            controller.error(error);
+
+            return;
+          }
+
+          if (!chunk.done) {
+            controller.enqueue(chunk.value);
+
+            return;
+          }
+
+          phase = 'footer';
+          reader.releaseLock();
+          onComplete?.();
         }
 
-        phase = 'footer';
-        reader.releaseLock();
-        onComplete?.();
-      }
+        if (footer) {
+          controller.enqueue(encoder.encode(footer));
+        }
 
-      if (footer) {
-        controller.enqueue(encoder.encode(footer));
-      }
-
-      controller.close();
+        controller.close();
+      },
     },
-  });
+    // Do not start reading React while a downstream wrapper is still delivering the header.
+    { highWaterMark: 0 },
+  );
 };
 
 export default composeHtml;

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -2,6 +2,7 @@ import headResponse from '@core/head-response';
 import render from '@core/render';
 import type { ICoreRenderOptions, ICoreRenderParams, ISsrRequestContext } from '@core/render';
 import type { ISsrExecutionContext, TSsrHandler } from '@core/types';
+import Diagnostics, { isDiagnosticsEnabled } from '@services/diagnostics';
 
 interface IHtmlShell {
   footer: string;
@@ -15,6 +16,11 @@ interface IRequestInit<TAppProps> {
 }
 
 interface ICreateHandlerOptions<TAppProps> extends ICoreRenderOptions<TAppProps> {
+  /**
+   * Development checks; defaults to NODE_ENV !== 'production', overridden by SSR_BOOST_DIAGNOSTICS.
+   */
+  diagnostics?: boolean;
+
   /**
    * Supply the document shell, including the application's browser entry script.
    */
@@ -34,7 +40,7 @@ interface ICreateHandlerOptions<TAppProps> extends ICoreRenderOptions<TAppProps>
  */
 const createHandler = <TAppProps = Record<string, any>>(
   params: ICoreRenderParams<TAppProps>,
-  { getHtml, onRequest, ...options }: ICreateHandlerOptions<TAppProps>,
+  { diagnostics, getHtml, onRequest, ...options }: ICreateHandlerOptions<TAppProps>,
 ): TSsrHandler => {
   /**
    * Build fresh context for this request before invoking the renderer.
@@ -48,6 +54,9 @@ const createHandler = <TAppProps = Record<string, any>>(
 
     const context: ISsrRequestContext<TAppProps> = {
       appProps: (requestInit?.appProps ?? {}) as NonNullable<TAppProps>,
+      diagnostics: isDiagnosticsEnabled(diagnostics)
+        ? new Diagnostics(new URL(request.url).pathname)
+        : undefined,
       html: await getHtml(request),
       request,
       response: {

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -14,9 +14,11 @@ import buildCustomState from '@helpers/build-custom-state';
 import buildRouterState from '@helpers/build-router-state';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import obtainStreamError from '@helpers/obtain-stream-error';
+import type Diagnostics from '@services/diagnostics';
 
 export interface ISsrRequestContext<TAppProps = Record<string, any>> {
   appProps: NonNullable<TAppProps>;
+  diagnostics?: Diagnostics;
 
   /**
    * First render failure, or the explicit timeout/cancellation classification.
@@ -167,11 +169,15 @@ const prepareHtmlResponse = <TAppProps,>(
   }
 
   const shell = onShellReady?.({ context }) ?? {};
-  const routerState = buildRouterState(context.routerContext!);
-  const customState = buildCustomState(getState?.({ context }));
+  const routerState = buildRouterState(context.routerContext!, context.diagnostics);
+  const customState = buildCustomState(getState?.({ context }), context.diagnostics);
   const header = shell.header || context.html.header;
+  const shellFooter = shell.footer || context.html.footer;
+
+  context.diagnostics?.inspectShell({ header, footer: shellFooter });
+
   // Router state unblocks the browser entry, so custom state must already be available.
-  const footer = customState + routerState + (shell.footer || context.html.footer);
+  const footer = customState + routerState + shellFooter;
   const headers = new Headers(context.response.headers);
 
   return { header, footer, headers, status: context.response.status };
@@ -356,6 +362,7 @@ const render = async <TAppProps,>(
     const transformed = transformHtml(
       body,
       onResponse ? (html, isEnd) => onResponse({ context, html, isEnd }) : undefined,
+      context.diagnostics,
     );
 
     output.start();

--- a/src/core/transform-html.ts
+++ b/src/core/transform-html.ts
@@ -14,21 +14,23 @@ const transformHtml = (
     return stream;
   }
 
+  const reader = stream.getReader();
   const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
+  const encoder = transform ? new TextEncoder() : undefined;
+  let isStopped = false;
 
   /**
    * Observe emitted text after the hook has chosen whether to keep or replace it.
    */
-  const emit = (html: string, controller: TransformStreamDefaultController<Uint8Array>): void => {
-    controller.enqueue(encoder.encode(html));
+  const emit = (html: string, controller: ReadableStreamDefaultController<Uint8Array>): void => {
+    controller.enqueue(encoder!.encode(html));
     diagnostics?.append(String(html));
   };
 
   /**
    * Keep the original HTML when the response hook does not replace a chunk.
    */
-  const apply = (html: string, controller: TransformStreamDefaultController<Uint8Array>): void => {
+  const apply = (html: string, controller: ReadableStreamDefaultController<Uint8Array>): void => {
     if (!html) {
       return;
     }
@@ -39,30 +41,91 @@ const transformHtml = (
     emit(result ?? html, controller);
   };
 
-  return stream.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
+  return new ReadableStream<Uint8Array>(
+    {
       /**
-       * Flush the decoder before letting the response hook emit any retained content.
+       * Forward cancellation immediately, without waiting for an in-flight pipe write.
        */
-      flush: (controller) => {
-        apply(decoder.decode(), controller);
+      cancel: async (reason) => {
+        isStopped = true;
 
-        const html = transform?.('', true);
-
-        diagnostics?.inspectOnResponse(html);
-
-        if (html) {
-          emit(html, controller);
+        try {
+          await reader.cancel(reason);
+        } finally {
+          reader.releaseLock();
         }
-
-        diagnostics?.complete();
       },
 
       /**
-       * Decode successive chunks using the same UTF-8 state.
+       * Read only on downstream demand and leave observed bytes untouched without a hook.
        */
-      transform: (chunk, controller) => apply(decoder.decode(chunk, { stream: true }), controller),
-    }),
+      pull: async (controller) => {
+        try {
+          while (!isStopped) {
+            const chunk = await reader.read();
+
+            if (isStopped) {
+              return;
+            }
+
+            if (chunk.done) {
+              const remaining = decoder.decode();
+
+              if (transform) {
+                apply(remaining, controller);
+
+                const html = transform('', true);
+
+                diagnostics?.inspectOnResponse(html);
+
+                if (html) {
+                  emit(html, controller);
+                }
+              } else if (remaining) {
+                diagnostics?.append(remaining);
+              }
+
+              diagnostics?.complete();
+              isStopped = true;
+              reader.releaseLock();
+              controller.close();
+
+              return;
+            }
+
+            const html = decoder.decode(chunk.value, { stream: true });
+
+            if (transform) {
+              if (!html) {
+                continue;
+              }
+
+              apply(html, controller);
+            } else {
+              diagnostics?.append(html);
+              controller.enqueue(chunk.value);
+            }
+
+            return;
+          }
+        } catch (error) {
+          if (isStopped) {
+            return;
+          }
+
+          isStopped = true;
+          controller.error(error);
+
+          try {
+            await reader.cancel(error).catch(() => undefined);
+          } finally {
+            reader.releaseLock();
+          }
+        }
+      },
+    },
+    // An observer must not add another queue or read React ahead of the consumer.
+    { highWaterMark: 0 },
   );
 };
 

--- a/src/core/transform-html.ts
+++ b/src/core/transform-html.ts
@@ -1,3 +1,5 @@
+import type Diagnostics from '@services/diagnostics';
+
 type TTransformHtml = (html: string, isEnd: boolean) => string | undefined | void;
 
 /**
@@ -6,13 +8,22 @@ type TTransformHtml = (html: string, isEnd: boolean) => string | undefined | voi
 const transformHtml = (
   stream: ReadableStream<Uint8Array>,
   transform?: TTransformHtml,
+  diagnostics?: Diagnostics,
 ): ReadableStream<Uint8Array> => {
-  if (!transform) {
+  if (!transform && !diagnostics) {
     return stream;
   }
 
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
+
+  /**
+   * Observe emitted text after the hook has chosen whether to keep or replace it.
+   */
+  const emit = (html: string, controller: TransformStreamDefaultController<Uint8Array>): void => {
+    controller.enqueue(encoder.encode(html));
+    diagnostics?.append(String(html));
+  };
 
   /**
    * Keep the original HTML when the response hook does not replace a chunk.
@@ -22,7 +33,10 @@ const transformHtml = (
       return;
     }
 
-    controller.enqueue(encoder.encode(transform(html, false) ?? html));
+    const result = transform?.(html, false);
+
+    diagnostics?.inspectOnResponse(result);
+    emit(result ?? html, controller);
   };
 
   return stream.pipeThrough(
@@ -33,11 +47,15 @@ const transformHtml = (
       flush: (controller) => {
         apply(decoder.decode(), controller);
 
-        const html = transform('', true);
+        const html = transform?.('', true);
+
+        diagnostics?.inspectOnResponse(html);
 
         if (html) {
-          controller.enqueue(encoder.encode(html));
+          emit(html, controller);
         }
+
+        diagnostics?.complete();
       },
 
       /**

--- a/src/helpers/build-custom-state.ts
+++ b/src/helpers/build-custom-state.ts
@@ -1,9 +1,15 @@
 import htmlEscape from '@helpers/html-escape';
+import type Diagnostics from '@services/diagnostics';
 
 /**
  * Build custom state
  */
-function buildCustomState(initState?: Record<string, Record<string, any>> | void): string {
+function buildCustomState(
+  initState?: Record<string, Record<string, any>> | void,
+  diagnostics?: Diagnostics,
+): string {
+  diagnostics?.inspectState(initState);
+
   const stateScripts = Object.entries(initState ?? {}).map(([key, state]) => {
     if (!key || !state || !Object.keys(state || {}).length) {
       return '';

--- a/src/helpers/build-router-state.ts
+++ b/src/helpers/build-router-state.ts
@@ -1,11 +1,14 @@
 import type { StaticHandlerContext } from 'react-router';
 import htmlEscape from '@helpers/html-escape';
 import serializeErrors from '@helpers/serialize-errors';
+import type Diagnostics from '@services/diagnostics';
 
 /**
  * Build router state
  */
-function buildRouterState(context: StaticHandlerContext): string {
+function buildRouterState(context: StaticHandlerContext, diagnostics?: Diagnostics): string {
+  diagnostics?.inspectRouterState(context);
+
   const { loaderData, actionData, errors } = context;
   const routerState = {
     loaderData,

--- a/src/node/production.ts
+++ b/src/node/production.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import type { ICreateHandlerOptions, IHtmlShell } from '@core/handler';
+import { splitHtmlShell } from '@services/diagnostics';
 import RouteAssets from '@services/route-assets';
 
 interface ILoadHtmlShellOptions {
@@ -20,15 +21,7 @@ const loadHtmlShell = async ({
   outlet = '<!--ssr-outlet-->',
 }: ILoadHtmlShellOptions): Promise<() => IHtmlShell> => {
   const html = await readFile(indexFile, 'utf8');
-  const parts = html.split(outlet);
-
-  if (!outlet || parts.length !== 2) {
-    throw new Error(
-      `Invalid HTML shell in "${indexFile}": expected exactly one non-empty outlet ${JSON.stringify(outlet)}.`,
-    );
-  }
-
-  const [header, footer] = parts;
+  const [header, footer] = splitHtmlShell(html, indexFile, outlet);
 
   return () => ({ header, footer });
 };

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -1,0 +1,304 @@
+import type { StaticHandlerContext } from 'react-router';
+import Logger from '@services/logger';
+
+type TDiagnosticCode =
+  | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
+  | 'SSR_BOOST_STATE_NOT_SERIALIZABLE'
+  | 'SSR_BOOST_OUTLET_MISSING'
+  | 'SSR_BOOST_HYDRATION_STATE_MISSING'
+  | 'SSR_BOOST_DUPLICATE_OUTPUT'
+  | 'SSR_BOOST_ONRESPONSE_INVALID_RETURN';
+
+interface ISerializationIssue {
+  path: string;
+  reason: string;
+}
+
+const OUTLET = '<!--ssr-outlet-->';
+const HYDRATION = 'window.__staticRouterHydrationData';
+const warnedKey = Symbol.for('@lomray/vite-ssr-boost/diagnostics');
+// Retain deduplication across managed development module reloads and package copies.
+const registry = globalThis as typeof globalThis & { [warnedKey]?: Set<string> };
+
+/**
+ * Resolve overrides without requiring Node globals in Fetch runtimes.
+ */
+const isDiagnosticsEnabled = (enabled?: boolean): boolean => {
+  const env = typeof process === 'undefined' ? undefined : process.env;
+
+  if (env?.SSR_BOOST_DIAGNOSTICS === '0' || env?.SSR_BOOST_DIAGNOSTICS === '1') {
+    return env.SSR_BOOST_DIAGNOSTICS === '1';
+  }
+
+  return enabled ?? env?.NODE_ENV !== 'production';
+};
+
+/**
+ * Keep warnings and fatal shell errors linked to the same stable reference.
+ */
+const formatDiagnostic = (code: TDiagnosticCode, sentence: string): string =>
+  `[ssr-boost] ${code}: ${sentence} See https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics#${code.toLowerCase()}`;
+
+/**
+ * Reject unusable file-backed shells in every runtime mode.
+ */
+const splitHtmlShell = (html: string, file: string, outlet = OUTLET): [string, string] => {
+  const parts = html.split(outlet);
+
+  if (!outlet || parts.length !== 2) {
+    throw new Error(
+      formatDiagnostic(
+        'SSR_BOOST_OUTLET_MISSING',
+        `Invalid HTML shell in ${JSON.stringify(file)}: expected exactly one non-empty outlet ${JSON.stringify(outlet)}.`,
+      ),
+    );
+  }
+
+  return parts as [string, string];
+};
+
+/**
+ * Describe runtime values without serializing their contents.
+ */
+const valueType = (value: unknown): string => {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value !== 'object') {
+    const names: Record<string, string> = { bigint: 'BigInt', symbol: 'Symbol' };
+
+    return names[typeof value] ?? typeof value;
+  }
+
+  const prototype = Object.getPrototypeOf(value) as { constructor?: { name?: unknown } } | null;
+  const name = prototype?.constructor?.name;
+
+  return typeof name === 'string' && name ? name : 'object';
+};
+
+/**
+ * Find values JSON cannot preserve, descending only into plain objects and arrays.
+ */
+const walkSerializable = (
+  value: unknown,
+  report: (issue: ISerializationIssue) => void,
+  path = '$',
+  ancestors = new Set<object>(),
+): void => {
+  const type = typeof value;
+
+  if (type === 'function' || type === 'bigint' || type === 'symbol') {
+    report({ path, reason: `${valueType(value)} is not JSON-serializable` });
+
+    return;
+  }
+
+  if (value === null || type !== 'object') {
+    return;
+  }
+
+  const object = value as object;
+  const prototype: unknown = Object.getPrototypeOf(object);
+
+  if (
+    prototype !== Object.prototype &&
+    prototype !== null &&
+    !(Array.isArray(object) && prototype === Array.prototype)
+  ) {
+    const name = valueType(object);
+
+    report({
+      path,
+      reason: name === 'Date' ? 'Date hydrates as a string' : `${name} is not JSON-serializable`,
+    });
+
+    return;
+  }
+
+  if (ancestors.has(object)) {
+    report({ path, reason: 'a circular reference is not JSON-serializable' });
+
+    return;
+  }
+
+  ancestors.add(object);
+
+  for (const [key, child] of Object.entries(object)) {
+    const suffix =
+      Array.isArray(object) && /^(0|[1-9]\d*)$/.test(key)
+        ? `[${key}]`
+        : /^[A-Za-z_$][\w$]*$/.test(key)
+          ? `.${key}`
+          : `[${JSON.stringify(key)}]`;
+
+    walkSerializable(child, report, path + suffix, ancestors);
+  }
+
+  ancestors.delete(object);
+};
+
+/**
+ * Inspect one development response while allowing every chunk to stream immediately.
+ */
+class Diagnostics {
+  protected chunks: string[] = [];
+
+  public constructor(
+    protected readonly route: string,
+    protected readonly logger: Pick<Logger, 'warn'> = new Logger(),
+  ) {}
+
+  /**
+   * Emit each concrete message once per process, including across handler instances.
+   */
+  protected warn(code: TDiagnosticCode, detail: string): void {
+    const message = formatDiagnostic(code, detail);
+    const warned = (registry[warnedKey] ??= new Set<string>());
+
+    if (!warned.has(message)) {
+      warned.add(message);
+      this.logger.warn(message, {});
+    }
+  }
+
+  /**
+   * A split Fetch shell has one insertion boundary and must not retain raw outlets.
+   */
+  public inspectShell({ header, footer }: { header: string; footer: string }): void {
+    if (
+      typeof header !== 'string' ||
+      typeof footer !== 'string' ||
+      header.includes(OUTLET) ||
+      footer.includes(OUTLET)
+    ) {
+      this.warn(
+        'SSR_BOOST_OUTLET_MISSING',
+        `HTML shell for route ${JSON.stringify(this.route)} must supply both header and footer around exactly one ${OUTLET} outlet, with no outlet left in either half.`,
+      );
+    }
+  }
+
+  /**
+   * Include React Router's route id and the full loader/action key path.
+   */
+  public inspectRouterState({ loaderData, actionData }: StaticHandlerContext): void {
+    for (const [kind, data] of Object.entries({ loaderData, actionData })) {
+      for (const [route, value] of Object.entries(data ?? {})) {
+        walkSerializable(
+          value,
+          ({ path, reason }) =>
+            this.warn(
+              'SSR_BOOST_LOADER_NOT_SERIALIZABLE',
+              `Route ${JSON.stringify(route)} at ${path}: ${reason}.`,
+            ),
+          `${kind}[${JSON.stringify(route)}]`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Check custom state before the serializer can omit or coerce it.
+   */
+  public inspectState(state: unknown): void {
+    walkSerializable(state, ({ path, reason }) =>
+      this.warn(
+        'SSR_BOOST_STATE_NOT_SERIALIZABLE',
+        `getState for route ${JSON.stringify(this.route)} at ${path}: ${reason}.`,
+      ),
+    );
+  }
+
+  /**
+   * Hooks are synchronous and can only keep, replace or withhold a chunk.
+   */
+  public inspectOnResponse(value: unknown): void {
+    if (value !== undefined && typeof value !== 'string') {
+      this.warn(
+        'SSR_BOOST_ONRESPONSE_INVALID_RETURN',
+        `onResponse for route ${JSON.stringify(this.route)} returned ${valueType(value)}; return a string or undefined.`,
+      );
+    }
+  }
+
+  /**
+   * Retain only the output that actually leaves the response transform.
+   */
+  public append(html: string): void {
+    this.chunks.push(html);
+  }
+
+  /**
+   * Scan completed HTML so markers split across chunks are still recognized.
+   */
+  public complete(): void {
+    const html = this.chunks.join('');
+
+    this.chunks = [];
+
+    const markers = new Map<string, number>();
+    const count = (marker: string): void => {
+      markers.set(marker, (markers.get(marker) ?? 0) + 1);
+    };
+    // Skip comments and raw text so markup examples and state strings are not tags.
+    const markup = html
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(
+        /(<(script|style|textarea|title)\b(?:[^"'<>]|"[^"]*"|'[^']*')*>)([\s\S]*?)<\/\2\s*>/gi,
+        (_tag, opening: string, name: string, content: string) => {
+          if (name.toLowerCase() === 'script') {
+            if (/\bwindow\.__staticRouterHydrationData\s*=/.test(content)) {
+              count(HYDRATION);
+            }
+
+            for (const match of content.matchAll(/\$RC\s*\(\s*(["'])(B:[^"']+)\1/g)) {
+              count(`$RC("${match[2]}")`);
+            }
+          }
+
+          return opening;
+        },
+      );
+
+    for (const match of markup.matchAll(/<([a-z][\w:-]*)\b((?:[^"'<>]|"[^"]*"|'[^']*')*)>/gi)) {
+      const name = match[1].toLowerCase();
+
+      if (name === 'html' || name === 'head') {
+        count(`<${name}>`);
+      }
+
+      for (const attribute of match[2].matchAll(
+        /([^\s=]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g,
+      )) {
+        const value = attribute[2] ?? attribute[3] ?? attribute[4];
+
+        if (attribute[1].toLowerCase() === 'id' && /^(S|B):/.test(value)) {
+          count(`id="${value}"`);
+        }
+      }
+    }
+
+    if (!markers.has(HYDRATION)) {
+      this.warn(
+        'SSR_BOOST_HYDRATION_STATE_MISSING',
+        `Completed response for route ${JSON.stringify(this.route)} has no ${HYDRATION} script; preserve the hydration footer in onResponse.`,
+      );
+    }
+
+    for (const [marker, total] of markers) {
+      if (total > 1) {
+        this.warn(
+          'SSR_BOOST_DUPLICATE_OUTPUT',
+          `Completed response for route ${JSON.stringify(this.route)} repeats ${marker}; onResponse must return undefined to keep a chunk and '' to withhold one.`,
+        );
+      }
+    }
+  }
+}
+
+export { formatDiagnostic, isDiagnosticsEnabled, splitHtmlShell, walkSerializable };
+
+export type { ISerializationIssue, TDiagnosticCode };
+
+export default Diagnostics;


### PR DESCRIPTION
## Goal

Replace silence with warnings in development: the failures that used to be found by reading HTML by hand (loader data that cannot be serialized, a shell without the outlet, an `onResponse` hook that duplicates or drops output, a second `<head>`) now print a stable code, the concrete route or key, and a link to the documentation page that explains the fix. Production pays nothing.

## Changes

- `src/services/diagnostics.ts`: the six codes `SSR_BOOST_LOADER_NOT_SERIALIZABLE`, `SSR_BOOST_STATE_NOT_SERIALIZABLE`, `SSR_BOOST_OUTLET_MISSING`, `SSR_BOOST_HYDRATION_STATE_MISSING`, `SSR_BOOST_DUPLICATE_OUTPUT`, `SSR_BOOST_ONRESPONSE_INVALID_RETURN`; a walker that reports Promises, functions, Map/Set, BigInt, Symbol, class instances and circular references with the key path (Date is reported as "hydrates as a string"); a completed-output scan that counts `<html>`/`<head>`, the hydration script and React streaming segment ids across chunk boundaries; one message per process through the existing logger.
- Enablement: on for `ssr-boost dev`, off for `ssr-boost start`; `createHandler({ diagnostics })` defaults to `NODE_ENV !== 'production'`; `SSR_BOOST_DIAGNOSTICS=0|1` overrides both. When off, no state is walked and no chunk is buffered (`transformHtml` returns the raw stream when there is neither a hook nor diagnostics).
- The managed server now validates the HTML shell with the same readable error as `loadHtmlShell` (a shell without exactly one outlet cannot work in any mode).
- Docs: `docs/reference/diagnostics.md` (one section per code: when it appears, why it matters, how to fix), sidebar entry, a paragraph in the server lifecycle guide and the `diagnostics` option in the server entry API page.
- CI pin: the acceptance template moves from `922db67` to `71d859c` (template `prod` with `@lomray/react-head-manager` 2.1.2). The old pin shipped 2.1.1, whose double `<head>` on React 19 is exactly what `SSR_BOOST_DUPLICATE_OUTPUT` reports.

## Verification

- `npm run lint:check`, `npm run ts:check`, `npm test` (542 passed), `npm run build`, `npm run docs:build`.
- A proof test emits all six messages exactly once across four requests and two handler instances; a production-mode test asserts no walk and no buffering.
- Template acceptance against the new pin: exit 0 and zero `SSR_BOOST_` lines in the development server output.
