### PR TITLE
docs: add npm create @lomray/ssr-app to the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@
 
 ## Quick start
 
+**Start a new app** with the `minimal` template (default):
+
+```bash
+npm create @lomray/ssr-app@latest my-app
+```
+
+Choose the `full` template by passing the flag after `--`:
+
+```bash
+npm create @lomray/ssr-app@latest my-app -- --template full
+```
+
+**Add to an existing app:**
+
 ```bash
 npm i @lomray/vite-ssr-boost
 ```
@@ -36,7 +50,7 @@ The [migration guide](./docs/guide/migrate-existing-spa.md) walks through the fi
 | `src/server.ts`  | Add the server entry and request-scoped setup.       |
 | `package.json`   | Use the `ssr-boost` dev, build and start commands.   |
 
-Starting a new app? Choose one of the [template branches](./docs/examples/index.md).
+Starting a new app? Choose one of the [template branches](./docs/examples/index.md) with the [`npm create` command](./docs/guide/getting-started.md#create-a-new-app) or clone the branch directly.
 
 ## Who this is for
 
@@ -73,6 +87,14 @@ Add `SsrBoost()` to the Vite plugins, wire `client.ts` and `server.ts`, and repl
 The package declares `engines.node: ">=22.12.0"`. The example uses Node 22.23.2; React Router and build tools can raise the required Node version.
 
 Start with the [minimal template](https://github.com/Lomray-Software/vite-template/tree/example/minimal):
+
+```bash
+npm create @lomray/ssr-app@latest my-app
+cd my-app
+npm run develop
+```
+
+Or clone the template branch directly:
 
 ```bash
 git clone --branch example/minimal https://github.com/Lomray-Software/vite-template.git

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -2,6 +2,8 @@
 
 The [vite-template repository](https://github.com/Lomray-Software/vite-template) contains the application examples. Start with `example/minimal` for the entries used in the [migration guide](/guide/migrate-existing-spa), or choose `prod` for state management and deployment workflows.
 
+Use `npm create @lomray/ssr-app@latest my-app -- --template <name>` to create an app from a branch: `full` selects `prod`, `minimal` (the default) selects `example/minimal`, `custom-server` selects `example/custom-server`, and `localization` selects `example/localization`. See [Create a new app](/guide/getting-started#create-a-new-app) for the flags.
+
 ## `prod`
 
 The [prod branch](https://github.com/Lomray-Software/vite-template/tree/prod) combines a MobX manager, consistent-suspense, a route manager and meta tags. It includes component-level data streaming, Docker, Amplify and Vercel build scripts, and deployment workflows. Use it when the application needs the state and stream wiring shown in its server and client entries.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,38 @@
 # Getting Started
 
+## Create a new app
+
+Requires Node.js `22.12.0` or newer. Create an app with the `minimal` template (default):
+
+```bash
+npm create @lomray/ssr-app@latest my-app
+cd my-app
+npm run develop
+```
+
+The [create-ssr-app README](https://github.com/Lomray-Software/create-ssr-app#templates) describes the templates:
+
+- `full`: Streaming SSR, MobX, consistent Suspense, meta tags and route management
+- `minimal` (default): Six runtime dependencies, loaders, a lazy route with CSS, redirect, client-only route and 404, plus the SPA-to-SSR file diff
+- `custom-server`: Development through the managed CLI, production through an application-owned Fastify server with static assets, compression and Early Hints; dual export of the managed entry and a Fetch handler
+- `localization`: i18next with the language chosen on the server from the cookie or Accept-Language, transferred to the client before hydration, and a cookie-based switcher
+
+With npm, put flags after `--` so npm forwards them to the scaffolder:
+
+```bash
+npm create @lomray/ssr-app@latest my-app -- --template full
+```
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `-t, --template <name>` | `minimal` | `full`, `minimal`, `custom-server`, or `localization`. |
+| `--no-install` | Install | Skip installation and print the install command in Next steps. |
+| `--no-git` | Initialize git | Skip git initialization; remove `.husky/` and `scripts.prepare`. |
+| `-y, --yes` | Off | Accept defaults without prompts. |
+
 ## Install
+
+For an existing Vite app, install the package and follow the setup below.
 
 ```bash
 npm i @lomray/vite-ssr-boost

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ hero:
     alt: Vite SSR BOOST logo
   actions:
     - theme: brand
+      text: Create an app
+      link: /guide/getting-started#create-a-new-app
+    - theme: alt
       text: Migrate a SPA
       link: /guide/migrate-existing-spa
-    - theme: alt
-      text: Get Started
-      link: /guide/getting-started
     - theme: alt
       text: GitHub
       link: https://github.com/Lomray-Software/vite-ssr-boost
@@ -40,7 +40,7 @@ features:
 
 ## Start with the managed server
 
-Add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
+Create a new app with `npm create @lomray/ssr-app@latest my-app` to start from the minimal template. For an existing app, add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
 
 ## Read this first
 


### PR DESCRIPTION
## Goal

Make the shortest path to a new app the first thing a reader sees: `@lomray/create-ssr-app` 1.0.0 is published, so the README, the getting-started guide, the home page and the examples page now show `npm create @lomray/ssr-app@latest my-app`.

## Changes

- README: "Start a new app" (default `minimal` template, `-- --template full` form) before the install command; the quick start alternative above the `git clone` block.
- `docs/guide/getting-started.md`: new first section "Create a new app" with the four templates and the flags `--template`, `--no-install`, `--no-git`, `--yes` (wording from the create-ssr-app README).
- `docs/index.md`: hero actions are now "Create an app", "Migrate a SPA", "GitHub"; one sentence under the managed server introduction.
- `docs/examples/index.md`: which `--template` value creates each branch.

## Verification

- `npm create @lomray/ssr-app@latest /tmp/c8-app -- --template minimal --no-install --no-git -y` ran from npm and produced `c8-app@0.1.0` without `.github`, `.husky` or `scripts.prepare`.
- `npm run docs:build` (dead-link check), `npm run lint:check`, `npm run ts:check`, `npm test` (482), `npm run build`, `npm run test:size`; README relative links (16 targets) resolve.
