### PR TITLE
docs: support policy, upgrade guide, llms.txt, context7 scope and provenance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -36,3 +38,18 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Versions**
+- vite-ssr-boost:
+- Node or other runtime:
+- React / React DOM:
+- React Router:
+- Vite:
+
+**Adapter and route setup**
+- Managed CLI / Node / Express / Fastify / Hono / edge:
+- Development or production; SSR or SPA:
+- Route objects, loaders and lazy routes (or a minimal reproduction link):
+
+**Diagnostic codes**
+Include any `SSR_BOOST_*` diagnostic codes and relevant logs, with secrets removed. See [Development diagnostics](https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics).

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,30 @@
+name: Refresh Context7 Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  # GITHUB_TOKEN-created releases do not trigger another release workflow.
+  workflow_call:
+    secrets:
+      CONTEXT7_API_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+    steps:
+      - name: Trigger Context7 refresh
+        # GitHub requires an env indirection for optional secrets in step conditions.
+        if: ${{ env.CONTEXT7_API_KEY != '' }}
+        run: |
+          curl --fail-with-body --silent --show-error --max-time 60 \
+            -X POST https://context7.com/api/v1/refresh \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $CONTEXT7_API_KEY" \
+            -d '{"libraryName":"/lomray-software/vite-ssr-boost"}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [ prod ]
     paths:
       - 'docs/**'
+      - 'scripts/build-llms.mjs'
       - '.github/workflows/docs.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -29,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ prod, staging ]
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 env:
   NODE_VERSION: 22.23.2
   ENABLE_CACHE: yes
@@ -96,6 +102,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+  refresh-context7:
+    needs: [release]
+    if: ${{ github.ref == 'refs/heads/prod' }}
+    uses: ./.github/workflows/context7-refresh.yml
+    secrets:
+      CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
 
   sonarcube:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Follow up on issues needing reproduction'
 on:
   schedule:
     - cron: '30 1 * * 1'
@@ -6,12 +6,27 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: 'needs-reproduction'
+          exempt-issue-labels: 'bug,confirmed,enhancement'
+          # Disable PR label cleanup too; issue activity still removes its stale label.
+          remove-stale-when-updated: false
+          remove-issue-stale-when-updated: true
           stale-issue-label: 'no-issue-activity'
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.'
-          close-issue-message: 'The issue has been closed for inactivity.'
+          stale-issue-message: >-
+            This issue is waiting for a reproduction and has had no activity for 30 days.
+            Please share a minimal reproduction or an update within 14 days to keep it open.
+          close-issue-message: >-
+            This issue was closed because the requested reproduction is still missing after
+            the 14-day reminder. Add a reproduction and reopen it, or comment with the
+            reproduction and ask a maintainer to reopen it if you cannot do so yourself.
+          close-issue-reason: 'not_planned'

--- a/README.md
+++ b/README.md
@@ -20,18 +20,6 @@
 
 ## Quick start
 
-**Start a new app** with the `minimal` template (default):
-
-```bash
-npm create @lomray/ssr-app@latest my-app
-```
-
-Choose the `full` template by passing the flag after `--`:
-
-```bash
-npm create @lomray/ssr-app@latest my-app -- --template full
-```
-
 **Add to an existing app:**
 
 ```bash
@@ -49,6 +37,18 @@ The [migration guide](./docs/guide/migrate-existing-spa.md) walks through the fi
 | `src/client.ts`  | Use the browser entry for hydration or SPA mounting. |
 | `src/server.ts`  | Add the server entry and request-scoped setup.       |
 | `package.json`   | Use the `ssr-boost` dev, build and start commands.   |
+
+**Start a new app** with the `minimal` template (default):
+
+```bash
+npm create @lomray/ssr-app@latest my-app
+```
+
+Choose the `full` template by passing the flag after `--`:
+
+```bash
+npm create @lomray/ssr-app@latest my-app -- --template full
+```
 
 Starting a new app? Choose one of the [template branches](./docs/examples/index.md) with the [`npm create` command](./docs/guide/getting-started.md#create-a-new-app) or clone the branch directly.
 
@@ -84,7 +84,7 @@ Add `SsrBoost()` to the Vite plugins, wire `client.ts` and `server.ts`, and repl
 
 ## Install and template quick start
 
-The package declares `engines.node: ">=22.12.0"`. The example uses Node 22.23.2; React Router and build tools can raise the required Node version.
+See [Compatibility](#compatibility) for the package Node requirement. The example uses Node 22.23.2; React Router and build tools can raise the required Node version.
 
 Start with the [minimal template](https://github.com/Lomray-Software/vite-template/tree/example/minimal):
 
@@ -110,6 +110,8 @@ For production, run `npm run build` and `npm run start:ssr`. For a SPA build, ru
 Already running this in production? Point our [free performance audit](https://audit.lomray.com/?utm_source=github&utm_medium=readme-vite-ssr-boost&utm_campaign=owned-surface-github) at the URL. It reports Core Web Vitals, JavaScript bundle weight and whether the HTML really arrives server-rendered. No signup.
 
 ## Compatibility
+
+See the [support policy](./SUPPORT.md) for version lifetimes, response targets and breaking-change commitments, and [Upgrade from 7 to 8](./docs/guide/upgrade-v8.md) for migration instructions.
 
 The package is tested against the current and previous major of React, React Router and Vite, with an additional Vite 6 row. The [compatibility workflow](./.github/workflows/react-compatibility.yml) runs the full test suite and a built Worker check on Node 22.23.2 with these exact combinations:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ When reporting security issues, please provide the following information:
  - Steps to reproduce the vulnerability
  - Your contact information
 
-We take all security reports seriously and will do our best to rapidly address the issue. We are grateful for your contributions to our security efforts, and we will acknowledge your report upon resolution.
+We will provide a human acknowledgment within **two business days** of receiving your security report. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer. We will keep you informed while we investigate and coordinate a fix; acknowledgment does not mean resolution. See [Support policy](./SUPPORT.md) for the security maintenance windows.
 
 ## Responsible Disclosure
 We adhere to the principle of responsible disclosure. This means that if you discover a vulnerability, you agree to:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Support policy
+
+Policy effective **5 September 2026**.
+
+## Supported versions
+
+| Release line | Maintenance commitment | Through (inclusive) |
+| --- | --- | --- |
+| Latest 8.x minor | Bug fixes and security fixes | 5 September 2027 |
+| 7.1.x | Security backports | 5 March 2027 |
+
+When a new 8.x minor ships, upgrade to that minor to continue receiving bug and security fixes. The 7.1.x line receives security backports during its stated window.
+
+## Upstream compatibility
+
+For every new stable major of React, React Router or Vite, we will publish a **supported**, **investigating** or **unsupported** statement within **30 days** of its release. We will publish that statement in GitHub Discussions or Releases and link to the tested combinations where applicable. A permissive peer dependency range alone is not a support statement.
+
+## Response commitments
+
+- We will provide a human acknowledgment of a GitHub issue within **five business days**.
+- We will provide a human acknowledgment of a security report within **two business days**. Follow the [security reporting policy](./SECURITY.md) to report privately.
+
+These are acknowledgment targets; the time needed to investigate and resolve a report depends on its scope. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer.
+
+Issues explicitly labeled `needs-reproduction` receive an inactivity reminder after 30 days and may be closed 14 days later. Issues labeled `bug`, `confirmed` or `enhancement`, and all pull requests, are exempt. Add the requested reproduction and reopen the issue, or ask a maintainer to reopen it in a comment.
+
+## Deprecations and breaking changes
+
+We will announce deprecations at least **90 days** and **two minor releases** before removal, and remove deprecated APIs only in a **major release**. Both notice periods must be satisfied. Raising the package's Node.js requirement counts as a breaking change and requires a major release.
+
+## Maintenance updates
+
+We will publish a short maintenance note **each month**, beginning in **September 2026**, in [GitHub Discussions](https://github.com/Lomray-Software/vite-ssr-boost/discussions) or [Releases](https://github.com/Lomray-Software/vite-ssr-boost/releases). Each note will cover maintenance activity and compatibility status, including months with no release.

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,41 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/lomray-software/vite-ssr-boost",
-  "public_key": "pk_9IAtRK9ehH9s9ktsgMjAJ"
+  "public_key": "pk_9IAtRK9ehH9s9ktsgMjAJ",
+  "projectTitle": "Vite SSR BOOST",
+  "description": "SSR and streaming for existing Vite + React Router apps in Data mode, without Framework mode",
+  "branch": "prod",
+  "folders": ["docs"],
+  "excludeFolders": [
+    "__tests__",
+    "__mocks__",
+    "__helpers__",
+    "tests",
+    "scripts",
+    "src",
+    "lib",
+    "node_modules",
+    "./examples",
+    "./acceptance",
+    "docs/.vitepress",
+    "docs/public"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "LICENSE.md",
+    "PR_DESCRIPTION.md",
+    "SECURITY.md",
+    "SUPPORT.md"
+  ],
+  "rules": [
+    "For v8, use @lomray/vite-ssr-boost/adapters/express/entry for the managed Express server entry.",
+    "For v8, import the default createHandler from @lomray/vite-ssr-boost/core/handler for Fetch-based servers.",
+    "For v8, use @lomray/vite-ssr-boost/browser/entry for hydration or SPA mounting.",
+    "The @lomray/vite-ssr-boost/node/entry path was removed in 8.0.0. Never generate v8 examples importing it; consult the v7.1.0 index only for v7 applications.",
+    "Use React Router Data mode with route objects. Loader data must be JSON-serializable: nested promises become {}, and Await/use cannot hydrate loader promises."
+  ],
+  "previousVersions": [{ "tag": "v7.1.0" }]
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: 'Introduction', link: '/' },
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Migrate an Existing SPA', link: '/guide/migrate-existing-spa' },
+          { text: 'Upgrade from 7 to 8', link: '/guide/upgrade-v8' },
           { text: 'Choosing an SSR Approach', link: '/guide/choosing' },
           { text: 'Rendering Modes', link: '/guide/rendering-modes' },
           { text: 'Routing', link: '/guide/routing' },
@@ -83,6 +84,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'AI Usage', link: '/ai-usage' },
+          { text: 'Support and versions', link: '/reference/support' },
           { text: 'Talking Points', link: '/reference/talking-points' },
           { text: 'Hydration order and streaming', link: '/reference/hydration-and-streaming' },
           { text: 'FAQ', link: '/reference/faq' },

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -18,11 +18,12 @@ The package declares `engines.node: ">=22.12.0"` and peers for Vite `>=5`, React
 - Fetch core: default export `createHandler` from `@lomray/vite-ssr-boost/core/handler`.
 - Transport adapters: `@lomray/vite-ssr-boost/adapters/node`, `adapters/express`, `adapters/fastify`, `adapters/hono` and `adapters/edge`, all under the package prefix.
 - Renderers: `@lomray/vite-ssr-boost/node/render-to-stream` and `@lomray/vite-ssr-boost/edge/render-to-stream`.
+- Node production helpers: `@lomray/vite-ssr-boost/node/production`.
 - CLI binary: `ssr-boost`.
 
 ## Default workflow and transport ownership
 
-Prefer the managed CLI for Vite development, HMR, asset manifests and production static files. It uses Express, and managed request/render hooks retain the live Express `req` and `res` objects. The removed `node/entry` path is not the v8 server entry.
+Prefer the managed CLI for Vite development, HMR, asset manifests and production static files. It uses Express, and managed request/render hooks retain the live Express `req` and `res` objects. `node/entry` was removed in 8.0.0; use `adapters/express/entry` for v8 and follow [Upgrade from 7 to 8](/guide/upgrade-v8).
 
 A Fetch transport owns its development server, bundling, static assets and route-asset injection. It can initialize `ServerConfig` from `@lomray/vite-ssr-boost/services/server-config` and inject manifest assets with `SsrManifest` from `@lomray/vite-ssr-boost/services/ssr-manifest`; see [Runtime adapters](/guide/runtime-adapters). The [custom-server example](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) demonstrates this integration with Fastify in production and the managed CLI in development.
 
@@ -49,3 +50,19 @@ Loader results are serialized with `JSON.stringify` into `window.__staticRouterH
 - Plugin `entrypoint` configures additional build surfaces.
 - The package does not implement RSC, Server Actions or file-system routing conventions.
 - Use the [comparison guide](/guide/choosing) and its official sources for claims about other projects.
+
+## Machine-readable documentation
+
+The docs build generates [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt) and [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt) from the Markdown sources. The short file includes the package identity, the resolved release version when available, the public entrypoints and data-loading contract from this page, and an absolute URL for every documentation page. The full file concatenates those pages with their source URLs.
+
+Run `npm run docs:build` to regenerate both files in `docs/.vitepress/dist`. The version comes from `git describe --tags --match 'v*' --abbrev=0`, with the leading `v` removed. If tags are unavailable, the build falls back to `npm view @lomray/vite-ssr-boost version`; if that also fails, it omits the version line. The build reports which source it used. The docs workflow fetches full Git history and tags so CI can use the tag path. The source manifest's placeholder version is never used; semantic-release assigns the published package version in `lib/package.json` separately.
+
+Generation checks that every indexed URL has a built HTML page and reports the page/link counts. GitHub Pages deploys these files with the rest of the docs; generated copies are not checked in.
+
+## Keeping the Context7 index fresh
+
+[`context7.json`](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/context7.json) selects the `prod` branch and `docs/`. Context7 also includes root Markdown automatically; the filename exclusions leave `README.md` as the root source. Tests, scripts, package output and non-documentation examples are excluded, while `docs/examples/` stays indexed. The rules identify the v8 entrypoints and the removed `node/entry` path. The `v7.1.0` tag is configured as a separate previous version for v7 users. See the [Context7 configuration guide](https://context7.com/docs/library-owners).
+
+Maintainers set the optional repository Actions secret `CONTEXT7_API_KEY`. The [refresh workflow](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/.github/workflows/context7-refresh.yml) calls the [documented refresh API](https://context7.com/docs/integrations/github-actions) on published releases or manual dispatch. The `prod` release job also calls it as a reusable workflow: [events created with `GITHUB_TOKEN` do not start another workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow). This also refreshes docs-only changes after a successful `prod` release job.
+
+The API step uses a job environment variable in its condition, following [GitHub's optional-secret pattern](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets), so a missing key skips the request. The request refreshes the library's configured source; `context7.json` selects `prod`, so publishing a prerelease does not switch the main index to `staging`. After promoting documentation to `prod`, maintainers can dispatch the workflow to retry a failed refresh or refresh without a release. Check the workflow result and the [Context7 listing](https://context7.com/lomray-software/vite-ssr-boost) after indexing completes; a successful API request queues refresh work and does not prove parsing has finished.

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -33,32 +33,7 @@ transforms streamed HTML. The core decodes split UTF-8 chunks safely before invo
 
 ### Migration notes
 
-Update imports relative to `@lomray/vite-ssr-boost/` (also applies to explicit `.js` imports):
-
-| Removed path | New path |
-| --- | --- |
-| `node/entry` | `adapters/express/entry` |
-| `node/server` | `adapters/express/server` |
-| `node/render` | `adapters/express/render` |
-| `node/create-fetch-request` | `adapters/express/create-request` |
-| `services/prepare-server` | `adapters/express/prepare-server` |
-
-The old `node/write-response` and `helpers/handle-response` internals are removed. The renderer now
-handles response composition and redirects through the Fetch core; custom Node transports can send
-the resulting `Response` with `node/write-fetch-response`.
-
-- The default shell-error page returns a generic HTTP 500 without exception messages. Use `onError`
-  for diagnostics or `onShellError` for a custom page.
-- Request/render hook failures reach Express error middleware through `next(error)`, rather than
-  falling through to a 404. Register error middleware after the SSR handler.
-- Unless explicitly overridden, rendered responses use React Router's status, including 404 for
-  unmatched routes. Previously these could be sent as 200.
-- Render timeouts and client/intentional cancellation report `onError` codes `timeout` and `cancel`.
-  The managed Express server logs these at info level. Unexpected errors retain their original error.
-- Parsed JSON and flat URL-encoded bodies work automatically. Nested form values and unsupported
-  custom or multipart parser results fail explicitly; use `getBody` as shown below.
-- Package exports support extensionless and explicit `.js` imports for the new paths, with matching
-  TypeScript declarations. Other module paths are unchanged.
+See [Upgrade from 7 to 8](/guide/upgrade-v8) for the complete import map, `onResponse` contract, `context.request`, Node requirement and changed error handling.
 
 Express and compression are optional dependencies installed by default. If your install command
 uses `--omit=optional`, install them explicitly:

--- a/docs/guide/upgrade-v8.md
+++ b/docs/guide/upgrade-v8.md
@@ -1,0 +1,81 @@
+# Upgrade from 7 to 8
+
+Use this guide when upgrading an existing `@lomray/vite-ssr-boost` v7 application. If you are adding SSR to a Vite SPA for the first time, start with [Migrate an existing SPA](/guide/migrate-existing-spa).
+
+## Node requirement
+
+The package requires Node.js `>=22.12.0`, as declared by [`package.json` engines.node](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/package.json). Check the engine requirements of your chosen React Router and build tools as well. Raising this package requirement in the future is a breaking change under the [support policy](/reference/support).
+
+## Update the package and imports
+
+```bash
+npm install @lomray/vite-ssr-boost@^8
+```
+
+The following paths were removed in **8.0.0**. For the managed CLI, update the server entry:
+
+```ts
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+
+export default entryServer(App, routes, options);
+```
+
+Update imports relative to `@lomray/vite-ssr-boost/` (also applies to explicit `.js` imports):
+
+| Removed path | New path |
+| --- | --- |
+| `node/entry` | `adapters/express/entry` |
+| `node/server` | `adapters/express/server` |
+| `node/render` | `adapters/express/render` |
+| `node/create-fetch-request` | `adapters/express/create-request` |
+| `services/prepare-server` | `adapters/express/prepare-server` |
+
+The old `node/write-response` and `helpers/handle-response` internals are removed. The renderer now
+handles response composition and redirects through the Fetch core; custom Node transports can send
+the resulting `Response` with `node/write-fetch-response`.
+
+- The default shell-error page returns a generic HTTP 500 without exception messages. Use `onError`
+  for diagnostics or `onShellError` for a custom page.
+- Request/render hook failures reach Express error middleware through `next(error)`, rather than
+  falling through to a 404. Register error middleware after the SSR handler.
+- Unless explicitly overridden, rendered responses use React Router's status, including 404 for
+  unmatched routes. Previously these could be sent as 200.
+- Render timeouts and client/intentional cancellation report `onError` codes `timeout` and `cancel`.
+  The managed Express server logs these at info level. Unexpected errors retain their original error.
+- Parsed JSON and flat URL-encoded bodies work automatically. Nested form values and unsupported
+  custom or multipart parser results fail explicitly; use [`getBody`](/guide/runtime-adapters#request-bodies).
+- Package exports support extensionless and explicit `.js` imports for the new paths, with matching
+  TypeScript declarations. Other module paths are unchanged.
+
+The browser entry remains `@lomray/vite-ssr-boost/browser/entry`. Applications that own their transport can use the default `createHandler` export from `@lomray/vite-ssr-boost/core/handler`; follow [Runtime adapters](/guide/runtime-adapters) for server, asset and bundling responsibilities.
+
+Express and compression are optional dependencies installed by default. If you install with `--omit=optional`, install `express` and `compression` explicitly for the managed CLI.
+
+## Review `onResponse`
+
+The hook receives `{ context, html, isEnd }` and synchronously returns a string, `undefined` or nothing. It transforms decoded HTML chunks; split UTF-8 characters are preserved, but a chunk can still end partway through an HTML tag.
+
+- Regular chunks use `isEnd: false`. Return `undefined` or nothing to keep the original chunk, a string to replace it, or `''` to withhold it while buffering an unfinished token.
+- After the complete composed body, including the footer, the hook receives one final call with `html: ''` and `isEnd: true`. Return a string to append buffered content; `undefined` or `''` appends nothing.
+- This contract applies to streamed and buffered rendering (`isStream: false`). Hooks that ignore `isEnd` remain supported.
+
+For a request-scoped `@lomray/consistent-suspense` transform:
+
+```ts
+onResponse: ({ context: { appProps: { streamSuspense }, isStream }, html, isEnd }) => {
+  if (!isStream) return;
+  return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
+},
+```
+
+See the [server entry API](/api/server-entry#onresponse) for the full signature.
+
+## Review `context.request`
+
+The Express adapter's render-hook context now includes `request`, the Fetch `Request` used by React Router and the core. Use its `url`, `headers` and `signal` for Fetch-based request handling and cancellation. When constructing typed render-hook contexts in application code or fixtures, include this field.
+
+Managed Express request/render hooks retain the live Express `req` and `res`; keep Express-specific cookies, middleware and response takeover on those objects. `context.request` is available in render hooks, after the adapter converts the request; it is not an Express request and is not added to the earlier managed `onRequest` parameters. Fetch-core hooks use Web-standard requests and responses and do not emulate Express objects.
+
+## Check the upgraded application
+
+Run development and production builds, then check hydration, lazy-route JS/CSS, redirects, unmatched-route 404s, error middleware and any HTML transform. If you use parsed request bodies, streaming or cancellation, exercise those paths too. Loader results must remain JSON-serializable for first-paint hydration; nested promises are not hydrated by `<Await>` or `use()`. See the [data-loading contract](/guide/migrate-existing-spa#data-loading).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ hero:
     alt: Vite SSR BOOST logo
   actions:
     - theme: brand
-      text: Create an app
-      link: /guide/getting-started#create-a-new-app
-    - theme: alt
       text: Migrate a SPA
       link: /guide/migrate-existing-spa
+    - theme: alt
+      text: Create an app
+      link: /guide/getting-started#create-a-new-app
     - theme: alt
       text: GitHub
       link: https://github.com/Lomray-Software/vite-ssr-boost
@@ -40,12 +40,13 @@ features:
 
 ## Start with the managed server
 
-Create a new app with `npm create @lomray/ssr-app@latest my-app` to start from the minimal template. For an existing app, add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
+For an existing app, add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. Create a new app with `npm create @lomray/ssr-app@latest my-app` to start from the minimal template. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
 
 ## Read this first
 
 - [Choosing an SSR approach](/guide/choosing) compares routing, data and server ownership.
 - [Migrate an existing SPA](/guide/migrate-existing-spa) shows the five-file change from the minimal template.
+- [Upgrade from 7 to 8](/guide/upgrade-v8) covers changed imports, hooks and the Node requirement.
 - [Example projects](/examples/) describes the template branches.
 - [FAQ](/reference/faq) answers questions about RSC, SPA output and runtimes.
 - [Getting Started](/guide/getting-started) covers installation and entry files.

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -1,0 +1,35 @@
+# Support and versions
+
+Policy effective **5 September 2026**.
+
+## Supported versions
+
+| Release line | Maintenance commitment | Through (inclusive) |
+| --- | --- | --- |
+| Latest 8.x minor | Bug fixes and security fixes | 5 September 2027 |
+| 7.1.x | Security backports | 5 March 2027 |
+
+When a new 8.x minor ships, upgrade to that minor to continue receiving bug and security fixes. The 7.1.x line receives security backports during its stated window.
+
+## Upstream compatibility
+
+For every new stable major of React, React Router or Vite, we will publish a **supported**, **investigating** or **unsupported** statement within **30 days** of its release. We will publish that statement in GitHub Discussions or Releases and link to the tested combinations where applicable. A permissive peer dependency range alone is not a support statement.
+
+## Response commitments
+
+- We will provide a human acknowledgment of a GitHub issue within **five business days**.
+- We will provide a human acknowledgment of a security report within **two business days**. Follow the [security reporting policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md) to report privately.
+
+These are acknowledgment targets; the time needed to investigate and resolve a report depends on its scope. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer.
+
+Issues explicitly labeled `needs-reproduction` receive an inactivity reminder after 30 days and may be closed 14 days later. Issues labeled `bug`, `confirmed` or `enhancement`, and all pull requests, are exempt. Add the requested reproduction and reopen the issue, or ask a maintainer to reopen it in a comment.
+
+## Deprecations and breaking changes
+
+We will announce deprecations at least **90 days** and **two minor releases** before removal, and remove deprecated APIs only in a **major release**. Both notice periods must be satisfied. Raising the package's Node.js requirement counts as a breaking change and requires a major release.
+
+## Maintenance updates
+
+We will publish a short maintenance note **each month**, beginning in **September 2026**, in [GitHub Discussions](https://github.com/Lomray-Software/vite-ssr-boost/discussions) or [Releases](https://github.com/Lomray-Software/vite-ssr-boost/releases). Each note will cover maintenance activity and compatibility status, including months with no release.
+
+See the [repository support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md), [tested compatibility combinations](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/README.md#compatibility) and [Upgrade from 7 to 8](/guide/upgrade-v8).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lomray/vite-ssr-boost",
   "version": "1.0.0",
-  "description": "Vite plugin for create awesome SSR or SPA applications on React.",
+  "description": "SSR and streaming for existing Vite + React Router apps in Data mode, without Framework mode",
   "type": "module",
   "exports": {
     "./node/production": {
@@ -32,7 +32,12 @@
     "vite",
     "plugin",
     "react",
-    "ssr"
+    "ssr",
+    "react-router",
+    "server-side-rendering",
+    "data-router",
+    "streaming",
+    "spa"
   ],
   "publishConfig": {
     "access": "public"
@@ -51,7 +56,7 @@
     "build": "rollup -c",
     "build:watch": "rollup -c -w",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:build": "vitepress build docs && node scripts/build-llms.mjs",
     "docs:preview": "vitepress preview docs",
     "release": "npm run build && cd lib && npm publish",
     "lint:check": "eslint . --max-warnings=0",

--- a/scripts/build-llms.mjs
+++ b/scripts/build-llms.mjs
@@ -1,0 +1,84 @@
+import { execFileSync } from 'node:child_process';
+import { access, readFile, readdir, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const root = new URL('../', import.meta.url);
+const docs = new URL('docs/', root);
+const dist = new URL('.vitepress/dist/', docs);
+const site = 'https://lomray-software.github.io/vite-ssr-boost/';
+const pkg = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const readVersion = (command, args) => {
+  try {
+    return execFileSync(command, args, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 30_000,
+    }).trim();
+  } catch {
+    return '';
+  }
+};
+const tagVersion = readVersion('git', ['describe', '--tags', '--match', 'v*', '--abbrev=0'])
+  .replace(/^v/, '');
+const version = tagVersion || readVersion('npm', ['view', pkg.name, 'version']);
+const versionSource = tagVersion ? 'git describe' : 'npm view';
+const files = (await readdir(docs, { recursive: true }))
+  .filter((file) => file.endsWith('.md') && !file.split('/').some((part) => part.startsWith('.')))
+  .sort();
+const pages = [];
+
+for (const file of files) {
+  const source = await readFile(new URL(file, docs), 'utf8');
+  const html = file.replace(/\.md$/, '.html');
+  const route = file.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '');
+  const url = new URL(route, site).href;
+  const title = source.match(/^# (.+)$/m)?.[1] ?? (file === 'index.md' ? 'Vite SSR BOOST' : route);
+
+  // Keep clean URLs aligned with VitePress output, including nested index pages.
+  try {
+    await access(new URL(html, dist));
+  } catch {
+    throw new Error(`Missing built page for ${url}: ${html}`);
+  }
+
+  pages.push({ title, url, source });
+}
+
+const grounding = await readFile(new URL('ai-usage.md', docs), 'utf8');
+const section = (heading) => {
+  const content = grounding.split(`## ${heading}\n`)[1]?.split('\n## ')[0].trim();
+
+  if (!content) {
+    throw new Error(`Missing AI grounding section: ${heading}`);
+  }
+
+  // These source sections use site-root links; make them usable outside the docs site.
+  return `## ${heading}\n\n${content.replace(/\]\(\/(?!\/)/g, `](${site}`)}`;
+};
+const introduction = [
+  '# Vite SSR BOOST',
+  `> ${pkg.description}`,
+  `Package: \`${pkg.name}\``,
+  ...(version ? [`Version: \`${version}\``] : []),
+  section('Public entrypoints'),
+  section('Data loading contract'),
+].join('\n\n');
+const index = `${introduction}\n\n## Documentation\n\n${pages
+  .map(({ title, url }) => `- [${title}](${url})`)
+  .join('\n')}\n`;
+const full = `${introduction}\n\n${pages
+  .map(({ url, source }) => `---\n\nSource: ${url}\n\n${source.trim()}`)
+  .join('\n\n')}\n`;
+
+await writeFile(new URL('llms.txt', dist), index);
+await writeFile(new URL('llms-full.txt', dist), full);
+
+process.stdout.write(
+  (version
+    ? `Documentation version: ${version} (source: ${versionSource})\n`
+    : 'Documentation version: omitted (git tags and npm registry unavailable)\n') +
+    `llms.txt: ${pages.length} page links, ${Buffer.byteLength(index)} bytes\n` +
+    `llms-full.txt: ${pages.length} concatenated pages, ${Buffer.byteLength(full)} bytes\n` +
+    `Verified ${pages.length}/${pages.length} page links resolve in ${fileURLToPath(dist)}\n`,
+);


### PR DESCRIPTION
## Goal

Make the package easier to trust and to find for teams that add SSR to an existing Vite + React Router app: a written support policy, one upgrade page for 7 → 8, machine-readable docs for AI assistants, a correctly scoped Context7 index, npm provenance, and a home page that puts migration first.

## Changes

- `docs/index.md` hero: "Migrate a SPA" first, then "Create an app"; README quick start leads with "Add to an existing app".
- `SUPPORT.md` + `docs/reference/support.md` (sidebar "Support and versions"): 8.x fixes until 5 September 2027, 7.1.x security backports until 5 March 2027, upstream-major statement within 30 days, acknowledgment in five business days (two for security), 90 days / two minors deprecation notice, Node bumps are majors, monthly maintenance note. `SECURITY.md` aligned; issue templates link the policy.
- `stale.yml` only touches `needs-reproduction` issues (30 + 14 days, reopen instructions); `bug`, `confirmed`, `enhancement` and pull requests are exempt.
- `docs/guide/upgrade-v8.md`: import map, removed internals, response/error changes, `onResponse`, `context.request`, Node requirement stated once from `package.json`.
- `llms.txt` and `llms-full.txt` generated at `docs:build` from the Markdown sources (26 pages, links verified against the built output; version taken from the latest `v*` tag, npm as fallback); `docs.yml` fetches tags.
- `context7.json` scoped to `prod`, `docs/` and the README with v8 entrypoint rules and `v7.1.0` as a previous version; `context7-refresh.yml` refreshes the index on releases and manual dispatch, skipped when `CONTEXT7_API_KEY` is absent.
- npm: description names React Router Data mode; keywords add `react-router`, `server-side-rendering`, `data-router`, `streaming`, `spa`.
- Release workflow: `id-token: write` and `NPM_CONFIG_PROVENANCE: true` (npm documents token-based publishing with provenance from GitHub Actions).

## Verification

`npm run docs:build` (0 dead links, both llms files present), `npm run lint:check`, `npm run ts:check`, `npm test` (577), `npm run build`, `npm run test:size`, `npm run test:core:no-optional`; all changed workflows parse as YAML; README relative links resolve; `context7.json` validates against the published schema.

## Follow-ups for the maintainer

- Add the `CONTEXT7_API_KEY` secret if automatic refreshes are wanted; otherwise trigger a refresh on context7.com after this reaches `prod`.
- The v8.0.0 GitHub release notes state a stricter Node requirement (`^22.22.2 || >=24.15.0`) than `package.json` (`>=22.12.0`); correct the notes.
