### PR TITLE
feat: stream loader and action promises for Await and use in data mode

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,6 +10,20 @@ env:
   ENABLE_CACHE: yes
 
 jobs:
+  browser:
+    name: Chromium streaming hydration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
   react:
     uses: ./.github/workflows/react-compatibility.yml
 
@@ -97,7 +111,7 @@ jobs:
 
   sonarcube:
     runs-on: ubuntu-latest
-    needs: [check, react]
+    needs: [check, react, browser]
     concurrency:
       group: ${{ github.ref }}-sonarcube
       cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,27 @@ env:
   ENABLE_CACHE: yes
 
 jobs:
+  browser:
+    name: Chromium streaming hydration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
   react:
     uses: ./.github/workflows/react-compatibility.yml
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [react]
+    needs: [react, browser]
     concurrency:
       group: ${{ github.ref }}-release
       cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ cache
 .env.*
 docs/.vitepress/dist
 docs/.vitepress/cache
+
+playwright-report
+test-results

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npm create @lomray/ssr-app@latest my-app -- --template full
 
 Starting a new app? Choose one of the [template branches](./docs/examples/index.md) with the [`npm create` command](./docs/guide/getting-started.md#create-a-new-app) or clone the branch directly.
 
+To defer loader work, return `{ title, slow: fetchUsers() }` and render `slow` with Suspense and `<Await>`; see the [streaming guide](./docs/guide/data-streaming.md).
+
 ## Who this is for
 
 - Teams adding SSR to a Vite SPA with React Router route objects.
@@ -66,9 +68,13 @@ Starting a new app? Choose one of the [template branches](./docs/examples/index.
 - Your React version within the package's peer range: React and React DOM `>=18.2.0`.
 - Your hosting choice, provided it can run the selected SSR transport or serve SPA files.
 
+Loader and action promises support `<Await>` and React 19 `use()` during hydration by default. [Stream loader data](./docs/guide/data-streaming.md) shows the loader pattern and `hydration: 'early'` for shell interaction before slow boundaries finish.
+
 ## What you add
 
 Add `SsrBoost()` to the Vite plugins, wire `client.ts` and `server.ts`, and replace the Vite scripts with `ssr-boost` commands. The [migration guide](./docs/guide/migrate-existing-spa.md) includes these entries and the HTML outlet, copied from the minimal example.
+
+Deferred router data needs no additional state library. Keep footer hydration by default, or opt into early hydration with custom state available at `onShellReady`.
 
 ## Choose your server
 

--- a/__fixtures__/browser-template/client.jsx
+++ b/__fixtures__/browser-template/client.jsx
@@ -1,0 +1,7 @@
+import entry from '@lomray/vite-ssr-boost/browser/entry';
+import { App, routes } from './routes.jsx';
+void entry(App, routes, {
+  init: async () => {
+    if (!window.custom?.ready) throw new Error('Custom state missing before hydration');
+  },
+});

--- a/__fixtures__/browser-template/index.html
+++ b/__fixtures__/browser-template/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="UTF-8"><title>Stream loader data</title><script type="module" src="/client.jsx" async></script></head><body><div id="root"><!--ssr-outlet--></div></body></html>

--- a/__fixtures__/browser-template/routes.jsx
+++ b/__fixtures__/browser-template/routes.jsx
@@ -1,0 +1,54 @@
+import React, { Suspense, useState } from 'react';
+import { Await, Link, useLoaderData } from 'react-router';
+
+const Shell = ({ children }) => {
+  const [count, setCount] = useState(0);
+  return (
+    <main>
+      <button onClick={() => setCount(count + 1)}>Count {count}</button>
+      <Link to="/">Home</Link>
+      <Link to="/deferred">Deferred</Link>
+      {children}
+    </main>
+  );
+};
+const UseContent = ({ promise }) => <p data-resolved>Users: {React.use(promise).users}</p>;
+const Deferred = () => {
+  const data = useLoaderData();
+  return (
+    <Shell>
+      <h1>{data.title}</h1>
+      <Suspense fallback={<p data-fallback>Loading users</p>}>
+        {data.use ? (
+          <UseContent promise={data.slow} />
+        ) : (
+          <Await resolve={data.slow} errorElement={<p data-error>Could not load users</p>}>
+            {(value) => <p data-resolved>Users: {value.users}</p>}
+          </Await>
+        )}
+      </Suspense>
+    </Shell>
+  );
+};
+export const routes = [
+  {
+    path: '/',
+    Component: () => (
+      <Shell>
+        <p>Home</p>
+      </Shell>
+    ),
+  },
+  {
+    path: '/deferred',
+    Component: Deferred,
+    loader: ({ request }) => ({
+      title: 'Deferred',
+      use: new URL(request.url).searchParams.has('use'),
+      slow: fetch(new URL('/api/slow', request.url), { signal: request.signal }).then((response) =>
+        response.json(),
+      ),
+    }),
+  },
+];
+export const App = ({ children }) => <>{children}</>;

--- a/__fixtures__/browser-template/server.jsx
+++ b/__fixtures__/browser-template/server.jsx
@@ -1,0 +1,19 @@
+import { createStaticHandler } from 'react-router';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import { App, routes } from './routes.jsx';
+import React from 'react';
+export const handler = (html) =>
+  createHandler(
+    {
+      handler: createStaticHandler(routes),
+      createApp: (children) => <App>{children}</App>,
+      renderToStream,
+    },
+    {
+      hydration: 'early',
+      diagnostics: false,
+      getHtml: () => html,
+      getState: () => ({ custom: { ready: true } }),
+    },
+  );

--- a/__helpers__/data-stream.tsx
+++ b/__helpers__/data-stream.tsx
@@ -1,0 +1,210 @@
+import React, { Suspense } from 'react';
+import {
+  Await,
+  createStaticHandler,
+  useActionData,
+  useAsyncError,
+  useLoaderData,
+} from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import createHandler from '@core/handler';
+import type { ICreateHandlerOptions } from '@core/handler';
+import type { TRenderToStream } from '@core/render';
+
+const ErrorElement = () => <p data-error>{(useAsyncError() as Error).message}</p>;
+const Page = () => {
+  const action = useActionData() as { slow: Promise<string> } | undefined;
+  const loader = useLoaderData() as { slow: Promise<string> };
+  const value = action ?? loader;
+  return (
+    <main>
+      <button>Shell</button>
+      <Suspense fallback={<p data-fallback>Loading</p>}>
+        <Await resolve={value.slow} errorElement={<ErrorElement />}>
+          {(text) => <p data-resolved>{text}</p>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+};
+const fixture = (
+  renderer: TRenderToStream,
+  options: Partial<ICreateHandlerOptions<Record<string, any>>> = {},
+  loader = () => ({
+    slow: new Promise<string>((resolve) => setTimeout(() => resolve('Resolved users: 3'), 150)),
+  }),
+  Component = Page,
+) =>
+  createHandler(
+    {
+      createApp: (children) => children,
+      handler: createStaticHandler([{ id: 'root', path: '*', Component, loader, action: loader }]),
+      renderToStream: renderer,
+    },
+    {
+      diagnostics: false,
+      getHtml: () => ({
+        header: '<!doctype html><html><body><div id="root">',
+        footer: '</div></body></html>',
+      }),
+      ...options,
+    },
+  );
+const chunks = async (response: Response) => {
+  const result: { html: string; time: number }[] = [];
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    result.push({ html: decoder.decode(chunk.value), time: performance.now() });
+  }
+  return result;
+};
+
+const testDataStream = (name: string, renderer: TRenderToStream): void => {
+  describe(`real React loader/action streaming (${name})`, () => {
+    it.each(['GET', 'POST'])(
+      'streams fallback and settlements before footer initialization for %s',
+      async (method) => {
+        const start = performance.now();
+        const parts = await chunks(
+          await fixture(renderer, { getState: () => ({ custom: { ready: true } }) })(
+            new Request('http://test/deferred', { method }),
+          ),
+        );
+        const html = parts.map((part) => part.html).join('');
+        expect(parts[0].html).not.toContain('SSRBPromise');
+        expect(parts[0].html).not.toContain('window.__staticRouterHydrationData');
+        expect(html.indexOf('SSRBPromise')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+        expect(html.indexOf('["resolve"')).toBeLessThan(html.indexOf('<p data-resolved'));
+        expect(html).toContain('Resolved users: 3');
+        expect(html.indexOf('data-fallback')).toBeLessThan(html.indexOf('["resolve"'));
+        expect(html.indexOf('window.__staticRouterHydrationData')).toBeGreaterThan(
+          html.indexOf('<p data-resolved'),
+        );
+        expect(html.indexOf('window.custom')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+        expect(html.indexOf('window.custom')).toBeLessThan(
+          html.indexOf('window.__staticRouterHydrationData'),
+        );
+        expect(
+          parts.find((part) => part.html.includes('["resolve"'))!.time - start,
+        ).toBeGreaterThanOrEqual(130);
+      },
+    );
+
+    it('streams rejection details and Await errorElement HTML', async () => {
+      const handler = fixture(renderer, {}, () => ({
+        slow: new Promise<string>((_, reject) =>
+          setTimeout(() => reject(new Error('Deferred failed')), 40),
+        ),
+      }));
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject"');
+      expect(html).toContain('Deferred failed');
+      expect(html).toContain('<p data-error');
+      expect(html).not.toContain('data-resolved');
+    });
+
+    it('keeps two simultaneous request identities and results isolated', async () => {
+      let count = 0;
+      const handler = fixture(renderer, {}, () => {
+        const id = ++count;
+        return {
+          slow: new Promise<string>((resolve) =>
+            setTimeout(() => resolve(`request-${id}`), id === 1 ? 70 : 20),
+          ),
+        };
+      });
+      const [first, second] = await Promise.all([
+        handler(new Request('http://test/one')).then((r) => r.text()),
+        handler(new Request('http://test/two')).then((r) => r.text()),
+      ]);
+      expect(first).toContain('request-1');
+      expect(first).not.toContain('request-2');
+      expect(second).toContain('request-2');
+      expect(second).not.toContain('request-1');
+      expect(first).toContain('["resolve",0');
+      expect(second).toContain('["resolve",0');
+    });
+
+    it('rejects pending promises before the timeout closes the response', async () => {
+      const onError = vi.fn();
+      const handler = fixture(renderer, { abortDelay: 40, onError }, () => ({
+        slow: new Promise<string>(() => undefined),
+      }));
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject",0');
+      expect(html).toContain('SSR loader/action promise aborted');
+      expect(html.endsWith('</html>')).toBe(true);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('keeps the deadline for pending loader data that React never reads', async () => {
+      const handler = fixture(
+        renderer,
+        { abortDelay: 40 },
+        () => ({ slow: new Promise<string>(() => undefined) }),
+        () => <p>no boundary</p>,
+      );
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject",0');
+      expect(html).toContain('no boundary');
+    });
+
+    it('buffers bot rendering until both React and unconsumed data settle', async () => {
+      const start = performance.now();
+      const handler = fixture(renderer, { onRouterReady: () => ({ isStream: false }) });
+      const response = await handler(
+        new Request('http://test/', { headers: { 'User-Agent': 'Googlebot' } }),
+      );
+      expect(performance.now() - start).toBeGreaterThanOrEqual(130);
+      const html = await response.text();
+      expect(html).toContain('<p data-resolved');
+      expect(html).toContain('Resolved users: 3');
+      expect(html).not.toContain('<!--$?-->');
+      expect(html.indexOf('["init"')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+      expect(html).toContain('["resolve",0');
+    });
+
+    it('emits custom state before early state and a shell marker before boundary chunks', async () => {
+      const getState = vi.fn(() => ({ custom: { ready: true } }));
+      const handler = fixture(renderer, { hydration: 'early', getState, nonce: 'test-nonce' });
+      const parts = await chunks(await handler(new Request('http://test/')));
+      const html = parts.map((part) => part.html).join('');
+      expect(parts[0].html).toContain('window.custom');
+      expect(parts[0].html).toContain('window.__staticRouterHydrationData');
+      expect(parts[0].html).toContain('SSRBPromise');
+      expect(html.indexOf('SSRBPromise')).toBeLessThan(html.indexOf('<main>'));
+      expect(html.indexOf('["resolve"')).toBeLessThan(html.indexOf('<p data-resolved'));
+      expect(html.indexOf('window.custom')).toBeLessThan(
+        html.indexOf('window.__staticRouterHydrationData'),
+      );
+      expect(html.indexOf('<button>Shell')).toBeLessThan(html.indexOf('["shell"]'));
+      expect(html.indexOf('["shell"]')).toBeLessThan(html.indexOf('<p data-resolved'));
+      expect(getState).toHaveBeenCalledTimes(1);
+      for (const [tag] of html.matchAll(/<script[^>]*>/g))
+        expect(tag).toContain('nonce="test-nonce"');
+    });
+
+    it.skipIf(!React.use)('supports React 19 use with a native loader promise', async () => {
+      const UsePage = () => {
+        const { slow } = useLoaderData() as { slow: Promise<string> };
+        const Content = () => <p data-use>{React.use(slow)}</p>;
+        return (
+          <Suspense fallback={<p>use fallback</p>}>
+            <Content />
+          </Suspense>
+        );
+      };
+      const html = await (
+        await fixture(renderer, {}, undefined, UsePage)(new Request('http://test/'))
+      ).text();
+      expect(html).toContain('<p data-use');
+      expect(html).toContain('Resolved users: 3');
+      expect(html).toContain('["resolve",0');
+    });
+  });
+};
+
+export default testDataStream;

--- a/__tests__/browser/stream-hydration.tsx
+++ b/__tests__/browser/stream-hydration.tsx
@@ -1,0 +1,78 @@
+import React, { Suspense, useState } from 'react';
+import type { Root } from 'react-dom/client';
+import { Await, useLoaderData } from 'react-router';
+import { afterEach, expect, it, vi } from 'vitest';
+import entry from '@browser/entry';
+import DataStream from '@core/data-stream';
+import { streamScript } from '@core/script';
+
+let root: Root | void;
+const App = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+const Counter = () => {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>Count {count}</button>;
+};
+const Page = () => {
+  const { slow } = useLoaderData() as { slow: Promise<string> };
+  return (
+    <main>
+      <Counter />
+      <Suspense fallback={<p>Loading users</p>}>
+        <Await resolve={slow}>{(value) => <p data-resolved>{value}</p>}</Await>
+      </Suspense>
+    </main>
+  );
+};
+const scripts = () => {
+  for (const script of [...document.querySelectorAll('script')]) {
+    Object.defineProperty(document, 'currentScript', { configurable: true, value: script });
+    new Function(script.textContent ?? '')();
+  }
+  Reflect.deleteProperty(document, 'currentScript');
+};
+
+afterEach(() => {
+  root?.unmount();
+  root = undefined;
+  document.body.innerHTML = '';
+  Reflect.deleteProperty(window, '__ssrBoostStream');
+  Reflect.deleteProperty(window, '__staticRouterHydrationData');
+  Reflect.deleteProperty(window, 'custom');
+  vi.restoreAllMocks();
+});
+
+it('hydrates and clicks the shell before deferred frames are applied', async () => {
+  let resolve!: (value: string) => void;
+  const slow = new Promise<string>((res) => {
+    resolve = res;
+  });
+  vi.spyOn(document, 'readyState', 'get').mockReturnValue('loading');
+  const routes = [{ id: 'root', path: '/', Component: Page, loader: () => ({ slow }) }];
+  const stream = new DataStream({
+    loaderData: { root: { slow } },
+    actionData: null,
+    errors: null,
+  } as never);
+  // Fizz's pending shell shape. Real Node/edge byte ordering is covered in the Node and edge integration suites.
+  document.body.innerHTML = `<div id="root">${stream.state(true)}<main><button>Count <!-- -->0</button><!--$?--><template id="B:0"></template><p>Loading users</p><!--/$--></main>${streamScript(['shell'])}</div>`;
+  Reflect.set(window, 'custom', { ready: true });
+  scripts();
+  const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  root = await entry(App, routes, {
+    init: async ({ router }) => {
+      expect(Reflect.get(window, 'custom')).toEqual({ ready: true });
+      expect((router.state.loaderData['root'] as any).slow).toBeInstanceOf(Promise);
+    },
+  });
+  document.querySelector('button')!.click();
+  await vi.waitFor(() => {
+    expect(document.querySelector('button')!.textContent).toBe('Count 1');
+  });
+  expect(document.body.textContent).toContain('Loading users');
+  expect(errors).not.toHaveBeenCalled();
+  resolve('Users: 3');
+  await stream.done;
+  document.getElementById('root')!.insertAdjacentHTML('beforeend', stream.take());
+  scripts();
+  expect(errors).not.toHaveBeenCalled();
+});

--- a/__tests__/core/data-stream.ts
+++ b/__tests__/core/data-stream.ts
@@ -1,0 +1,231 @@
+import { data, type StaticHandlerContext } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import receiveStream from '@browser/stream';
+import DataStream from '@core/data-stream';
+import { streamScript } from '@core/script';
+import Diagnostics from '@services/diagnostics';
+
+const context = (loaderData: unknown, actionData: unknown = null) =>
+  ({ loaderData, actionData, errors: null }) as StaticHandlerContext;
+const deferred = () => {
+  let resolve!: (value: any) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+const runScripts = (html: string) => {
+  for (const [, code] of html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)) {
+    new Function('window', code)(window);
+  }
+};
+
+afterEach(() => {
+  Reflect.deleteProperty(window, '__ssrBoostStream');
+  Reflect.deleteProperty(window, '__staticRouterHydrationData');
+});
+
+describe('loader/action stream codec', () => {
+  it.each(['before', 'after'])(
+    'restores stable placeholders when entry runs %s the scripts',
+    async (entryTime) => {
+      const slow = deferred();
+      const stream = new DataStream(
+        context(
+          { root: slow.promise, nested: [{ slow: slow.promise }] },
+          { root: { slow: slow.promise } },
+        ),
+      );
+      const receiver = entryTime === 'before' ? receiveStream() : undefined;
+      runScripts(await stream.state(false));
+      const state = (await (receiver ?? receiveStream()).ready) as any;
+      expect(state.loaderData.root).toBeInstanceOf(Promise);
+      expect(state.loaderData.root).toBe(state.loaderData.nested[0].slow);
+      expect(state.actionData.root.slow).toBe(state.loaderData.root);
+      slow.resolve({ nested: Promise.resolve({ answer: 42 }) });
+      await stream.done;
+      runScripts(await stream.take());
+      const result = await state.loaderData.root;
+      expect(result.nested).toBeInstanceOf(Promise);
+      expect(await result.nested).toEqual({ answer: 42 });
+    },
+  );
+
+  it.each(['before', 'after'])(
+    'restores settlements preceding footer initialization when entry runs %s the scripts',
+    async (entryTime) => {
+      const slow = deferred();
+      const stream = new DataStream(context({ root: { slow: slow.promise } }));
+      const receiver = entryTime === 'before' ? receiveStream() : undefined;
+      slow.resolve({ nested: Promise.resolve({ answer: 42 }) });
+      await stream.done;
+      runScripts(stream.take());
+      runScripts(stream.state(false));
+      const state = (await (receiver ?? receiveStream()).ready) as any;
+      expect(state.loaderData.root.slow).toBeInstanceOf(Promise);
+      const result = await state.loaderData.root.slow;
+      expect(result.nested).toBeInstanceOf(Promise);
+      expect(await result.nested).toEqual({ answer: 42 });
+    },
+  );
+
+  it('supports the same value matrix initially and inside settlements', async () => {
+    const value = {
+      json: { string: 'value', number: 3, boolean: true, null: null, array: [1, null] },
+      date: new Date('2026-09-01'),
+      map: new Map([[{ key: 1 }, ['value']]]),
+      set: new Set([1, 'two']),
+      missing: undefined,
+      big: 9007199254740993n,
+      regex: /<script>/gi,
+    };
+    const slow = deferred();
+    const stream = new DataStream(
+      context({ root: { value, slow: slow.promise } }, { root: { value } }),
+    );
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root.value).toEqual(value);
+    expect(state.actionData.root.value).toEqual(value);
+    slow.resolve(value);
+    await stream.done;
+    runScripts(await stream.take());
+    expect(await state.loaderData.root.slow).toEqual(value);
+    expect(Object.hasOwn(state.loaderData.root.value, 'missing')).toBe(true);
+  });
+
+  it.each([
+    [new TypeError('ordinary failure'), { message: 'ordinary failure', name: 'TypeError' }],
+    [
+      { status: 409, statusText: 'Conflict', data: { reason: 'duplicate' }, internal: false },
+      { message: 'Conflict', status: 409, statusText: 'Conflict', data: { reason: 'duplicate' } },
+    ],
+    [
+      data({ reason: 'invalid' }, { status: 422, statusText: 'Unprocessable' }),
+      {
+        message: 'Unprocessable',
+        status: 422,
+        statusText: 'Unprocessable',
+        data: { reason: 'invalid' },
+      },
+    ],
+  ])('preserves rejection details %# without stacks by default', async (error, expected) => {
+    const slow = deferred();
+    const stream = new DataStream(context({}, { root: { slow: slow.promise } }));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    slow.reject(error);
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.actionData.root.slow).rejects.toMatchObject(expected);
+    expect(
+      (await state.actionData.root.slow.catch((failure: unknown) => failure)).stack,
+    ).toBeUndefined();
+  });
+
+  it('includes stacks only when diagnostics are enabled', async () => {
+    const slow = deferred();
+    const stream = new DataStream(context({ root: slow.promise }), new Diagnostics('/stack'));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    const error = new Error('with stack');
+    slow.reject(error);
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.loaderData.root).rejects.toHaveProperty('stack', error.stack);
+  });
+
+  it('escapes script terminators, comments, separators, keys and nonce attributes', async () => {
+    const attack = '</script><!--\u2028\u2029';
+    const slow = deferred();
+    const stream = new DataStream(
+      context({ [attack]: { slow: slow.promise, attack } }),
+      undefined,
+      '\"<>&',
+    );
+    const initial = await stream.state(false);
+    expect(initial.match(/<\/script>/g)).toHaveLength(2);
+    expect(initial).not.toContain('<!--');
+    expect(initial).not.toMatch(/[\u2028\u2029]/);
+    expect(initial).toContain('nonce="&#34;&#60;&#62;&#38;"');
+    runScripts(initial);
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData[attack].attack).toBe(attack);
+    slow.resolve({ attack });
+    await stream.done;
+    const settlement = await stream.take();
+    expect(settlement.match(/<\/script>/g)).toHaveLength(1);
+    expect(settlement).not.toContain('<!--');
+    runScripts(settlement);
+    expect(await state.loaderData[attack].slow).toEqual({ attack });
+  });
+
+  it('rejects pending promises on abort, ignores late settlements and emits one diagnostic', async () => {
+    const slow = deferred();
+    const warn = vi.fn();
+    const stream = new DataStream(
+      context({ root: slow.promise }),
+      new Diagnostics('/abort-codec', { warn }),
+    );
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    stream.abort();
+    stream.abort();
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.loaderData.root).rejects.toThrow('SSR loader/action promise aborted');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('SSR_BOOST_STREAM_PROMISE_ABORTED');
+    slow.resolve('late');
+    await Promise.resolve();
+    expect(await stream.take()).toBe('');
+  });
+
+  it('waits for the parsed shell in early mode, including when shell arrives first', async () => {
+    const stream = new DataStream(context({ root: { title: 'early' } }));
+    const receiver = receiveStream();
+    const ready = vi.fn();
+    receiver.ready.then(ready);
+    runScripts(await stream.state(true));
+    await Promise.resolve();
+    expect(ready).not.toHaveBeenCalled();
+    runScripts(streamScript(['shell']));
+    await receiver.ready;
+    expect(ready).toHaveBeenCalled();
+  });
+
+  it('keeps prototype-shaped user keys as own data properties', async () => {
+    const value = JSON.parse('{"__proto__":{"polluted":true},"constructor":"safe"}');
+    const stream = new DataStream(context({ root: value }));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root).toEqual(value);
+    expect(Object.getPrototypeOf(state.loaderData.root)).toBe(Object.prototype);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+});
+
+describe('stream data diagnostics', () => {
+  it('continues warning about unsupported functions, symbols, classes and cycles', async () => {
+    class Model {
+      value = 1;
+    }
+    const cycle: any = {};
+    cycle.self = cycle;
+    const warn = vi.fn();
+    const stream = new DataStream(
+      context({ root: { fn: () => 1, symbol: Symbol('x'), model: new Model(), cycle } }),
+      new Diagnostics('/unsupported-codec', { warn }),
+    );
+    runScripts(stream.state(false));
+    expect(warn).toHaveBeenCalledTimes(4);
+    expect(
+      warn.mock.calls.every(([message]) => message.includes('SSR_BOOST_LOADER_NOT_SERIALIZABLE')),
+    ).toBe(true);
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root.fn).toBeUndefined();
+    expect(state.loaderData.root.cycle.self).toBe(state.loaderData.root.cycle);
+  });
+});

--- a/__tests__/core/diagnostics.ts
+++ b/__tests__/core/diagnostics.ts
@@ -71,17 +71,19 @@ afterEach(() => {
 
 describe('createHandler diagnostics', () => {
   it.each(['GET', 'POST'])('identifies the route and nested %s data path', async (method) => {
-    const handler = fixture({}, undefined, { items: [{ result: Promise.resolve(1) }] });
+    const handler = fixture({}, undefined, { items: [{ result: () => 1 }] });
     await (await handler(request(method))).text();
     const kind = method === 'POST' ? 'actionData' : 'loaderData';
     expect(messages()).toContain(
-      `[ssr-boost] SSR_BOOST_LOADER_NOT_SERIALIZABLE: Route "${pathname.slice(1)}" at ${kind}["${pathname.slice(1)}"].items[0].result: Promise is not JSON-serializable. See ${docs}ssr_boost_loader_not_serializable`,
+      `[ssr-boost] SSR_BOOST_LOADER_NOT_SERIALIZABLE: Route "${pathname.slice(1)}" at ${kind}["${pathname.slice(1)}"].items[0].result: function is not JSON-serializable. See ${docs}ssr_boost_loader_not_serializable`,
     );
   });
 
-  it('warns about BigInt before JSON serialization throws', async () => {
-    await expect(fixture({}, undefined, { count: 1n })(request())).rejects.toThrow(/BigInt/);
-    expect(messages()[0]).toContain('.count: BigInt is not JSON-serializable');
+  it('supports promises and BigInt without diagnostics', async () => {
+    await (
+      await fixture({}, undefined, { count: 1n, pending: Promise.resolve(1) })(request())
+    ).text();
+    expect(messages()).toEqual([]);
   });
 
   it('checks getState, including values omitted by the state builder', async () => {
@@ -262,7 +264,7 @@ describe('createHandler diagnostics', () => {
     }
   });
 
-  it('emits all six documented codes once across requests and handler instances', async () => {
+  it('deduplicates the six state/output codes across requests and handler instances', async () => {
     pathname = '/diagnostics-proof';
     const options = {
       getHtml: () => ({ header: '<html><head></head><body>', footer: undefined as never }),
@@ -275,7 +277,7 @@ describe('createHandler diagnostics', () => {
     };
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const handler = fixture(options, ['<head></head>', '<main>body</main>'], {
-        pending: Promise.resolve(1),
+        unsupported: () => 1,
       });
       await (await handler(request())).text();
       await (await handler(request())).text();

--- a/__tests__/core/html-boundary.ts
+++ b/__tests__/core/html-boundary.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import htmlBoundary from '@core/html-boundary';
+
+describe('HTML stream insertion boundaries', () => {
+  it('does not insert scripts in split tags, quotes, comments or raw text', () => {
+    const observe = htmlBoundary();
+    const feed = (value: string) => observe(new TextEncoder().encode(value));
+    expect(feed('<main title="hel')).toBe(false);
+    expect(feed('lo > wor')).toBe(false);
+    expect(feed('ld">')).toBe(true);
+    expect(feed('<!-- foo >')).toBe(false);
+    expect(feed('-->')).toBe(true);
+    expect(feed('<script>const x = "<p>')).toBe(false);
+    expect(feed('";</scr')).toBe(false);
+    expect(feed('ipt>')).toBe(true);
+    expect(feed('<style>p{color:red}')).toBe(false);
+    expect(feed('</style>')).toBe(true);
+    expect(feed('text spl')).toBe(false);
+    expect(feed('it</main>')).toBe(true);
+  });
+});

--- a/__tests__/integration/adapter-conformance.tsx
+++ b/__tests__/integration/adapter-conformance.tsx
@@ -6,7 +6,7 @@ import Fastify from 'fastify';
 import { Hono } from 'hono';
 import React, { Suspense } from 'react';
 import type { RouteObject } from 'react-router';
-import { createStaticHandler, redirect } from 'react-router';
+import { Await, createStaticHandler, redirect, useActionData, useLoaderData } from 'react-router';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import adapterEdge from '@adapters/edge';
 import adapterExpress from '@adapters/express';
@@ -33,6 +33,19 @@ interface IRuntimeFactory {
   renderer: TRenderToStream;
 }
 
+const DeferredPage = () => {
+  const action = useActionData() as { slow: Promise<string> } | undefined;
+  const loader = useLoaderData() as { slow: Promise<string> };
+  return (
+    <Suspense fallback={<p>loader fallback</p>}>
+      <Await resolve={(action ?? loader).slow}>{(value) => <p data-deferred>{value}</p>}</Await>
+    </Suspense>
+  );
+};
+const deferredLoader = () => ({
+  slow: new Promise<string>((resolve) => setTimeout(() => resolve('adapter deferred'), 35)),
+});
+
 const Broken = (): never => {
   throw new Error('conformance render failure');
 };
@@ -44,6 +57,7 @@ const Recoverable = () => (
 
 const createSsrHandler = (renderToStream: TRenderToStream, onAbort: () => void): TSsrHandler => {
   const routes: RouteObject[] = [
+    { path: '/deferred', Component: DeferredPage, loader: deferredLoader, action: deferredLoader },
     ...[204, 205, 304].map((status) => ({
       Component: () => <ResponseStatus status={status} />,
       path: `/status-${status}`,
@@ -134,7 +148,7 @@ const createSsrHandler = (renderToStream: TRenderToStream, onAbort: () => void):
           context.response.headers.append('Set-Cookie', 'router=1; Path=/');
         }
 
-        return {};
+        return { isStream: context.request.headers.get('user-agent') !== 'Googlebot' };
       },
       onShellError: ({ error }) => `<p data-shell-error>${error.message}</p>`,
       prepare: async ({ executionContext }) => {
@@ -270,6 +284,22 @@ describe.each(factories)('$name SSR conformance', ({ renderer, start }) => {
 
   afterAll(async () => {
     await runtime.close();
+  });
+
+  it.each(['GET', 'POST'])('transfers deferred %s data through the adapter', async (method) => {
+    const response = await runtime.request('/deferred', { method });
+    const html = await response.text();
+    expect(html).toContain('SSRBPromise');
+    expect(html).toContain('["resolve",0');
+    expect(html).toContain('<p data-deferred');
+    expect(html).toContain('adapter deferred');
+  });
+
+  it('buffers deferred HTML for bots', async () => {
+    const response = await runtime.request('/deferred', { headers: { 'User-Agent': 'Googlebot' } });
+    const html = await response.text();
+    expect(html).toContain('adapter deferred');
+    expect(html).not.toContain('<!--$?-->');
   });
 
   it('streams identical HTML, status, headers and cookies', async () => {

--- a/__tests__/integration/data-stream-edge.tsx
+++ b/__tests__/integration/data-stream-edge.tsx
@@ -1,0 +1,6 @@
+// @vitest-environment node
+import testDataStream from '@__helpers__/data-stream';
+import renderToStream from '@edge/render-to-stream';
+
+// React 18's Node and Web Fizz renderers must not share a React context instance.
+testDataStream('edge', renderToStream);

--- a/__tests__/integration/data-stream-node.tsx
+++ b/__tests__/integration/data-stream-node.tsx
@@ -1,0 +1,6 @@
+// @vitest-environment node
+import testDataStream from '@__helpers__/data-stream';
+import renderToStream from '@node/render-to-stream';
+
+// React 18's Node and Web Fizz renderers must not share a React context instance.
+testDataStream('node', renderToStream);

--- a/__tests__/integration/express-react-stream.tsx
+++ b/__tests__/integration/express-react-stream.tsx
@@ -6,7 +6,7 @@ import type { PropsWithChildren } from 'react';
 import React, { Suspense } from 'react';
 import express from 'express';
 import compression from 'compression';
-import { redirect } from 'react-router';
+import { Await, redirect, useLoaderData } from 'react-router';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import entry from '@adapters/express/entry';
@@ -134,8 +134,32 @@ describe('Express real React stream contract', () => {
       req.end();
     });
 
+  it('streams loader promises and early hydration through the managed entry', async () => {
+    const { body } = await request('/deferred');
+    expect(body).toContain('managed deferred');
+    expect(body).toContain('SSRBPromise');
+    expect(body).toContain('["resolve",0');
+    expect(body).toContain('["shell"]');
+    expect(body.indexOf('window.__staticRouterHydrationData')).toBeLessThan(body.indexOf('<main>'));
+    expect(body).toContain('nonce="managed-nonce"');
+  });
+
   beforeAll(async () => {
     const prepared = entry(App, [
+      {
+        path: '/deferred',
+        loader: () => ({
+          slow: new Promise<string>((resolve) => setTimeout(() => resolve('managed deferred'), 50)),
+        }),
+        Component: () => {
+          const { slow } = useLoaderData() as { slow: Promise<string> };
+          return (
+            <Suspense fallback={<p>pending loader</p>}>
+              <Await resolve={slow}>{(value) => <p data-loader>{value}</p>}</Await>
+            </Suspense>
+          );
+        },
+      },
       { path: '/timeout', Component: RecoverablePage },
       { path: '/disconnect', Component: RecoverablePage },
       { path: '/multipart', action: multipartAction, Component: () => <p>multipart rendered</p> },
@@ -197,6 +221,8 @@ describe('Express real React stream contract', () => {
         },
         {
           abortDelay: req.path === '/timeout' ? 50 : 2_000,
+          hydration: req.path === '/deferred' ? 'early' : 'footer',
+          nonce: 'managed-nonce',
           ...(req.path === '/multipart'
             ? {
                 getBody: () => {

--- a/browser-tests/data-stream.spec.mjs
+++ b/browser-tests/data-stream.spec.mjs
@@ -1,0 +1,60 @@
+import { test, expect, chromium } from '@playwright/test';
+
+for (const mode of ['Await', 'use']) {
+  test(`early shell is interactive within 300ms; ${mode} hydrates once and client loaders stay native`, async () => {
+    let browser;
+    try {
+      browser = await chromium.launch({ timeout: 10_000 });
+    } catch (error) {
+      const reason =
+        error.message.split('\n').find((line) => line.includes('Permission denied')) ||
+        error.message.split('\n')[0];
+      console.info(`SKIP Chromium: ${reason}`);
+      test.skip(true, `Chromium cannot launch in this environment: ${reason}`);
+      return;
+    }
+    try {
+      const page = await browser.newPage();
+      const errors = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      page.on('console', (message) => {
+        if (message.type() === 'error') errors.push(message.text());
+      });
+      await page.addInitScript(() => {
+        const observer = new MutationObserver(() => {
+          if (document.querySelector('button')) {
+            window.shellAt = performance.now();
+            observer.disconnect();
+          }
+        });
+        observer.observe(document, { childList: true, subtree: true });
+      });
+      // Warm the built entry, matching the cached async-entry timing regression.
+      await page.goto('http://127.0.0.1:4179/');
+      await page.getByRole('button', { name: 'Count 0' }).click();
+      await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+      await page.goto(`http://127.0.0.1:4179/deferred${mode === 'use' ? '?use=1' : ''}`, {
+        waitUntil: 'commit',
+      });
+      await page.getByRole('button', { name: 'Count 0' }).click({ timeout: 300 });
+      await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible({ timeout: 300 });
+      const interactiveMs = await page.evaluate(() => performance.now() - window.shellAt);
+      expect(interactiveMs).toBeLessThanOrEqual(300);
+      await expect(page.locator('[data-fallback]')).toBeVisible();
+      await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+      await expect(page.locator('[data-resolved]')).toHaveCount(1);
+      await expect(page.locator('[data-fallback]')).toHaveCount(0);
+      expect(errors).toEqual([]);
+      await page.getByRole('link', { name: 'Home', exact: true }).click();
+      await page.getByRole('link', { name: 'Deferred', exact: true }).click();
+      await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+      await expect(page.locator('[data-resolved]')).toHaveCount(1);
+      expect(errors).toEqual([]);
+      console.info(
+        `${mode}: shell interactive after ${Math.round(interactiveMs)}ms; no hydration errors or duplicates`,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
           { text: 'Choosing an SSR Approach', link: '/guide/choosing' },
           { text: 'Rendering Modes', link: '/guide/rendering-modes' },
           { text: 'Routing', link: '/guide/routing' },
+          { text: 'Stream loader data', link: '/guide/data-streaming' },
           { text: 'Server Lifecycle', link: '/guide/server-lifecycle' },
           { text: 'Runtime Adapters', link: '/guide/runtime-adapters' },
           { text: 'Deployment', link: '/guide/deployment' },

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -29,7 +29,7 @@ A Fetch transport owns its development server, bundling, static assets and route
 
 ## Data loading contract
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
 ## Application guidance
 
@@ -45,7 +45,8 @@ Loader results are serialized with `JSON.stringify` into `window.__staticRouterH
 
 - The browser entry resolves matched lazy routes and waits for the SSR state before creating the router and hydrating.
 - `data-force-spa="1"` on the root forces SPA mounting.
-- Rendering aborts on timeout or request cancellation.
+- Rendering and pending router promises abort on timeout or request cancellation.
+- Early hydration requires an async client entry and custom state available at `onShellReady`; buffered bot rendering waits for all promises.
 - CLI focus selection uses `--focus-only`; use `--focus-only client` for SPA build and start.
 - Plugin `entrypoint` configures additional build surfaces.
 - The package does not implement RSC, Server Actions or file-system routing conventions.

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -46,6 +46,9 @@ The entry returns a render definition consumed by the runtime server. It include
 
 ```ts
 interface IEntrypointOptions<TAppProps> {
+  hydration?: 'footer' | 'early';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   onServerCreated?;
   onServerStarted?;
   onRequest?;

--- a/docs/guide/choosing.md
+++ b/docs/guide/choosing.md
@@ -19,7 +19,7 @@ The RSC implementations linked above have different release contracts: React Rou
 
 ## Loader data in vite-ssr-boost
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Use Suspense with `<Await>` or React 19 `use()` for slow fields, and opt into `hydration: 'early'` when the shell should become interactive before slow boundaries finish. See [Stream loader data](/guide/data-streaming) for the value matrix and custom-state constraint.
 
 ## Choose a project
 

--- a/docs/guide/data-streaming.md
+++ b/docs/guide/data-streaming.md
@@ -1,0 +1,127 @@
+# Stream loader data
+
+Loader and action promises stream to the browser by default in React Router **Data mode**. Return critical data immediately and leave slower fields as promises. Both `<Await>` and React 19 `use()` receive native promises during hydration. Client navigations run your loaders in the browser, where their promises remain native.
+
+## Return a promise
+
+```tsx
+import { Suspense } from 'react';
+import { Await, useLoaderData } from 'react-router';
+
+export function loader() {
+  return {
+    title: 'Deferred',
+    slow: new Promise<{ users: number }>((resolve) => {
+      setTimeout(() => resolve({ users: 3 }), 1500);
+    }),
+  };
+}
+
+export default function DeferredPage() {
+  const data = useLoaderData() as ReturnType<typeof loader>;
+  return (
+    <main>
+      <h1>{data.title}</h1>
+      <Suspense fallback={<p>Loading users…</p>}>
+        <Await resolve={data.slow} errorElement={<p>Could not load users.</p>}>
+          {(value) => <p>Users: {value.users}</p>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+}
+```
+
+The same structure works in an `action`, read with `useActionData()`. React Router awaits the loader/action's own return promise before rendering: return an object containing a promise to defer a field. The transport also handles a promise at the root of an individual `loaderData` or `actionData` entry, promises nested in plain objects and arrays, and promises introduced by resolved values, including further nesting. Repeated references to a promise share one browser promise within that response.
+
+For real requests, pass the loader's `request.signal` to `fetch`. Keep loader code usable during client navigation; put server-only work behind an API. Attach rejection handlers to work that might reject **before** `staticHandler.query()` finishes; transport handlers are installed after the query.
+
+This follows React Router's [Suspense usage](https://reactrouter.com/how-to/suspense) and [custom Data framework architecture](https://reactrouter.com/start/data/custom).
+
+## React 19 `use()`
+
+Keep the consumer inside its Suspense boundary:
+
+```tsx
+import { Suspense, use } from 'react';
+import { useLoaderData } from 'react-router';
+
+function Users({ promise }: { promise: Promise<{ users: number }> }) {
+  const value = use(promise);
+  return <p>Users: {value.users}</p>;
+}
+
+export default function DeferredPage() {
+  const data = useLoaderData() as { slow: Promise<{ users: number }> };
+  return (
+    <Suspense fallback={<p>Loading users…</p>}>
+      <Users promise={data.slow} />
+    </Suspense>
+  );
+}
+```
+
+Use `<Await>` on React 18. Rejected `use()` promises go to the nearest React error boundary; `<Await errorElement>` can render local failure UI and `useAsyncError()` reads its rejection.
+
+## Supported values
+
+Initial router data and every streamed resolution use the same [devalue](https://github.com/sveltejs/devalue) value codec, with custom promise and error reducers. The transport does not depend on React Router's internal codec exports.
+
+| Value | Browser result |
+| --- | --- |
+| JSON primitives, plain objects, arrays | Same values; own string keys are preserved, including `__proto__`. |
+| `undefined` | Preserved in objects and arrays. |
+| `Date` | A `Date`, including invalid dates. |
+| `Map`, `Set` | Native collections, with recursively decoded keys and values. |
+| `bigint` | A `bigint`, without numeric precision loss. |
+| `RegExp` | Same source and flags; `lastIndex` resets to zero. |
+| `NaN`, positive/negative infinity, `-0`, sparse arrays | Preserved by the codec. |
+| `Promise` | One native promise per request-local identity. |
+| Errors and route error responses | The fields described below; arbitrary custom properties are omitted. |
+| Functions, symbols, other class instances, WeakMap/WeakSet | Unsupported; diagnostics warn and these values decode as `undefined`. |
+| Circular references | Outside the supported contract; diagnostics warn even where the codec can preserve a cycle. Prefer acyclic route data. |
+
+Object identity is preserved within a value frame. Across separate settlement frames only promise identity is guaranteed. Codec features beyond this table, such as typed arrays and arbitrary custom types, are not part of the router-data contract. `getState` continues to use **JSON**, so its custom state must contain plain snapshots with no promises or rich values.
+
+## Rejections and aborts
+
+Ordinary errors retain `message` and `name`. React Router error responses and rejected `data(value, { status, statusText })` values retain `message`, `status`, `statusText` and `data`; reconstructed response errors also satisfy `isRouteErrorResponse`. Stacks are sent only when diagnostics are enabled. Rejections after the shell was sent cannot change the HTTP status.
+
+`abortDelay` defaults to 15 seconds and starts after routing/preparation. It remains active until both React and pending loader/action promises finish, including promises the component never reads. On timeout, pending browser promises reject with `SSR loader/action promise aborted before it settled.` before the response closes. Development diagnostics report `SSR_BOOST_STREAM_PROMISE_ABORTED`. Disconnects cancel rendering and discard queued data when the consumer is gone. Aborting the render does not stop arbitrary application promises; use request cancellation for their underlying work.
+
+## Hydrate the shell early
+
+Opt in on the managed entry's lifecycle configuration:
+
+```ts
+export default entryServer(App, routes, {
+  init: () => ({
+    hydration: 'early',
+    getState: ({ context }) => ({ app: { locale: context.appProps.locale } }),
+  }),
+});
+```
+
+For a Fetch handler, pass `hydration: 'early'` alongside `getHtml` and other `createHandler` options. Use an **async** client module script (`<script type="module" src="/client.ts" async>`); an ordinary module waits for the HTML response to finish parsing. Static assets, matched lazy modules and the client's `init` callback must also load quickly enough for early interaction.
+
+Early mode collects `getState` at `onShellReady`, sends custom state first and router state next in the initial shell block before React's body bytes, and waits for React's bootstrap marker at the end of the parsed shell before hydrating. Slow boundaries can still be pending while a shell button responds. Keep state local to shell controls; on React 18, wrap updates that change a still-hydrating boundary in `startTransition` to avoid forcing that boundary to client rendering.
+
+**Custom state needed for hydration must be available at `onShellReady`.** State created only when a slow boundary resolves needs the application's own state transport. Selective hydration cannot compensate for missing initial custom state. React's bootstrap marker prevents hydration of a partially parsed shell, even if that shell spans multiple network chunks.
+
+The default is `hydration: 'footer'`: custom state and router hydration state stay in the footer, in that order. Settlements can arrive before that initialization and before the entry; the queue retains them without starting hydration.
+
+## Bots, adapters and limits
+
+Choose buffered output for crawlers with the existing hook:
+
+```ts
+onRouterReady: ({ context: { request } }) => ({
+  isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+}),
+```
+
+`isStream: false` waits for all React boundaries and all router promises, then sends complete HTML with resolved data frames in the footer. Successful buffered renders have no pending `<!--$?-->` Suspense markers. This overrides early hydration timing. Bot detection remains your application's choice.
+
+The shared transport works with Node, managed Express, the Express Fetch adapter, Fastify, Hono and edge renderers. It reads React only under response demand and preserves cancellation. Inline state and settlement scripts escape HTML delimiters and U+2028/U+2029; the `nonce` render option is forwarded to React and every generated custom-state/router-data script. `bootstrapScriptContent` is also forwarded to React; early mode prefixes its shell marker to it. Supply trusted JavaScript only for that option.
+
+Keep all generated scripts and closing HTML in `onResponse` transforms. Proxies or compression buffers can delay browser interactivity even though the server emits the shell early. See [Hydration order and streaming](/reference/hydration-and-streaming) and [Server lifecycle](/guide/server-lifecycle).

--- a/docs/guide/migrate-existing-spa.md
+++ b/docs/guide/migrate-existing-spa.md
@@ -145,7 +145,7 @@ Run `npm run develop` for development. Run `npm run build` and then `npm run sta
 
 ## Data loading
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
 The [users page](https://github.com/Lomray-Software/vite-template/blob/example/minimal/src/pages/users/index.tsx) shows a loader that waits for its data before returning. Keep loader code usable in the browser for client navigation; call an API for server-only operations.
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -58,6 +58,10 @@ const routes = [
 
 If route import detection matters for your build flow, keep lazy imports statically analyzable.
 
+## Loader and action promises
+
+Return promises for slow fields, such as `{ title, slow: fetchUsers() }`, and render them inside Suspense with `<Await>` or React 19 `use()`. The server streams their settlements and the browser reconstructs promises before router creation. See [Stream loader data](/guide/data-streaming), including `hydration: 'early'` for shell interaction while boundaries are pending. Keep loaders usable in the browser for client navigations.
+
 ## `routesPath`
 
 `routesPath` helps the plugin detect where route declarations live. Use it when your route files are not obvious from the default project shape.

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -83,6 +83,10 @@ Return:
 
 This is the place to switch between streaming and full-document rendering based on user agent, route match or any other request-level policy.
 
+## Promise streaming and hydration
+
+Loader/action promises stream by default. Set `hydration: 'early'` in the lifecycle configuration (or Fetch handler options) to hydrate the parsed shell while boundaries are pending. The early block contains `getState` custom state before router state, so custom state must be available at `onShellReady`. Default footer ordering remains custom state, router state, footer. `nonce` applies to React and all generated scripts; `bootstrapScriptContent` is forwarded with the early shell marker prepended when enabled. See [Stream loader data](/guide/data-streaming).
+
 ## `onShellReady`
 
 Replaces the template header or footer around the React stream. Generated hydration state is
@@ -147,6 +151,8 @@ The React render aborts when:
 - `abortDelay` is exceeded
 - the client disconnects before the response finishes
 - a source or destination stream fails
+
+Pending loader/action promises also reject on abort; connected browsers receive rejection scripts before closing. The timer remains active until both React and router promises finish, including unused data.
 
 The timer starts after loaders and `onRouterReady` finish. Use the loader's `request.signal` for
 outbound requests. Finishing the incoming request body does not cancel a response still streaming.

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -20,35 +20,31 @@ responses; invalid file-backed shells always throw, even with diagnostics disabl
 
 ### When it appears
 
-A loader or action returns a Promise, function, Map, Set, WeakMap, WeakSet, BigInt, Symbol, or class
-instance anywhere inside plain objects or arrays. The warning names the React Router route id and
-key path, such as `loaderData["details"].items[0].result`; Dates are reported as “hydrates as a string”,
-and circular references are reported too.
+A loader/action value or streamed resolution contains a function, symbol, unsupported class instance (including WeakMap/WeakSet), or circular reference. The warning identifies its route and key path. Promises, Dates, Maps, Sets, BigInts, RegExps and undefined are supported and do not trigger this warning.
 
 ### Why it matters
 
-Router hydration uses JSON, so a nested Promise or Map becomes `{}` and functions or symbols can
-disappear. BigInts and cycles make serialization throw, while Dates lose their Date methods after
-hydration.
+The [router data codec](/guide/data-streaming#supported-values) restores supported types. Unsupported values become `undefined`; custom class behavior is not transferred. Circular values are preserved within a frame but still warn so route data remains easy to inspect and reuse.
 
 ### How to fix
 
-Await loader data needed for the initial page and return plain JSON data at the reported path.
-Convert collections to arrays or objects, class instances to explicit data fields, and BigInts or
-Dates to strings with deliberate client-side reconstruction; keep streamed work in the application's
-Suspense mechanism instead of placing Promises in router hydration data.
+Return explicit data fields instead of functions or class instances, and remove cycles from your route data. Leave supported slow fields as promises and render them with Suspense and `<Await>` or React 19 `use()`.
+
+## SSR_BOOST_STREAM_PROMISE_ABORTED {#ssr_boost_stream_promise_aborted}
+
+A render timed out or was cancelled with loader/action promises still pending. The diagnostic names the route and pending count. Connected browsers receive rejection scripts before the response closes; cancelled response consumers discard queued frames. Increase `abortDelay` when the work legitimately needs longer, handle rejections with an error boundary, and pass the loader's `request.signal` to outbound fetches. The deadline starts after routing/preparation and also covers promises the React tree never reads. This diagnostic follows the development/explicit diagnostics settings above.
 
 ## SSR_BOOST_STATE_NOT_SERIALIZABLE {#ssr_boost_state_not_serializable}
 
 ### When it appears
 
-The object returned by `getState` contains one of the unsupported values listed above, including
+The object returned by `getState` contains a promise, function, symbol, bigint, Date, collection, class instance or cycle, including
 nested values inside arrays and plain objects. The warning identifies the request route and a path
 such as `$.store.items[0].createdAt`, even when the state builder would otherwise omit the value.
 
 ### Why it matters
 
-Custom state is serialized into browser scripts using JSON just like router state. A server store
+Custom state is serialized into browser scripts using JSON. Its value rules differ from router data. A server store
 containing class instances or collections can therefore hydrate with missing fields or changed types.
 
 ### How to fix

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -23,3 +23,7 @@ Choose [Next.js App Router](https://nextjs.org/docs/app) when you want its file-
 ## Does it work on Bun, Deno, Cloudflare?
 
 Yes, through the Fetch core, `@lomray/vite-ssr-boost/edge/render-to-stream` and `@lomray/vite-ssr-boost/adapters/edge`. Use the [runtime adapter integration](/guide/runtime-adapters#cloudflare-workers) with `Bun.serve`, `Deno.serve` or a Cloudflare Worker Fetch entry, and provide bundling, static assets and route-asset injection. Cloudflare bundles need the `workerd` and `worker` resolution conditions. The managed CLI and its Vercel/serverless output use Node and Express; they do not produce a Worker bundle.
+
+## Can `<Await>` and React 19 `use()` hydrate loader promises?
+
+Yes. Loader and action promises stream by default, including nested promises. The browser reconstructs them before creating the Data router. Enable `hydration: 'early'` to hydrate the shell while slow boundaries are pending; custom state must be ready at `onShellReady`. The default retains footer hydration. [Stream loader data](/guide/data-streaming) covers examples, errors and buffered crawler responses.

--- a/docs/reference/hydration-and-streaming.md
+++ b/docs/reference/hydration-and-streaming.md
@@ -37,9 +37,17 @@ The entry starts preloading the matched lazy routes while it waits. It awaits do
 
 The composed response sends the header, the React body stream and then this footer. Assigning router state releases the browser entry's wait, so the custom state must already be available at that point. The entry's `init` callback can then read that state.
 
+## Streamed loader and action data
+
+The [data stream](/guide/data-streaming) publishes stable promise placeholders in router initialization. Settlement scripts can arrive before initialization or the async entry: `window.__ssrBoostStream` buffers frames until its receiver is installed. The entry decodes the initial state and reconstructs native promises before `createRouter`.
+
+In default footer mode, custom state comes first in the footer, followed by the router hydration assignment and encoded initialization. Earlier settlement frames do not release the document wait. The assignment is an internal stream marker until the entry replaces it with decoded state.
+
+With `hydration: 'early'`, custom state and router state are emitted in the shell block before React body bytes. `getState` must already have everything hydration needs at `onShellReady`. The entry waits for React's bootstrap script at the end of the parsed shell before hydrating; it then allows slow boundaries to finish independently. This works across split shell chunks and requires an async client module. `isStream: false` still waits for complete React HTML and resolved data and uses the footer.
+
 ## Custom servers and `onResponse`
 
-Keep the generated footer in the same HTML response, after the React body, and complete the response. Do not send state in a separate request or withhold the final chunk. Replacing the footer through `onShellReady` preserves the generated state scripts and their order.
+Keep the generated state and settlement scripts in the same HTML response and complete it. Default mode keeps hydration state after the React body; early mode sends it with the shell. Do not send state in a separate request or withhold the final chunk. Replacing the footer through `onShellReady` preserves the generated state scripts and their order.
 
 [`src/core/transform-html.ts`](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/src/core/transform-html.ts) applies `onResponse` to decoded HTML chunks:
 

--- a/docs/reference/talking-points.md
+++ b/docs/reference/talking-points.md
@@ -21,9 +21,9 @@ The managed Express CLI is the default path for Vite development, HMR, static as
 
 ## Data loading
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
-The browser entry waits for document readiness or the router state assignment, together with matched lazy route preloads, before creating the router. Custom state is written before router state in the footer; see [Hydration order and streaming](/reference/hydration-and-streaming) for the timing and the `onResponse` contract.
+The browser entry waits for document readiness or the router state assignment, together with matched lazy route preloads, before creating the router. Custom state is written before router state in the footer by default. `hydration: 'early'` publishes both at shell-ready and waits for React's parsed-shell marker; see [Hydration order and streaming](/reference/hydration-and-streaming) for the timing and the `onResponse` contract.
 
 ## Who this is for
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
+        "devalue": "^5.9.2",
         "hoist-non-react-statics": "^3.3.2",
         "json5": "^2.2.3"
       },
@@ -27,6 +28,7 @@
         "@lomray/eslint-config": "^7.0.0",
         "@lomray/eslint-config-react": "^7.0.0",
         "@lomray/prettier-config": "^3.0.0",
+        "@playwright/test": "^1.63.0",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
         "@testing-library/react": "^16.3.3",
@@ -3206,6 +3208,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -7769,6 +7787,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -14202,6 +14226,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plimit-lit": {

--- a/package.json
+++ b/package.json
@@ -69,11 +69,13 @@
     "test:bun": "bun scripts/test-bun.mjs",
     "test:template": "npm run build && node scripts/test-template.mjs",
     "test:coverage": "vitest run --coverage",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:browser": "playwright test --config playwright.config.mjs"
   },
   "dependencies": {
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
+    "devalue": "^5.9.2",
     "hoist-non-react-statics": "^3.3.2",
     "json5": "^2.2.3"
   },
@@ -91,6 +93,7 @@
     "@lomray/eslint-config": "^7.0.0",
     "@lomray/eslint-config-react": "^7.0.0",
     "@lomray/prettier-config": "^3.0.0",
+    "@playwright/test": "^1.63.0",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@testing-library/react": "^16.3.3",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './browser-tests',
+  workers: 1,
+  timeout: 30_000,
+  reporter: 'list',
+  webServer: {
+    command: 'node scripts/browser-server.mjs',
+    url: 'http://127.0.0.1:4179',
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+});

--- a/scripts/browser-server.mjs
+++ b/scripts/browser-server.mjs
@@ -1,0 +1,83 @@
+import http from 'node:http';
+import { once } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'vite';
+import express from 'express';
+import adapterNode from '../lib/adapters/node.js';
+
+const directory = await mkdtemp(join(tmpdir(), 'ssr-boost-browser-'));
+const root = resolve('__fixtures__/browser-template');
+const config = {
+  configFile: false,
+  root,
+  logLevel: 'warn',
+  resolve: {
+    alias: { '@lomray/vite-ssr-boost': resolve('lib') },
+    dedupe: ['react', 'react-dom', 'react-router'],
+  },
+};
+await build({ ...config, build: { outDir: join(directory, 'client'), emptyOutDir: true } });
+// Bundle the server so its temporary output doesn't need its own node_modules tree.
+await build({
+  ...config,
+  ssr: { noExternal: true },
+  build: { ssr: join(root, 'server.jsx'), outDir: join(directory, 'server'), emptyOutDir: true },
+});
+const document = await readFile(join(directory, 'client/index.html'), 'utf8');
+const [header, footer] = document.split('<!--ssr-outlet-->');
+const { handler } = await import(pathToFileURL(join(directory, 'server/server.js')).href);
+const app = express();
+app.get('/api/slow', (_, response) => response.json({ users: 3 }));
+app.use(
+  '/assets',
+  express.static(join(directory, 'client/assets'), { maxAge: '1h', immutable: true }),
+);
+app.use(adapterNode(handler({ header, footer })));
+const upstream = http.createServer(app).listen(0, '127.0.0.1');
+await once(upstream, 'listening');
+const port = upstream.address().port;
+const proxy = http
+  .createServer((request, response) => {
+    const forward = () => {
+      if (response.destroyed) return;
+      // Preserve Host: SSR loader API requests must also travel through this proxy.
+      const pending = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          path: request.url,
+          method: request.method,
+          headers: request.headers,
+        },
+        (result) => {
+          response.writeHead(result.statusCode, result.headers);
+          result.pipe(response);
+        },
+      );
+      pending.on('error', () => {
+        if (!response.destroyed) response.writeHead(502).end();
+      });
+      response.on('close', () => pending.destroy());
+      request.pipe(pending);
+    };
+    if (request.url.startsWith('/api/slow')) setTimeout(forward, 2000);
+    else forward();
+  })
+  .listen(Number(process.env.BROWSER_TEST_PORT || 4179), '127.0.0.1');
+await once(proxy, 'listening');
+console.info(`Browser fixture ready: http://127.0.0.1:${proxy.address().port}`);
+const stop = async () => {
+  proxy.closeAllConnections();
+  upstream.closeAllConnections();
+  await Promise.all([
+    new Promise((resolve) => proxy.close(resolve)),
+    new Promise((resolve) => upstream.close(resolve)),
+  ]);
+  await rm(directory, { recursive: true, force: true });
+  process.exit(0);
+};
+process.once('SIGTERM', stop);
+process.once('SIGINT', stop);

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -6,7 +6,9 @@ import { build } from 'esbuild';
 // KB means 1024 bytes throughout. Recalibrate only for an intentional size change:
 // per entry = ceil(measured KB * 1.25 * 4) / 4; combined = measured KB + 1.
 const BROWSER_GZIP_BUDGETS_KB = {
-  'browser/entry': 1,
+  // B1: 3127 measured bytes, up from 685. Hard cap: at most 3 KiB growth.
+  'browser/entry': (685 + 3 * 1024) / 1024,
+  'browser/stream': 3.25,
   'components/navigate': 0.5,
   'components/only-client': 0.5,
   'components/render-client': 2.25,
@@ -19,7 +21,7 @@ const BROWSER_GZIP_BUDGETS_KB = {
   'helpers/import-route': 2.5,
   'interfaces/fc-route': 0.25,
 };
-const COMBINED_GZIP_BUDGET_KB = 4410 / 1024; // 3386 measured bytes + 1024 bytes.
+const COMBINED_GZIP_BUDGET_KB = 6817 / 1024; // 5793 measured bytes + 1024 bytes.
 
 const projectRoot = process.cwd();
 const lib = resolve(projectRoot, 'lib');

--- a/scripts/test-core-no-optional.mjs
+++ b/scripts/test-core-no-optional.mjs
@@ -73,7 +73,7 @@ try {
 
   runNpm([
     'install',
-    '--offline',
+    '--prefer-offline',
     '--omit=optional',
     '--legacy-peer-deps',
     '--ignore-scripts',

--- a/src/adapters/express/entry.tsx
+++ b/src/adapters/express/entry.tsx
@@ -28,6 +28,9 @@ export interface IEntrypointOptions<TAppProps = Record<string, any>> extends Pic
   | 'onError'
   | 'getState'
   | 'getBody'
+  | 'hydration'
+  | 'nonce'
+  | 'bootstrapScriptContent'
 > {
   onServerCreated?: (app: Express, serverApi: ServerApi) => Promise<void> | void;
   onServerStarted?: (app: Express, serverApi: ServerApi, server: Server) => Promise<void> | void;

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -44,6 +44,9 @@ export interface IRenderParams<TAppProps = Record<string, any>> {
 }
 
 export interface IRenderOptions<TAppProps = Record<string, any>> {
+  hydration?: 'early' | 'footer';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   abortDelay?: number;
   getBody?: (request: ExpressRequest) => BodyInit | null | undefined;
   onRouterReady?: (params: {
@@ -174,6 +177,9 @@ async function render(
     onError,
     getBody,
     getState,
+    hydration,
+    nonce,
+    bootstrapScriptContent,
     abortDelay = 15000,
   }: IRenderOptions,
 ): Promise<void> {
@@ -223,6 +229,9 @@ async function render(
       coreContext,
       {
         abortDelay,
+        hydration,
+        nonce,
+        bootstrapScriptContent,
 
         /**
          * Read custom state through the legacy request context.

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import type { DataRouter, RouteObject } from 'react-router';
 import { createBrowserRouter, matchRoutes, RouterProvider } from 'react-router';
+import receiveStream from '@browser/stream';
 import { IS_SSR_MODE } from '@constants/common';
 import type { TRouteObject } from '@interfaces/route-object';
 
@@ -81,6 +82,7 @@ async function entry<TAppProps>(
     rootId = 'root',
   }: IEntryClientOptions<TAppProps> = {},
 ): Promise<ReactDOM.Root | void> {
+  const stream = IS_SSR_MODE ? receiveStream() : undefined;
   const documentReady = waitForDocument();
   const lazyMatches = matchRoutes(
     routes as RouteObject[],
@@ -108,6 +110,13 @@ async function entry<TAppProps>(
         }
       }),
     ]);
+  }
+
+  const hydration = Reflect.get(window, '__staticRouterHydrationData') as
+    { __ssrBoostStream?: boolean } | undefined;
+
+  if (stream && hydration?.__ssrBoostStream) {
+    Reflect.set(window, '__staticRouterHydrationData', await stream.ready);
   }
 
   const router = createRouter(routes as RouteObject[], routerOptions);

--- a/src/browser/stream.ts
+++ b/src/browser/stream.ts
@@ -1,0 +1,95 @@
+import { parse } from 'devalue';
+
+type TFrame = ['init', string, boolean] | ['resolve' | 'reject', number, string] | ['shell'];
+interface IDeferred {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+}
+
+/** Install before waiting for the document: inline frames may precede the async entry. */
+const receiveStream = (): { ready: Promise<unknown> } => {
+  const target = window as typeof window & { __ssrBoostStream?: TFrame[] };
+  const queue = (target.__ssrBoostStream ??= []);
+  const promises = new Map<number, IDeferred>();
+  let hasShell = false;
+  let isEarly = false;
+  let isInitialized = false;
+  let state: unknown;
+  let resolveReady!: (value: unknown) => void;
+  let rejectReady!: (reason: unknown) => void;
+  const ready = new Promise<unknown>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  /** Return the same native promise for every occurrence of an identity. */
+  const deferred = (id: number): IDeferred => {
+    let pending = promises.get(id);
+
+    if (!pending) {
+      let resolve!: IDeferred['resolve'];
+      let reject!: IDeferred['reject'];
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
+      void promise.catch(() => undefined);
+      pending = { promise, resolve, reject };
+      promises.set(id, pending);
+    }
+
+    return pending;
+  };
+
+  /** Revive native promises synchronously before router creation or a settlement. */
+  const value = (payload: string): unknown =>
+    parse(payload, {
+      SSRBPromise: ([id]: [number]) => deferred(id).promise,
+      SSRBObject: (entries: [string, unknown][]) => Object.fromEntries(entries),
+      SSRBError: (entries: [string, unknown][]) => {
+        const data = Object.fromEntries(entries);
+        const error = Object.assign(new Error('Streamed loader/action rejection'), data);
+
+        if (!data.stack) {
+          delete error.stack;
+        }
+
+        return error;
+      },
+      SSRBUndefined: () => undefined,
+    });
+
+  /** Inline scripts and the buffered queue are processed in document order. */
+  queue.push = (...frames): number => {
+    for (const frame of frames) {
+      try {
+        if (frame[0] === 'shell') {
+          hasShell = true;
+        } else if (frame[0] === 'init') {
+          state = value(frame[1]);
+          [, , isEarly] = frame;
+          isInitialized = true;
+        } else {
+          deferred(frame[1])[frame[0]](value(frame[2]));
+        }
+
+        if (isInitialized && (!isEarly || hasShell)) {
+          resolveReady(state);
+        }
+      } catch (error) {
+        rejectReady(error);
+        promises.forEach((pending) => pending.reject(error));
+      }
+    }
+
+    return 0;
+  };
+  queue.push(...queue.splice(0));
+  void ready.catch(() => undefined);
+
+  return { ready };
+};
+
+export default receiveStream;

--- a/src/core/compose-html.ts
+++ b/src/core/compose-html.ts
@@ -1,84 +1,147 @@
-/**
- * Stream the shell, React body and hydration footer under downstream backpressure.
- */
+import type DataStream from '@core/data-stream';
+import htmlBoundary from '@core/html-boundary';
+
+/** Stream shell, data frames, React bytes and footer only under downstream demand. */
 const composeHtml = (
   header: string,
   body: ReadableStream<Uint8Array>,
   footer: string,
   abort?: (reason?: unknown) => void,
   onComplete?: () => void,
+  data?: DataStream,
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder();
   const reader = body.getReader();
   let phase: 'body' | 'footer' | 'header' = 'header';
+  let isStopped = false;
+  let isReleased = false;
+  let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | undefined;
+  const observe = htmlBoundary();
+  let canInject = true;
+  let heldChunk: Uint8Array | undefined;
+
+  /** Release exactly once, including cancellation during an outstanding read. */
+  const release = (): void => {
+    if (!isReleased) {
+      isReleased = true;
+      reader.releaseLock();
+    }
+  };
 
   return new ReadableStream<Uint8Array>(
     {
-      /**
-       * Release the React reader when the response consumer cancels.
-       */
+      /** Cancel immediately; a disconnected consumer cannot receive abort scripts. */
       cancel: async (reason) => {
+        isStopped = true;
         abort?.(reason);
-
-        if (phase === 'footer') {
-          return;
-        }
+        data?.cancel();
 
         try {
-          await reader.cancel(reason);
+          if (!isReleased) {
+            await reader.cancel(reason);
+          }
         } finally {
-          reader.releaseLock();
+          release();
           onComplete?.();
         }
       },
 
-      /**
-       * Emit one available shell or React chunk per downstream pull.
-       */
+      /** Keep at most the one React read requested by the current downstream pull. */
       async pull(controller) {
-        if (phase === 'header') {
-          phase = 'body';
+        try {
+          if (phase === 'header') {
+            phase = 'body';
 
-          if (header) {
-            controller.enqueue(encoder.encode(header));
+            if (header) {
+              controller.enqueue(encoder.encode(header));
 
+              return;
+            }
+          }
+
+          while (!isStopped) {
+            const frames = canInject ? data?.take() : undefined;
+
+            if (isStopped) {
+              return;
+            }
+
+            if (frames) {
+              controller.enqueue(encoder.encode(frames));
+
+              return;
+            }
+
+            if (heldChunk) {
+              canInject = observe(heldChunk);
+              controller.enqueue(heldChunk);
+              heldChunk = undefined;
+
+              return;
+            }
+
+            if (phase === 'body') {
+              pendingRead ??= reader.read();
+              const chunk = await (data && !data.isDone && canInject
+                ? Promise.race([pendingRead, data.changed().then(() => undefined)])
+                : pendingRead);
+
+              if (isStopped) {
+                return;
+              }
+
+              if (!chunk) {
+                continue;
+              }
+
+              pendingRead = undefined;
+
+              if (!chunk.done) {
+                heldChunk = chunk.value;
+                // Settle data already resolved by this React boundary before its HTML.
+                continue;
+              }
+
+              phase = 'footer';
+              canInject = true;
+              release();
+              continue;
+            }
+
+            if (data && !data.isDone) {
+              await data.changed();
+              continue;
+            }
+
+            if (footer) {
+              controller.enqueue(encoder.encode(footer));
+            }
+
+            isStopped = true;
+            onComplete?.();
+            controller.close();
+          }
+        } catch (error) {
+          if (isStopped) {
             return;
           }
-        }
 
-        if (phase === 'body') {
-          let chunk: ReadableStreamReadResult<Uint8Array>;
+          isStopped = true;
+          abort?.(error);
+          data?.cancel();
+          controller.error(error);
 
           try {
-            chunk = await reader.read();
-          } catch (error) {
-            abort?.(error);
-            reader.releaseLock();
+            if (!isReleased) {
+              await reader.cancel(error).catch(() => undefined);
+            }
+          } finally {
+            release();
             onComplete?.();
-            controller.error(error);
-
-            return;
           }
-
-          if (!chunk.done) {
-            controller.enqueue(chunk.value);
-
-            return;
-          }
-
-          phase = 'footer';
-          reader.releaseLock();
-          onComplete?.();
         }
-
-        if (footer) {
-          controller.enqueue(encoder.encode(footer));
-        }
-
-        controller.close();
       },
     },
-    // Do not start reading React while a downstream wrapper is still delivering the header.
     { highWaterMark: 0 },
   );
 };

--- a/src/core/data-stream.ts
+++ b/src/core/data-stream.ts
@@ -1,0 +1,258 @@
+import { stringify } from 'devalue';
+import { isRouteErrorResponse } from 'react-router';
+import type { StaticHandlerContext } from 'react-router';
+import script, { streamScript } from '@core/script';
+import serializeErrors from '@helpers/serialize-errors';
+import type Diagnostics from '@services/diagnostics';
+
+interface IPending {
+  settled: boolean;
+}
+
+/** Preserve route response details without shipping arbitrary error properties. */
+const errorProperties = (reason: unknown, diagnostics: boolean): Record<string, unknown> => {
+  const value = reason as {
+    type?: string;
+    init?: ResponseInit;
+    message?: string;
+    name?: string;
+    stack?: string;
+    data?: unknown;
+  } | null;
+  const isResponse = isRouteErrorResponse(reason);
+  const isDataError = value?.type === 'DataWithResponseInit';
+  const status = isResponse ? reason.status : value?.init?.status;
+  const statusText = isResponse ? reason.statusText : value?.init?.statusText;
+  const properties: Record<string, unknown> = {
+    message:
+      value?.message ??
+      (isResponse || isDataError
+        ? statusText || `Route data error (${status ?? 500})`
+        : String(reason)),
+    name: value?.name ?? 'Error',
+  };
+
+  if (isResponse || isDataError) {
+    Object.assign(properties, {
+      status: status ?? 500,
+      statusText: statusText ?? '',
+      data: value?.data,
+      internal: false,
+    });
+  }
+
+  if (diagnostics && value?.stack) {
+    properties.stack = value.stack;
+  }
+
+  return properties;
+};
+
+/**
+ * Request-local promise identities and settlements. devalue encodes each frame's
+ * value; promise reducers keep settlement scheduling outside the value codec.
+ * No React bytes are read here. Nested settlements can introduce further placeholders.
+ */
+class DataStream {
+  public readonly initial: string;
+  public readonly done: Promise<void>;
+  protected resolveDone!: () => void;
+  protected notify?: () => void;
+  protected change?: Promise<void>;
+  protected readonly identities = new WeakMap<Promise<unknown>, number>();
+  protected readonly pending = new Map<number, IPending>();
+  protected readonly frames: string[] = [];
+  protected initialized = false;
+  protected stopped = false;
+  protected aborted = false;
+  protected nextId = 0;
+
+  public constructor(
+    context: StaticHandlerContext,
+    protected readonly diagnostics?: Diagnostics,
+    protected readonly nonce?: string,
+  ) {
+    diagnostics?.inspectRouterState(context);
+    this.done = new Promise((resolve) => {
+      this.resolveDone = resolve;
+    });
+    try {
+      this.initial = this.encodeValue({
+        loaderData: context.loaderData,
+        actionData: context.actionData,
+        errors: serializeErrors(context.errors),
+      });
+      this.initialized = true;
+      this.wake();
+    } catch (error) {
+      this.cancel();
+      throw error;
+    }
+  }
+
+  /** Use the codec's public plugin API, without depending on React Router internals. */
+  protected promiseId = (value: unknown): [number] | false => {
+    if (value instanceof Promise) {
+      let id = this.identities.get(value);
+
+      if (id === undefined) {
+        id = this.nextId++;
+        this.identities.set(value, id);
+        this.pending.set(id, { settled: false });
+        const promiseId = id;
+
+        void value.then(
+          (result: unknown) => this.settle(promiseId, result, false),
+          (error: unknown) => this.settle(promiseId, error, true),
+        );
+
+        if (this.aborted) {
+          this.settle(id, new Error('SSR loader/action promise aborted before it settled.'), true);
+        }
+      }
+
+      return [id];
+    }
+
+    return false;
+  };
+
+  /** Encode one complete value, preserving the codec's built-in value representations. */
+  protected encodeValue(value: unknown): string {
+    return stringify(value, {
+      SSRBPromise: this.promiseId,
+      SSRBError: (error: unknown) =>
+        (error instanceof Error || isRouteErrorResponse(error)) &&
+        Object.entries(errorProperties(error, Boolean(this.diagnostics))),
+      SSRBObject: (item: unknown) =>
+        Boolean(item && typeof item === 'object' && Object.hasOwn(item, '__proto__')) &&
+        Object.entries(item as object),
+      SSRBUndefined: (item: unknown) =>
+        typeof item === 'function' ||
+        typeof item === 'symbol' ||
+        Boolean(
+          item &&
+          typeof item === 'object' &&
+          !Array.isArray(item) &&
+          ![
+            Object.prototype,
+            null,
+            Date.prototype,
+            Map.prototype,
+            Set.prototype,
+            RegExp.prototype,
+            Promise.prototype,
+            Error.prototype,
+          ].includes(Object.getPrototypeOf(item) as object),
+        ),
+    });
+  }
+
+  /** Publish only once, and finish encoding before announcing a settlement. */
+  protected settle(id: number, value: unknown, rejected: boolean): void {
+    const pending = this.pending.get(id);
+
+    if (!pending || pending.settled || this.stopped) {
+      return;
+    }
+
+    pending.settled = true;
+
+    if (!rejected) {
+      this.diagnostics?.inspectStreamValue(value, id);
+    }
+
+    try {
+      const payload = this.encodeValue(
+        rejected
+          ? Object.assign(
+              new Error('Streamed loader/action rejection'),
+              errorProperties(value, Boolean(this.diagnostics)),
+            )
+          : value,
+      );
+
+      this.frames.push(streamScript([rejected ? 'reject' : 'resolve', id, payload], this.nonce));
+    } catch (error) {
+      const payload = this.encodeValue(
+        new Error(`Cannot serialize streamed value: ${String(error)}`),
+      );
+
+      this.frames.push(streamScript(['reject', id, payload], this.nonce));
+    } finally {
+      this.pending.delete(id);
+      this.wake();
+    }
+  }
+
+  /** Notify a waiting pull and settle completion only after nested values were visited. */
+  protected wake(): void {
+    this.notify?.();
+    this.notify = undefined;
+    this.change = undefined;
+
+    if (this.initialized && !this.pending.size) {
+      this.resolveDone();
+    }
+  }
+
+  public get isDone(): boolean {
+    return this.initialized && !this.pending.size;
+  }
+
+  /** Wait for data, without starting a read from the React stream. */
+  public changed(): Promise<void> {
+    if (this.frames.length || this.isDone) {
+      return Promise.resolve();
+    }
+
+    return (this.change ??= new Promise((resolve) => {
+      this.notify = resolve;
+    }));
+  }
+
+  /** Drain completed value frames before delivering a React boundary chunk. */
+  public take(): string {
+    return this.frames.splice(0).join('');
+  }
+
+  /** Publish initialization in the selected shell/footer block to unblock hydration. */
+  public state(isEarly: boolean): string {
+    const { initial } = this;
+    const assignment = 'window.__staticRouterHydrationData = {__ssrBoostStream: true};';
+
+    return (
+      script(assignment, this.nonce, true) + streamScript(['init', initial, isEarly], this.nonce)
+    );
+  }
+
+  /** Reject outstanding placeholders before a timeout closes the HTML response. */
+  public abort(): void {
+    this.aborted = true;
+    let count = 0;
+
+    for (const [id, value] of this.pending) {
+      if (!value.settled) {
+        count++;
+        this.settle(id, new Error('SSR loader/action promise aborted before it settled.'), true);
+      }
+    }
+
+    if (count) {
+      this.diagnostics?.streamAborted(count);
+    }
+  }
+
+  /** A disconnected client cannot receive scripts; detach request state from late work. */
+  public cancel(): void {
+    this.stopped = true;
+    this.initialized = true;
+    this.pending.clear();
+    this.frames.length = 0;
+    this.wake();
+  }
+}
+
+export { errorProperties };
+
+export default DataStream;

--- a/src/core/html-boundary.ts
+++ b/src/core/html-boundary.ts
@@ -1,0 +1,59 @@
+/**
+ * Track tag, comment and raw-text boundaries across arbitrary React byte chunks.
+ * Data scripts may be inserted only after a complete tag, never in a split token
+ * or script/style body. This observer neither buffers HTML nor reads ahead.
+ */
+const htmlBoundary = (): ((chunk: Uint8Array) => boolean) => {
+  let mode: 'text' | 'tag' | 'comment' | 'raw' = 'text';
+  let token = '';
+  let quote = '';
+  let raw = '';
+
+  return (chunk) => {
+    for (const byte of chunk) {
+      const char = String.fromCharCode(byte);
+
+      if (mode === 'raw') {
+        token = (token + char).slice(-32);
+
+        if (char === '>' && new RegExp(`</${raw}\\s*>$`, 'i').test(token)) {
+          mode = 'text';
+          token = '';
+          raw = '';
+        }
+      } else if (mode === 'comment') {
+        token = (token + char).slice(-3);
+
+        if (token === '-->') {
+          mode = 'text';
+          token = '';
+        }
+      } else if (mode === 'tag') {
+        if (token.length < 32) {
+          token += char;
+        }
+
+        if (token === '<!--') {
+          mode = 'comment';
+        } else if (quote) {
+          if (char === quote) {
+            quote = '';
+          }
+        } else if (char === '"' || char === "'") {
+          quote = char;
+        } else if (char === '>') {
+          raw = /^<(script|style|textarea|title)(?:\s|>)/i.exec(token)?.[1]?.toLowerCase() ?? '';
+          mode = raw ? 'raw' : 'text';
+          token = '';
+        }
+      } else if (char === '<') {
+        mode = 'tag';
+        token = '<';
+      }
+    }
+
+    return mode === 'text' && chunk[chunk.length - 1] === 62;
+  };
+};
+
+export default htmlBoundary;

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -6,12 +6,12 @@ import StreamError from '@constants/stream-error';
 import { ServerProvider } from '@context/server';
 import type { IServerContext } from '@context/server';
 import composeHtml from '@core/compose-html';
+import DataStream from '@core/data-stream';
 import headResponse from '@core/head-response';
 import { mergeResponseHeaders } from '@core/headers';
 import transformHtml from '@core/transform-html';
 import type { ISsrExecutionContext } from '@core/types';
 import buildCustomState from '@helpers/build-custom-state';
-import buildRouterState from '@helpers/build-router-state';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import obtainStreamError from '@helpers/obtain-stream-error';
 import type Diagnostics from '@services/diagnostics';
@@ -40,6 +40,8 @@ export interface ISsrRequestContext<TAppProps = Record<string, any>> {
 }
 
 export interface IRenderStreamOptions {
+  nonce?: string;
+  bootstrapScriptContent?: string;
   onError: (error: unknown) => void;
   signal: AbortSignal;
 }
@@ -79,6 +81,10 @@ export interface ICoreRenderParams<TAppProps = Record<string, any>> {
 }
 
 export interface ICoreRenderOptions<TAppProps = Record<string, any>> {
+  /** Hydrate the parsed shell while deferred boundaries are still pending. */
+  hydration?: 'early' | 'footer';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   /**
    * React rendering deadline in milliseconds, starting after router preparation.
    */
@@ -157,7 +163,8 @@ const createShellErrorResponse = <TAppProps,>(
  */
 const prepareHtmlResponse = <TAppProps,>(
   context: ISsrRequestContext<TAppProps>,
-  { getState, onShellReady }: ICoreRenderOptions<TAppProps>,
+  { getState, onShellReady, hydration, nonce }: ICoreRenderOptions<TAppProps>,
+  dataStream: DataStream,
 ): IHtmlResponse => {
   const serverResponse = context.serverContext!.response;
 
@@ -169,15 +176,27 @@ const prepareHtmlResponse = <TAppProps,>(
   }
 
   const shell = onShellReady?.({ context }) ?? {};
-  const routerState = buildRouterState(context.routerContext!, context.diagnostics);
-  const customState = buildCustomState(getState?.({ context }), context.diagnostics);
-  const header = shell.header || context.html.header;
+  const isEarly = hydration === 'early' && context.isStream;
+  const customState = buildCustomState(
+    getState?.({ context }),
+    context.diagnostics,
+    nonce,
+    Boolean(isEarly),
+  );
+  let header = shell.header || context.html.header;
   const shellFooter = shell.footer || context.html.footer;
 
   context.diagnostics?.inspectShell({ header, footer: shellFooter });
 
   // Router state unblocks the browser entry, so custom state must already be available.
-  const footer = customState + routerState + shellFooter;
+  let footer = shellFooter;
+
+  if (isEarly) {
+    header += customState + dataStream.state(true);
+  } else {
+    footer = customState + dataStream.state(false) + dataStream.take() + footer;
+  }
+
   const headers = new Headers(context.response.headers);
 
   return { header, footer, headers, status: context.response.status };
@@ -192,6 +211,9 @@ const render = async <TAppProps,>(
   {
     abortDelay = 15_000,
     getState,
+    hydration = 'footer',
+    nonce,
+    bootstrapScriptContent,
     onError,
     onResponse,
     onRouterReady,
@@ -211,8 +233,14 @@ const render = async <TAppProps,>(
   }
 
   context.routerContext = queried;
+  const dataStream = new DataStream(queried, context.diagnostics, nonce);
 
-  await prepare?.({ context, executionContext });
+  try {
+    await prepare?.({ context, executionContext });
+  } catch (error) {
+    dataStream.cancel();
+    throw error;
+  }
 
   const { isStream = true } = (await onRouterReady?.({ context })) ?? {};
 
@@ -271,6 +299,7 @@ const render = async <TAppProps,>(
     abortReason = reason;
     cleanup();
     context.didError ??= StreamError.RenderCancel;
+    dataStream.abort();
     renderController.abort(reason);
     output?.abort(reason);
   };
@@ -291,6 +320,11 @@ const render = async <TAppProps,>(
 
   try {
     output = await renderToStream(node, {
+      nonce,
+      bootstrapScriptContent:
+        hydration === 'early' && isStream
+          ? `(window.__ssrBoostStream = window.__ssrBoostStream || []).push(["shell"]);${bootstrapScriptContent ?? ''};document.currentScript?.remove();`
+          : bootstrapScriptContent,
       /**
        * Classify expected cancellation separately from unexpected React errors.
        */
@@ -320,9 +354,9 @@ const render = async <TAppProps,>(
       output.abort(abortReason);
     }
 
-    void output.allReady.then(clearAbortTimer, clearAbortTimer);
+    void Promise.all([output.allReady, dataStream.done]).then(clearAbortTimer, clearAbortTimer);
 
-    await (isStream ? output.shellReady : output.allReady);
+    await (isStream ? output.shellReady : Promise.all([output.allReady, dataStream.done]));
   } catch (error) {
     abort(error);
     await output?.stream.cancel(error).catch(() => undefined);
@@ -343,10 +377,16 @@ const render = async <TAppProps,>(
       );
     }
 
-    const { header, footer, headers, status } = prepareHtmlResponse(context, {
-      getState,
-      onShellReady,
-    });
+    const { header, footer, headers, status } = prepareHtmlResponse(
+      context,
+      {
+        getState,
+        onShellReady,
+        hydration,
+        nonce,
+      },
+      dataStream,
+    );
 
     if (context.request.method === 'HEAD' || [204, 205, 304].includes(status)) {
       abort();
@@ -358,7 +398,7 @@ const render = async <TAppProps,>(
       });
     }
 
-    const body = composeHtml(header, output.stream, footer, abort, cleanup);
+    const body = composeHtml(header, output.stream, footer, abort, cleanup, dataStream);
     const transformed = transformHtml(
       body,
       onResponse ? (html, isEnd) => onResponse({ context, html, isEnd }) : undefined,

--- a/src/core/script.ts
+++ b/src/core/script.ts
@@ -1,0 +1,23 @@
+import htmlEscape from '@helpers/html-escape';
+
+/** Escape an attribute independently of the JavaScript string escaping rules. */
+const script = (content: string, nonce?: string, isTemporary = false): string => {
+  const attribute =
+    nonce === undefined
+      ? ''
+      : ` nonce="${nonce.replace(/[&<>"']/g, (char) => `&#${char.charCodeAt(0)};`)}"`;
+
+  return `<script async${attribute}>${content}${isTemporary ? 'document.currentScript?.remove();' : ''}</script>`;
+};
+
+/** Queue frames even when the async browser entry has not executed yet. */
+const streamScript = (frame: unknown, nonce?: string): string =>
+  script(
+    `(window.__ssrBoostStream = window.__ssrBoostStream || []).push(${htmlEscape(JSON.stringify(frame))});`,
+    nonce,
+    true,
+  );
+
+export { streamScript };
+
+export default script;

--- a/src/edge/render-to-stream.ts
+++ b/src/edge/render-to-stream.ts
@@ -11,7 +11,10 @@ const getRenderer = async (): Promise<typeof ReactDOMServer.renderToReadableStre
 /**
  * Adapt React Web streams and settle readiness even when initialization is aborted.
  */
-const renderToStream: TRenderToStream = async (node, { onError, signal }) => {
+const renderToStream: TRenderToStream = async (
+  node,
+  { onError, signal, nonce, bootstrapScriptContent },
+) => {
   const controller = new AbortController();
   let rejectPending!: (reason: Error) => void;
 
@@ -46,7 +49,12 @@ const renderToStream: TRenderToStream = async (node, { onError, signal }) => {
   try {
     stream = await Promise.race([
       getRenderer().then((renderToReadableStream) =>
-        renderToReadableStream(node, { onError, signal: controller.signal }),
+        renderToReadableStream(node, {
+          onError,
+          signal: controller.signal,
+          nonce,
+          bootstrapScriptContent,
+        }),
       ),
       pendingAbort,
     ]);

--- a/src/helpers/build-custom-state.ts
+++ b/src/helpers/build-custom-state.ts
@@ -1,3 +1,4 @@
+import script from '@core/script';
 import htmlEscape from '@helpers/html-escape';
 import type Diagnostics from '@services/diagnostics';
 
@@ -7,6 +8,8 @@ import type Diagnostics from '@services/diagnostics';
 function buildCustomState(
   initState?: Record<string, Record<string, any>> | void,
   diagnostics?: Diagnostics,
+  nonce?: string,
+  isTemporary = false,
 ): string {
   diagnostics?.inspectState(initState);
 
@@ -20,7 +23,7 @@ function buildCustomState(
       ? `.${key}`
       : `[${htmlEscape(JSON.stringify(key))}]`;
 
-    return `<script async>window${property} = JSON.parse(${json});</script>`;
+    return script(`window${property} = JSON.parse(${json});`, nonce, isTemporary);
   });
 
   return stateScripts.join('').trim();

--- a/src/helpers/build-router-state.ts
+++ b/src/helpers/build-router-state.ts
@@ -1,4 +1,5 @@
 import type { StaticHandlerContext } from 'react-router';
+import script from '@core/script';
 import htmlEscape from '@helpers/html-escape';
 import serializeErrors from '@helpers/serialize-errors';
 import type Diagnostics from '@services/diagnostics';
@@ -6,7 +7,11 @@ import type Diagnostics from '@services/diagnostics';
 /**
  * Build router state
  */
-function buildRouterState(context: StaticHandlerContext, diagnostics?: Diagnostics): string {
+function buildRouterState(
+  context: StaticHandlerContext,
+  diagnostics?: Diagnostics,
+  nonce?: string,
+): string {
   diagnostics?.inspectRouterState(context);
 
   const { loaderData, actionData, errors } = context;
@@ -17,7 +22,7 @@ function buildRouterState(context: StaticHandlerContext, diagnostics?: Diagnosti
   };
   const json = htmlEscape(JSON.stringify(JSON.stringify(routerState)));
 
-  return `<script async>window.__staticRouterHydrationData = JSON.parse(${json});</script>`;
+  return script(`window.__staticRouterHydrationData = JSON.parse(${json});`, nonce);
 }
 
 export default buildRouterState;

--- a/src/node/render-to-stream.ts
+++ b/src/node/render-to-stream.ts
@@ -44,6 +44,8 @@ const renderToStream: TRenderToStream = (node, options) => {
   let hasShellSettled = false;
   let hasAborted = false;
   const rendered = renderToPipeableStream(node, {
+    nonce: options.nonce,
+    bootstrapScriptContent: options.bootstrapScriptContent,
     onAllReady: resolveAll,
     onError: options.onError,
 

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -3,6 +3,7 @@ import Logger from '@services/logger';
 
 type TDiagnosticCode =
   | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
+  | 'SSR_BOOST_STREAM_PROMISE_ABORTED'
   | 'SSR_BOOST_STATE_NOT_SERIALIZABLE'
   | 'SSR_BOOST_OUTLET_MISSING'
   | 'SSR_BOOST_HYDRATION_STATE_MISSING'
@@ -78,15 +79,27 @@ const valueType = (value: unknown): string => {
 };
 
 /**
- * Find values JSON cannot preserve, descending only into plain objects and arrays.
+ * Custom state uses JSON. Router state also supports promises, Date, RegExp, bigint,
+ * Map and Set through the stream codec; functions, symbols, classes and cycles warn.
  */
 const walkSerializable = (
   value: unknown,
   report: (issue: ISerializationIssue) => void,
   path = '$',
   ancestors = new Set<object>(),
+  streamed = false,
 ): void => {
   const type = typeof value;
+
+  if (
+    streamed &&
+    (value instanceof Promise ||
+      value instanceof Date ||
+      value instanceof RegExp ||
+      type === 'bigint')
+  ) {
+    return;
+  }
 
   if (type === 'function' || type === 'bigint' || type === 'symbol') {
     report({ path, reason: `${valueType(value)} is not JSON-serializable` });
@@ -102,6 +115,7 @@ const walkSerializable = (
   const prototype: unknown = Object.getPrototypeOf(object);
 
   if (
+    !(streamed && (object instanceof Map || object instanceof Set)) &&
     prototype !== Object.prototype &&
     prototype !== null &&
     !(Array.isArray(object) && prototype === Array.prototype)
@@ -124,7 +138,17 @@ const walkSerializable = (
 
   ancestors.add(object);
 
-  for (const [key, child] of Object.entries(object)) {
+  const entries =
+    streamed && object instanceof Map
+      ? [...(object as Map<unknown, unknown>)].flatMap(([key, child], index) => [
+          [`${index}.key`, key],
+          [`${index}.value`, child],
+        ])
+      : streamed && object instanceof Set
+        ? [...(object as Set<unknown>)].map((child, index) => [String(index), child])
+        : Object.entries(object);
+
+  for (const [key, child] of entries as [string, unknown][]) {
     const suffix =
       Array.isArray(object) && /^(0|[1-9]\d*)$/.test(key)
         ? `[${key}]`
@@ -132,7 +156,7 @@ const walkSerializable = (
           ? `.${key}`
           : `[${JSON.stringify(key)}]`;
 
-    walkSerializable(child, report, path + suffix, ancestors);
+    walkSerializable(child, report, path + suffix, ancestors, streamed);
   }
 
   ancestors.delete(object);
@@ -193,9 +217,34 @@ class Diagnostics {
               `Route ${JSON.stringify(route)} at ${path}: ${reason}.`,
             ),
           `${kind}[${JSON.stringify(route)}]`,
+          new Set(),
+          true,
         );
       }
     }
+  }
+
+  /** Report the request's pending loader/action promises at the render deadline. */
+  public streamAborted(count: number): void {
+    this.warn(
+      'SSR_BOOST_STREAM_PROMISE_ABORTED',
+      `Route ${JSON.stringify(this.route)} aborted with ${count} pending loader/action promise(s); the browser receives a rejection when connected.`,
+    );
+  }
+
+  /** Inspect streamed resolutions with the same supported value matrix as initial data. */
+  public inspectStreamValue(value: unknown, id: number): void {
+    walkSerializable(
+      value,
+      ({ path, reason }) =>
+        this.warn(
+          'SSR_BOOST_LOADER_NOT_SERIALIZABLE',
+          `Route ${JSON.stringify(this.route)} at ${path}: ${reason}.`,
+        ),
+      `promise[${id}]`,
+      new Set(),
+      true,
+    );
   }
 
   /**


### PR DESCRIPTION
## Goal

Close the largest gap against React Router Framework mode while keeping route objects: a loader may return `{ title, slow: fetchSlow() }` and the browser gets a real promise for `slow`, so `<Await>` and React 19 `use()` hydrate in Data mode. Optionally, the shell can hydrate and become interactive before slow boundaries finish.

## Design

- After `staticHandler.query()`, promises inside `loaderData`/`actionData` (top level, nested, and inside settled values) become stable placeholders in the serialized router state; each settlement is written into the HTML stream as an inline script that resolves or rejects the matching browser promise. Values are encoded with `devalue` (JSON values, `undefined`, `Date`, `Map`, `Set`, `bigint`, `RegExp`, non-finite numbers); functions, symbols and class instances decode as `undefined` with a development warning. Rejections keep `message`/`name`, and route error responses keep `status`, `statusText`, `data` (revived errors satisfy `isRouteErrorResponse`); stacks only with diagnostics.
- Frames are injected only at complete HTML token boundaries, ahead of the React boundary chunk they belong to, with the configured React `nonce`; streams stay demand-driven and the cancellation semantics are unchanged. A timeout rejects pending browser promises before the response closes; a disconnected client discards frames. Buffered (bot) rendering waits for the promises and ships resolved values.
- Default hydration is unchanged (state in the footer, custom state first). `hydration: 'early'` emits custom state and router state before the React body and hydrates once React's bootstrap marker at the end of the shell has been parsed; custom state must be available at `onShellReady` in that mode.
- Browser entry: a queue receiver (`window.__ssrBoostStream`) installed before the document wait, promises reconstructed before `createRouter`; client navigations keep native loader promises. Browser entry +2.4 KB gzip (budget updated to baseline + 3 KB).
- Diagnostics: `SSR_BOOST_LOADER_NOT_SERIALIZABLE` no longer fires for promises; `SSR_BOOST_STREAM_PROMISE_ABORTED` reports promises still pending at abort (development only).

## Verification

- `npm run lint:check`, `npm run ts:check`, `npm test` (627 on React 19 / Router 8 / Vite 8; 625 + 2 skipped on React 18 / Router 7 / Vite 6, `use()` needs React 19), `npm run build`, `npm run test:size`, `npm run test:core:no-optional`, `npm run test:edge:packed` (workerd), `npm run docs:build`.
- Template acceptance against the pinned template: exit 0, zero `SSR_BOOST_` lines; template copy with a `/deferred` route: streamed sequence shows the placeholder state, the fallback, the resolution script 1.5 s later and the resolved boundary; Googlebot request returns complete HTML without pending markers; smoke green.
- New Playwright job (`npm run test:browser`, Chromium): with the slow data delayed by 2 s, the shell button responds within ~40 ms of shell arrival; `<Await>` and `use()` hydrate once, no hydration errors, no duplicate content, client navigation keeps native promises. Run locally in real Chromium and added to PR and release workflows.
