### PR TITLE
feat: streamed loader data, init and doctor, support and discovery docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -36,3 +38,18 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Versions**
+- vite-ssr-boost:
+- Node or other runtime:
+- React / React DOM:
+- React Router:
+- Vite:
+
+**Adapter and route setup**
+- Managed CLI / Node / Express / Fastify / Hono / edge:
+- Development or production; SSR or SPA:
+- Route objects, loaders and lazy routes (or a minimal reproduction link):
+
+**Diagnostic codes**
+Include any `SSR_BOOST_*` diagnostic codes and relevant logs, with secrets removed. See [Development diagnostics](https://lomray-software.github.io/vite-ssr-boost/reference/diagnostics).

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please read the [support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md) for supported versions and response targets. Report security issues privately using [SECURITY.md](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md).
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,30 @@
+name: Refresh Context7 Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  # GITHUB_TOKEN-created releases do not trigger another release workflow.
+  workflow_call:
+    secrets:
+      CONTEXT7_API_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+    steps:
+      - name: Trigger Context7 refresh
+        # GitHub requires an env indirection for optional secrets in step conditions.
+        if: ${{ env.CONTEXT7_API_KEY != '' }}
+        run: |
+          curl --fail-with-body --silent --show-error --max-time 60 \
+            -X POST https://context7.com/api/v1/refresh \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $CONTEXT7_API_KEY" \
+            -d '{"libraryName":"/lomray-software/vite-ssr-boost"}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [ prod ]
     paths:
       - 'docs/**'
+      - 'scripts/build-llms.mjs'
       - '.github/workflows/docs.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -29,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,6 +10,20 @@ env:
   ENABLE_CACHE: yes
 
 jobs:
+  browser:
+    name: Chromium streaming hydration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
   react:
     uses: ./.github/workflows/react-compatibility.yml
 
@@ -97,7 +111,7 @@ jobs:
 
   sonarcube:
     runs-on: ubuntu-latest
-    needs: [check, react]
+    needs: [check, react, browser]
     concurrency:
       group: ${{ github.ref }}-sonarcube
       cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ prod, staging ]
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 env:
   NODE_VERSION: 22.23.2
   ENABLE_CACHE: yes
@@ -96,6 +102,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+  refresh-context7:
+    needs: [release]
+    if: ${{ github.ref == 'refs/heads/prod' }}
+    uses: ./.github/workflows/context7-refresh.yml
+    secrets:
+      CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
 
   sonarcube:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,27 @@ env:
   ENABLE_CACHE: yes
 
 jobs:
+  browser:
+    name: Chromium streaming hydration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
   react:
     uses: ./.github/workflows/react-compatibility.yml
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [react]
+    needs: [react, browser]
     concurrency:
       group: ${{ github.ref }}-release
       cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Follow up on issues needing reproduction'
 on:
   schedule:
     - cron: '30 1 * * 1'
@@ -6,12 +6,27 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: 'needs-reproduction'
+          exempt-issue-labels: 'bug,confirmed,enhancement'
+          # Disable PR label cleanup too; issue activity still removes its stale label.
+          remove-stale-when-updated: false
+          remove-issue-stale-when-updated: true
           stale-issue-label: 'no-issue-activity'
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.'
-          close-issue-message: 'The issue has been closed for inactivity.'
+          stale-issue-message: >-
+            This issue is waiting for a reproduction and has had no activity for 30 days.
+            Please share a minimal reproduction or an update within 14 days to keep it open.
+          close-issue-message: >-
+            This issue was closed because the requested reproduction is still missing after
+            the 14-day reminder. Add a reproduction and reopen it, or comment with the
+            reproduction and ask a maintainer to reopen it if you cannot do so yourself.
+          close-issue-reason: 'not_planned'

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ cache
 .env.*
 docs/.vitepress/dist
 docs/.vitepress/cache
+
+playwright-report
+test-results

--- a/README.md
+++ b/README.md
@@ -20,18 +20,6 @@
 
 ## Quick start
 
-**Start a new app** with the `minimal` template (default):
-
-```bash
-npm create @lomray/ssr-app@latest my-app
-```
-
-Choose the `full` template by passing the flag after `--`:
-
-```bash
-npm create @lomray/ssr-app@latest my-app -- --template full
-```
-
 **Add to an existing app:**
 
 ```bash
@@ -49,6 +37,18 @@ The [migration guide](./docs/guide/migrate-existing-spa.md) walks through the fi
 | `src/client.ts`  | Use the browser entry for hydration or SPA mounting. |
 | `src/server.ts`  | Add the server entry and request-scoped setup.       |
 | `package.json`   | Use the `ssr-boost` dev, build and start commands.   |
+
+**Start a new app** with the `minimal` template (default):
+
+```bash
+npm create @lomray/ssr-app@latest my-app
+```
+
+Choose the `full` template by passing the flag after `--`:
+
+```bash
+npm create @lomray/ssr-app@latest my-app -- --template full
+```
 
 Starting a new app? Choose one of the [template branches](./docs/examples/index.md) with the [`npm create` command](./docs/guide/getting-started.md#create-a-new-app) or clone the branch directly.
 
@@ -84,7 +84,7 @@ Add `SsrBoost()` to the Vite plugins, wire `client.ts` and `server.ts`, and repl
 
 ## Install and template quick start
 
-The package declares `engines.node: ">=22.12.0"`. The example uses Node 22.23.2; React Router and build tools can raise the required Node version.
+See [Compatibility](#compatibility) for the package Node requirement. The example uses Node 22.23.2; React Router and build tools can raise the required Node version.
 
 Start with the [minimal template](https://github.com/Lomray-Software/vite-template/tree/example/minimal):
 
@@ -110,6 +110,8 @@ For production, run `npm run build` and `npm run start:ssr`. For a SPA build, ru
 Already running this in production? Point our [free performance audit](https://audit.lomray.com/?utm_source=github&utm_medium=readme-vite-ssr-boost&utm_campaign=owned-surface-github) at the URL. It reports Core Web Vitals, JavaScript bundle weight and whether the HTML really arrives server-rendered. No signup.
 
 ## Compatibility
+
+See the [support policy](./SUPPORT.md) for version lifetimes, response targets and breaking-change commitments, and [Upgrade from 7 to 8](./docs/guide/upgrade-v8.md) for migration instructions.
 
 The package is tested against the current and previous major of React, React Router and Vite, with an additional Vite 6 row. The [compatibility workflow](./.github/workflows/react-compatibility.yml) runs the full test suite and a built Worker check on Node 22.23.2 with these exact combinations:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 
 ```bash
 npm i @lomray/vite-ssr-boost
+npx ssr-boost init --dry-run
+npx ssr-boost init --apply
+npm install
+npx ssr-boost doctor
 ```
 
 `@lomray/vite-ssr-boost` adds server rendering to your Vite project while keeping your route objects and components. Build SSR and SPA output from the same app, and choose a managed Express server or a Fetch handler for your own transport.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npm create @lomray/ssr-app@latest my-app -- --template full
 
 Starting a new app? Choose one of the [template branches](./docs/examples/index.md) with the [`npm create` command](./docs/guide/getting-started.md#create-a-new-app) or clone the branch directly.
 
+To defer loader work, return `{ title, slow: fetchUsers() }` and render `slow` with Suspense and `<Await>`; see the [streaming guide](./docs/guide/data-streaming.md).
+
 ## Who this is for
 
 - Teams adding SSR to a Vite SPA with React Router route objects.
@@ -66,9 +68,13 @@ Starting a new app? Choose one of the [template branches](./docs/examples/index.
 - Your React version within the package's peer range: React and React DOM `>=18.2.0`.
 - Your hosting choice, provided it can run the selected SSR transport or serve SPA files.
 
+Loader and action promises support `<Await>` and React 19 `use()` during hydration by default. [Stream loader data](./docs/guide/data-streaming.md) shows the loader pattern and `hydration: 'early'` for shell interaction before slow boundaries finish.
+
 ## What you add
 
 Add `SsrBoost()` to the Vite plugins, wire `client.ts` and `server.ts`, and replace the Vite scripts with `ssr-boost` commands. The [migration guide](./docs/guide/migrate-existing-spa.md) includes these entries and the HTML outlet, copied from the minimal example.
+
+Deferred router data needs no additional state library. Keep footer hydration by default, or opt into early hydration with custom state available at `onShellReady`.
 
 ## Choose your server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ When reporting security issues, please provide the following information:
  - Steps to reproduce the vulnerability
  - Your contact information
 
-We take all security reports seriously and will do our best to rapidly address the issue. We are grateful for your contributions to our security efforts, and we will acknowledge your report upon resolution.
+We will provide a human acknowledgment within **two business days** of receiving your security report. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer. We will keep you informed while we investigate and coordinate a fix; acknowledgment does not mean resolution. See [Support policy](./SUPPORT.md) for the security maintenance windows.
 
 ## Responsible Disclosure
 We adhere to the principle of responsible disclosure. This means that if you discover a vulnerability, you agree to:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Support policy
+
+Policy effective **5 September 2026**.
+
+## Supported versions
+
+| Release line | Maintenance commitment | Through (inclusive) |
+| --- | --- | --- |
+| Latest 8.x minor | Bug fixes and security fixes | 5 September 2027 |
+| 7.1.x | Security backports | 5 March 2027 |
+
+When a new 8.x minor ships, upgrade to that minor to continue receiving bug and security fixes. The 7.1.x line receives security backports during its stated window.
+
+## Upstream compatibility
+
+For every new stable major of React, React Router or Vite, we will publish a **supported**, **investigating** or **unsupported** statement within **30 days** of its release. We will publish that statement in GitHub Discussions or Releases and link to the tested combinations where applicable. A permissive peer dependency range alone is not a support statement.
+
+## Response commitments
+
+- We will provide a human acknowledgment of a GitHub issue within **five business days**.
+- We will provide a human acknowledgment of a security report within **two business days**. Follow the [security reporting policy](./SECURITY.md) to report privately.
+
+These are acknowledgment targets; the time needed to investigate and resolve a report depends on its scope. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer.
+
+Issues explicitly labeled `needs-reproduction` receive an inactivity reminder after 30 days and may be closed 14 days later. Issues labeled `bug`, `confirmed` or `enhancement`, and all pull requests, are exempt. Add the requested reproduction and reopen the issue, or ask a maintainer to reopen it in a comment.
+
+## Deprecations and breaking changes
+
+We will announce deprecations at least **90 days** and **two minor releases** before removal, and remove deprecated APIs only in a **major release**. Both notice periods must be satisfied. Raising the package's Node.js requirement counts as a breaking change and requires a major release.
+
+## Maintenance updates
+
+We will publish a short maintenance note **each month**, beginning in **September 2026**, in [GitHub Discussions](https://github.com/Lomray-Software/vite-ssr-boost/discussions) or [Releases](https://github.com/Lomray-Software/vite-ssr-boost/releases). Each note will cover maintenance activity and compatibility status, including months with no release.

--- a/__fixtures__/browser-template/client.jsx
+++ b/__fixtures__/browser-template/client.jsx
@@ -1,0 +1,7 @@
+import entry from '@lomray/vite-ssr-boost/browser/entry';
+import { App, routes } from './routes.jsx';
+void entry(App, routes, {
+  init: async () => {
+    if (!window.custom?.ready) throw new Error('Custom state missing before hydration');
+  },
+});

--- a/__fixtures__/browser-template/index.html
+++ b/__fixtures__/browser-template/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="UTF-8"><title>Stream loader data</title><script type="module" src="/client.jsx" async></script></head><body><div id="root"><!--ssr-outlet--></div></body></html>

--- a/__fixtures__/browser-template/routes.jsx
+++ b/__fixtures__/browser-template/routes.jsx
@@ -1,0 +1,54 @@
+import React, { Suspense, useState } from 'react';
+import { Await, Link, useLoaderData } from 'react-router';
+
+const Shell = ({ children }) => {
+  const [count, setCount] = useState(0);
+  return (
+    <main>
+      <button onClick={() => setCount(count + 1)}>Count {count}</button>
+      <Link to="/">Home</Link>
+      <Link to="/deferred">Deferred</Link>
+      {children}
+    </main>
+  );
+};
+const UseContent = ({ promise }) => <p data-resolved>Users: {React.use(promise).users}</p>;
+const Deferred = () => {
+  const data = useLoaderData();
+  return (
+    <Shell>
+      <h1>{data.title}</h1>
+      <Suspense fallback={<p data-fallback>Loading users</p>}>
+        {data.use ? (
+          <UseContent promise={data.slow} />
+        ) : (
+          <Await resolve={data.slow} errorElement={<p data-error>Could not load users</p>}>
+            {(value) => <p data-resolved>Users: {value.users}</p>}
+          </Await>
+        )}
+      </Suspense>
+    </Shell>
+  );
+};
+export const routes = [
+  {
+    path: '/',
+    Component: () => (
+      <Shell>
+        <p>Home</p>
+      </Shell>
+    ),
+  },
+  {
+    path: '/deferred',
+    Component: Deferred,
+    loader: ({ request }) => ({
+      title: 'Deferred',
+      use: new URL(request.url).searchParams.has('use'),
+      slow: fetch(new URL('/api/slow', request.url), { signal: request.signal }).then((response) =>
+        response.json(),
+      ),
+    }),
+  },
+];
+export const App = ({ children }) => <>{children}</>;

--- a/__fixtures__/browser-template/server.jsx
+++ b/__fixtures__/browser-template/server.jsx
@@ -1,0 +1,19 @@
+import { createStaticHandler } from 'react-router';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import { App, routes } from './routes.jsx';
+import React from 'react';
+export const handler = (html) =>
+  createHandler(
+    {
+      handler: createStaticHandler(routes),
+      createApp: (children) => <App>{children}</App>,
+      renderToStream,
+    },
+    {
+      hydration: 'early',
+      diagnostics: false,
+      getHtml: () => html,
+      getState: () => ({ custom: { ready: true } }),
+    },
+  );

--- a/__fixtures__/init/alias-wrapper/index.html.txt
+++ b/__fixtures__/init/alias-wrapper/index.html.txt
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/__fixtures__/init/alias-wrapper/package.json.txt
+++ b/__fixtures__/init/alias-wrapper/package.json.txt
@@ -1,0 +1,24 @@
+{
+  "name": "vite-react-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.1.1",
+    "vite": "8.2.2",
+    "typescript": "6.0.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.7"
+  }
+}

--- a/__fixtures__/init/alias-wrapper/src/About.tsx.txt
+++ b/__fixtures__/init/alias-wrapper/src/About.tsx.txt
@@ -1,0 +1,2 @@
+import './about.css'
+export function Component() { return <h1 className="about-page">About route rendered on server</h1> }

--- a/__fixtures__/init/alias-wrapper/src/App.tsx.txt
+++ b/__fixtures__/init/alias-wrapper/src/App.tsx.txt
@@ -1,0 +1,2 @@
+import type { PropsWithChildren } from 'react'
+export default function App({ children }: PropsWithChildren) { return <div className="app-wrapper">{children}</div> }

--- a/__fixtures__/init/alias-wrapper/src/Home.tsx.txt
+++ b/__fixtures__/init/alias-wrapper/src/Home.tsx.txt
@@ -1,0 +1,1 @@
+export default function Home() { return <h1>Home route</h1> }

--- a/__fixtures__/init/alias-wrapper/src/about.css.txt
+++ b/__fixtures__/init/alias-wrapper/src/about.css.txt
@@ -1,0 +1,1 @@
+.about-page { color: rgb(1, 2, 3); }

--- a/__fixtures__/init/alias-wrapper/src/index.css.txt
+++ b/__fixtures__/init/alias-wrapper/src/index.css.txt
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/__fixtures__/init/alias-wrapper/src/main.tsx.txt
+++ b/__fixtures__/init/alias-wrapper/src/main.tsx.txt
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router'
+import Home from '@/Home'
+import App from '@/App'
+import './index.css'
+
+const routes = [
+  { path: '/', Component: Home },
+  { path: '/about', lazy: () => import('@/About') },
+]
+const router = createBrowserRouter(routes)
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><App><RouterProvider router={router} /></App></StrictMode>,
+)

--- a/__fixtures__/init/alias-wrapper/src/vite-env.d.ts.txt
+++ b/__fixtures__/init/alias-wrapper/src/vite-env.d.ts.txt
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/__fixtures__/init/alias-wrapper/tsconfig.json.txt
+++ b/__fixtures__/init/alias-wrapper/tsconfig.json.txt
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/__fixtures__/init/alias-wrapper/vite.config.ts.txt
+++ b/__fixtures__/init/alias-wrapper/vite.config.ts.txt
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'node:url'
+import react from '@vitejs/plugin-react'
+
+// Keep the React plugin and this comment.
+export default defineConfig({
+  resolve: { alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) } },
+  plugins: [react()],
+})

--- a/__fixtures__/init/javascript/index.html.txt
+++ b/__fixtures__/init/javascript/index.html.txt
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/__fixtures__/init/javascript/package.json.txt
+++ b/__fixtures__/init/javascript/package.json.txt
@@ -1,0 +1,21 @@
+{
+  "name": "vite-react-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.1.1",
+    "vite": "8.2.2"
+  }
+}

--- a/__fixtures__/init/javascript/src/About.jsx.txt
+++ b/__fixtures__/init/javascript/src/About.jsx.txt
@@ -1,0 +1,2 @@
+import './about.css'
+export function Component() { return <h1 className="about-page">About route rendered on server</h1> }

--- a/__fixtures__/init/javascript/src/Home.jsx.txt
+++ b/__fixtures__/init/javascript/src/Home.jsx.txt
@@ -1,0 +1,1 @@
+export default function Home() { return <h1>Home route</h1> }

--- a/__fixtures__/init/javascript/src/about.css.txt
+++ b/__fixtures__/init/javascript/src/about.css.txt
@@ -1,0 +1,1 @@
+.about-page { color: rgb(1, 2, 3); }

--- a/__fixtures__/init/javascript/src/index.css.txt
+++ b/__fixtures__/init/javascript/src/index.css.txt
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/__fixtures__/init/javascript/src/main.jsx.txt
+++ b/__fixtures__/init/javascript/src/main.jsx.txt
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router'
+import Home from './Home'
+import './index.css'
+
+const routes = [
+  { path: '/', Component: Home },
+  { path: '/about', lazy: () => import('./About') },
+]
+const router = createBrowserRouter(routes)
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode><RouterProvider router={router} /></StrictMode>,
+)

--- a/__fixtures__/init/javascript/vite.config.js.txt
+++ b/__fixtures__/init/javascript/vite.config.js.txt
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Keep the React plugin and this comment.
+export default defineConfig({
+  plugins: [react()],
+})

--- a/__fixtures__/init/root-inline/index.html.txt
+++ b/__fixtures__/init/root-inline/index.html.txt
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/__fixtures__/init/root-inline/package.json.txt
+++ b/__fixtures__/init/root-inline/package.json.txt
@@ -1,0 +1,24 @@
+{
+  "name": "vite-react-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.1.1",
+    "vite": "8.2.2",
+    "typescript": "6.0.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.7"
+  }
+}

--- a/__fixtures__/init/root-inline/src/About.tsx.txt
+++ b/__fixtures__/init/root-inline/src/About.tsx.txt
@@ -1,0 +1,2 @@
+import './about.css'
+export function Component() { return <h1 className="about-page">About route rendered on server</h1> }

--- a/__fixtures__/init/root-inline/src/Home.tsx.txt
+++ b/__fixtures__/init/root-inline/src/Home.tsx.txt
@@ -1,0 +1,1 @@
+export default function Home() { return <h1>Home route</h1> }

--- a/__fixtures__/init/root-inline/src/about.css.txt
+++ b/__fixtures__/init/root-inline/src/about.css.txt
@@ -1,0 +1,1 @@
+.about-page { color: rgb(1, 2, 3); }

--- a/__fixtures__/init/root-inline/src/index.css.txt
+++ b/__fixtures__/init/root-inline/src/index.css.txt
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/__fixtures__/init/root-inline/src/main.tsx.txt
+++ b/__fixtures__/init/root-inline/src/main.tsx.txt
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router'
+import Home from './Home'
+import './index.css'
+
+const routes = [
+  { path: '/', Component: Home },
+  { path: '/about', lazy: () => import('./About') },
+]
+const router = createBrowserRouter(routes)
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><RouterProvider router={router} /></StrictMode>,
+)

--- a/__fixtures__/init/root-inline/src/vite-env.d.ts.txt
+++ b/__fixtures__/init/root-inline/src/vite-env.d.ts.txt
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/__fixtures__/init/root-inline/tsconfig.json.txt
+++ b/__fixtures__/init/root-inline/tsconfig.json.txt
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/__fixtures__/init/root-inline/vite.config.ts.txt
+++ b/__fixtures__/init/root-inline/vite.config.ts.txt
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Keep the React plugin and this comment.
+export default defineConfig({
+  plugins: [react()],
+})

--- a/__fixtures__/init/src-export/package.json.txt
+++ b/__fixtures__/init/src-export/package.json.txt
@@ -1,0 +1,24 @@
+{
+  "name": "vite-react-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-router": "8.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.1.1",
+    "vite": "8.2.2",
+    "typescript": "6.0.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.7"
+  }
+}

--- a/__fixtures__/init/src-export/src/About.tsx.txt
+++ b/__fixtures__/init/src-export/src/About.tsx.txt
@@ -1,0 +1,2 @@
+import './about.css'
+export function Component() { return <h1 className="about-page">About route rendered on server</h1> }

--- a/__fixtures__/init/src-export/src/Home.tsx.txt
+++ b/__fixtures__/init/src-export/src/Home.tsx.txt
@@ -1,0 +1,1 @@
+export default function Home() { return <h1>Home route</h1> }

--- a/__fixtures__/init/src-export/src/about.css.txt
+++ b/__fixtures__/init/src-export/src/about.css.txt
@@ -1,0 +1,1 @@
+.about-page { color: rgb(1, 2, 3); }

--- a/__fixtures__/init/src-export/src/index.css.txt
+++ b/__fixtures__/init/src-export/src/index.css.txt
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/__fixtures__/init/src-export/src/index.html.txt
+++ b/__fixtures__/init/src-export/src/index.html.txt
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/__fixtures__/init/src-export/src/main.tsx.txt
+++ b/__fixtures__/init/src-export/src/main.tsx.txt
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router'
+import { appRoutes as routes } from './routes'
+import './index.css'
+
+const router = createBrowserRouter(routes)
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><RouterProvider router={router} /></StrictMode>,
+)

--- a/__fixtures__/init/src-export/src/routes.ts.txt
+++ b/__fixtures__/init/src-export/src/routes.ts.txt
@@ -1,0 +1,5 @@
+import Home from './Home'
+export const appRoutes = [
+  { path: '/', Component: Home },
+  { id: 'about', path: '/about', lazy: () => import('./About') },
+] satisfies import('react-router').RouteObject[]

--- a/__fixtures__/init/src-export/src/vite-env.d.ts.txt
+++ b/__fixtures__/init/src-export/src/vite-env.d.ts.txt
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/__fixtures__/init/src-export/tsconfig.json.txt
+++ b/__fixtures__/init/src-export/tsconfig.json.txt
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/__fixtures__/init/src-export/vite.config.ts.txt
+++ b/__fixtures__/init/src-export/vite.config.ts.txt
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Keep the React plugin and this comment.
+export default defineConfig({
+  root: 'src',
+  publicDir: '../public',
+  build: { outDir: '../dist' },
+  plugins: [react()],
+})

--- a/__fixtures__/init/stock-react-ts/index.html.txt
+++ b/__fixtures__/init/stock-react-ts/index.html.txt
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/__fixtures__/init/stock-react-ts/package.json.txt
+++ b/__fixtures__/init/stock-react-ts/package.json.txt
@@ -1,0 +1,23 @@
+{
+  "name": "vite-react-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "6.1.1",
+    "vite": "8.2.2",
+    "typescript": "6.0.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.7"
+  }
+}

--- a/__fixtures__/init/stock-react-ts/src/App.tsx.txt
+++ b/__fixtures__/init/stock-react-ts/src/App.tsx.txt
@@ -1,0 +1,8 @@
+import { useState } from 'react'
+
+function App() {
+  const [count, setCount] = useState(0)
+  return <main><h1>Vite + React</h1><button onClick={() => setCount(count + 1)}>count is {count}</button></main>
+}
+
+export default App

--- a/__fixtures__/init/stock-react-ts/src/index.css.txt
+++ b/__fixtures__/init/stock-react-ts/src/index.css.txt
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/__fixtures__/init/stock-react-ts/src/main.tsx.txt
+++ b/__fixtures__/init/stock-react-ts/src/main.tsx.txt
@@ -1,0 +1,8 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><App /></StrictMode>,
+)

--- a/__fixtures__/init/stock-react-ts/src/vite-env.d.ts.txt
+++ b/__fixtures__/init/stock-react-ts/src/vite-env.d.ts.txt
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/__fixtures__/init/stock-react-ts/tsconfig.json.txt
+++ b/__fixtures__/init/stock-react-ts/tsconfig.json.txt
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/__fixtures__/init/stock-react-ts/vite.config.ts.txt
+++ b/__fixtures__/init/stock-react-ts/vite.config.ts.txt
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Keep the React plugin and this comment.
+export default defineConfig({
+  plugins: [react()],
+})

--- a/__fixtures__/routes/computed-keys.json
+++ b/__fixtures__/routes/computed-keys.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default [{ ['path']: '/about', ['id']: 'about', ['lazy']: () => import('./About') }];\n"
+}

--- a/__fixtures__/routes/default-alias.json
+++ b/__fixtures__/routes/default-alias.json
@@ -1,0 +1,4 @@
+{
+  "client": "import boot from '@lomray/vite-ssr-boost/browser/entry';\nimport routes from './routes';\nvoid boot(App, routes);\n",
+  "routes": "export default [{ path: '/about', lazy: () => import('./About') }];\n"
+}

--- a/__fixtures__/routes/explicit-id.json
+++ b/__fixtures__/routes/explicit-id.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default [{ id: 'layout', children: [{ path: '/skipped' }, { id: 'about', path: '/about', lazy: () => import('./About') }] }];\n"
+}

--- a/__fixtures__/routes/imported-children.json
+++ b/__fixtures__/routes/imported-children.json
@@ -1,0 +1,6 @@
+{
+  "routes": "import { childRoutes as children } from './nested/children';\nexport default [{ children }];\n",
+  "files": {
+    "nested/children.ts": "const routes = [{ path: '/about', lazy: () => import('../About') }];\nexport { routes as childRoutes };\n"
+  }
+}

--- a/__fixtures__/routes/lazy-function.json
+++ b/__fixtures__/routes/lazy-function.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default [{ path: '/about', lazy: async function () { return await import('./About'); } }];\n"
+}

--- a/__fixtures__/routes/lazy-then.json
+++ b/__fixtures__/routes/lazy-then.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default [{ path: '/about', lazy: () => import('./About').then(module => ({ Component: module.Component })) }];\n"
+}

--- a/__fixtures__/routes/named-alias.json
+++ b/__fixtures__/routes/named-alias.json
@@ -1,0 +1,4 @@
+{
+  "client": "import { entry as boot } from '@lomray/vite-ssr-boost/browser/entry';\nimport { list as routes } from './routes';\nvoid boot(App, routes);\n",
+  "routes": "const appRoutes = [{ path: '/about', lazy: () => import('./About') }];\nexport { appRoutes as list };\n"
+}

--- a/__fixtures__/routes/object-spread.json
+++ b/__fixtures__/routes/object-spread.json
@@ -1,0 +1,6 @@
+{
+  "routes": "import { shared as defaults } from './shared';\nexport default [{ ...defaults, id: 'about', path: '/about' }];\n",
+  "files": {
+    "shared.ts": "export const shared = { lazy: () => import('./About'), handle: { title: 'Do not include app data in a bundle' } };\n"
+  }
+}

--- a/__fixtures__/routes/skipped-position.json
+++ b/__fixtures__/routes/skipped-position.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default [{ path: '/skipped' }, { id: 'parent', children: [{ path: '/also-skipped' }, { path: '/about', lazy: () => import('./About') }] }];\n"
+}

--- a/__fixtures__/routes/wrapped-arrays.json
+++ b/__fixtures__/routes/wrapped-arrays.json
@@ -1,0 +1,3 @@
+{
+  "routes": "export default ([{ children: ([{ path: '/about', lazy: () => import('./About') }] as import('react-router').RouteObject[]) }] satisfies import('react-router').RouteObject[])!;\n"
+}

--- a/__helpers__/data-stream.tsx
+++ b/__helpers__/data-stream.tsx
@@ -1,0 +1,210 @@
+import React, { Suspense } from 'react';
+import {
+  Await,
+  createStaticHandler,
+  useActionData,
+  useAsyncError,
+  useLoaderData,
+} from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import createHandler from '@core/handler';
+import type { ICreateHandlerOptions } from '@core/handler';
+import type { TRenderToStream } from '@core/render';
+
+const ErrorElement = () => <p data-error>{(useAsyncError() as Error).message}</p>;
+const Page = () => {
+  const action = useActionData() as { slow: Promise<string> } | undefined;
+  const loader = useLoaderData() as { slow: Promise<string> };
+  const value = action ?? loader;
+  return (
+    <main>
+      <button>Shell</button>
+      <Suspense fallback={<p data-fallback>Loading</p>}>
+        <Await resolve={value.slow} errorElement={<ErrorElement />}>
+          {(text) => <p data-resolved>{text}</p>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+};
+const fixture = (
+  renderer: TRenderToStream,
+  options: Partial<ICreateHandlerOptions<Record<string, any>>> = {},
+  loader = () => ({
+    slow: new Promise<string>((resolve) => setTimeout(() => resolve('Resolved users: 3'), 150)),
+  }),
+  Component = Page,
+) =>
+  createHandler(
+    {
+      createApp: (children) => children,
+      handler: createStaticHandler([{ id: 'root', path: '*', Component, loader, action: loader }]),
+      renderToStream: renderer,
+    },
+    {
+      diagnostics: false,
+      getHtml: () => ({
+        header: '<!doctype html><html><body><div id="root">',
+        footer: '</div></body></html>',
+      }),
+      ...options,
+    },
+  );
+const chunks = async (response: Response) => {
+  const result: { html: string; time: number }[] = [];
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    result.push({ html: decoder.decode(chunk.value), time: performance.now() });
+  }
+  return result;
+};
+
+const testDataStream = (name: string, renderer: TRenderToStream): void => {
+  describe(`real React loader/action streaming (${name})`, () => {
+    it.each(['GET', 'POST'])(
+      'streams fallback and settlements before footer initialization for %s',
+      async (method) => {
+        const start = performance.now();
+        const parts = await chunks(
+          await fixture(renderer, { getState: () => ({ custom: { ready: true } }) })(
+            new Request('http://test/deferred', { method }),
+          ),
+        );
+        const html = parts.map((part) => part.html).join('');
+        expect(parts[0].html).not.toContain('SSRBPromise');
+        expect(parts[0].html).not.toContain('window.__staticRouterHydrationData');
+        expect(html.indexOf('SSRBPromise')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+        expect(html.indexOf('["resolve"')).toBeLessThan(html.indexOf('<p data-resolved'));
+        expect(html).toContain('Resolved users: 3');
+        expect(html.indexOf('data-fallback')).toBeLessThan(html.indexOf('["resolve"'));
+        expect(html.indexOf('window.__staticRouterHydrationData')).toBeGreaterThan(
+          html.indexOf('<p data-resolved'),
+        );
+        expect(html.indexOf('window.custom')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+        expect(html.indexOf('window.custom')).toBeLessThan(
+          html.indexOf('window.__staticRouterHydrationData'),
+        );
+        expect(
+          parts.find((part) => part.html.includes('["resolve"'))!.time - start,
+        ).toBeGreaterThanOrEqual(130);
+      },
+    );
+
+    it('streams rejection details and Await errorElement HTML', async () => {
+      const handler = fixture(renderer, {}, () => ({
+        slow: new Promise<string>((_, reject) =>
+          setTimeout(() => reject(new Error('Deferred failed')), 40),
+        ),
+      }));
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject"');
+      expect(html).toContain('Deferred failed');
+      expect(html).toContain('<p data-error');
+      expect(html).not.toContain('data-resolved');
+    });
+
+    it('keeps two simultaneous request identities and results isolated', async () => {
+      let count = 0;
+      const handler = fixture(renderer, {}, () => {
+        const id = ++count;
+        return {
+          slow: new Promise<string>((resolve) =>
+            setTimeout(() => resolve(`request-${id}`), id === 1 ? 70 : 20),
+          ),
+        };
+      });
+      const [first, second] = await Promise.all([
+        handler(new Request('http://test/one')).then((r) => r.text()),
+        handler(new Request('http://test/two')).then((r) => r.text()),
+      ]);
+      expect(first).toContain('request-1');
+      expect(first).not.toContain('request-2');
+      expect(second).toContain('request-2');
+      expect(second).not.toContain('request-1');
+      expect(first).toContain('["resolve",0');
+      expect(second).toContain('["resolve",0');
+    });
+
+    it('rejects pending promises before the timeout closes the response', async () => {
+      const onError = vi.fn();
+      const handler = fixture(renderer, { abortDelay: 40, onError }, () => ({
+        slow: new Promise<string>(() => undefined),
+      }));
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject",0');
+      expect(html).toContain('SSR loader/action promise aborted');
+      expect(html.endsWith('</html>')).toBe(true);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('keeps the deadline for pending loader data that React never reads', async () => {
+      const handler = fixture(
+        renderer,
+        { abortDelay: 40 },
+        () => ({ slow: new Promise<string>(() => undefined) }),
+        () => <p>no boundary</p>,
+      );
+      const html = await (await handler(new Request('http://test/'))).text();
+      expect(html).toContain('["reject",0');
+      expect(html).toContain('no boundary');
+    });
+
+    it('buffers bot rendering until both React and unconsumed data settle', async () => {
+      const start = performance.now();
+      const handler = fixture(renderer, { onRouterReady: () => ({ isStream: false }) });
+      const response = await handler(
+        new Request('http://test/', { headers: { 'User-Agent': 'Googlebot' } }),
+      );
+      expect(performance.now() - start).toBeGreaterThanOrEqual(130);
+      const html = await response.text();
+      expect(html).toContain('<p data-resolved');
+      expect(html).toContain('Resolved users: 3');
+      expect(html).not.toContain('<!--$?-->');
+      expect(html.indexOf('["init"')).toBeGreaterThan(html.indexOf('<p data-resolved'));
+      expect(html).toContain('["resolve",0');
+    });
+
+    it('emits custom state before early state and a shell marker before boundary chunks', async () => {
+      const getState = vi.fn(() => ({ custom: { ready: true } }));
+      const handler = fixture(renderer, { hydration: 'early', getState, nonce: 'test-nonce' });
+      const parts = await chunks(await handler(new Request('http://test/')));
+      const html = parts.map((part) => part.html).join('');
+      expect(parts[0].html).toContain('window.custom');
+      expect(parts[0].html).toContain('window.__staticRouterHydrationData');
+      expect(parts[0].html).toContain('SSRBPromise');
+      expect(html.indexOf('SSRBPromise')).toBeLessThan(html.indexOf('<main>'));
+      expect(html.indexOf('["resolve"')).toBeLessThan(html.indexOf('<p data-resolved'));
+      expect(html.indexOf('window.custom')).toBeLessThan(
+        html.indexOf('window.__staticRouterHydrationData'),
+      );
+      expect(html.indexOf('<button>Shell')).toBeLessThan(html.indexOf('["shell"]'));
+      expect(html.indexOf('["shell"]')).toBeLessThan(html.indexOf('<p data-resolved'));
+      expect(getState).toHaveBeenCalledTimes(1);
+      for (const [tag] of html.matchAll(/<script[^>]*>/g))
+        expect(tag).toContain('nonce="test-nonce"');
+    });
+
+    it.skipIf(!React.use)('supports React 19 use with a native loader promise', async () => {
+      const UsePage = () => {
+        const { slow } = useLoaderData() as { slow: Promise<string> };
+        const Content = () => <p data-use>{React.use(slow)}</p>;
+        return (
+          <Suspense fallback={<p>use fallback</p>}>
+            <Content />
+          </Suspense>
+        );
+      };
+      const html = await (
+        await fixture(renderer, {}, undefined, UsePage)(new Request('http://test/'))
+      ).text();
+      expect(html).toContain('<p data-use');
+      expect(html).toContain('Resolved users: 3');
+      expect(html).toContain('["resolve",0');
+    });
+  });
+};
+
+export default testDataStream;

--- a/__helpers__/project-fixture.ts
+++ b/__helpers__/project-fixture.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Copy source-only fixtures into disposable projects. */
+export const copyFixture = (layout: string): string => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ssr-boost-init-test-'));
+  const source = path.resolve('__fixtures__/init', layout);
+
+  for (const file of fs.readdirSync(source, { recursive: true, encoding: 'utf8' })) {
+    if (!file.endsWith('.txt')) {
+      continue;
+    }
+
+    const destination = path.join(directory, file.slice(0, -4));
+
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(source, file), destination);
+  }
+
+  return directory;
+};
+
+export const writeFixture = (root: string, file: string, value: string): void => {
+  fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+  fs.writeFileSync(path.join(root, file), value);
+};
+
+export interface IRouteFixture {
+  client?: string;
+  routes: string;
+  files?: Record<string, string>;
+}
+
+export const routeFixtures = fs.readdirSync(path.resolve('__fixtures__/routes')).map((file) => ({
+  name: file.replace('.json', ''),
+  ...(JSON.parse(
+    fs.readFileSync(path.resolve('__fixtures__/routes', file), 'utf8'),
+  ) as IRouteFixture),
+}));
+
+export const writeRouteFixture = (root: string, fixture: IRouteFixture): void => {
+  writeFixture(
+    root,
+    'client.ts',
+    `import { Fragment as App } from 'react';\n${fixture.client ?? "import boot from '@lomray/vite-ssr-boost/browser/entry';\nimport routes from './routes';\nvoid boot(App, routes);\n"}`,
+  );
+  writeFixture(root, 'routes.ts', fixture.routes);
+  writeFixture(root, 'About.tsx', 'export function Component() { return <h1>About route</h1>; }\n');
+
+  for (const [file, content] of Object.entries(fixture.files ?? {})) {
+    writeFixture(root, file, content);
+  }
+};

--- a/__tests__/__snapshots__/init.ts.snap
+++ b/__tests__/__snapshots__/init.ts.snap
@@ -1,0 +1,438 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`init > alias-wrapper has a complete dry-run diff and applies idempotently 1`] = `
+"===================================================================
+--- a/index.html
++++ b/index.html
+@@ -1,8 +1,8 @@
+ <!doctype html>
+ <html lang="en">
+   <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+   <body>
+-    <div id="root"></div>
++    <div id="root"><!--ssr-outlet--></div>
+     <script type="module" src="/src/main.tsx"></script>
+   </body>
+ </html>
+
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -3,17 +3,19 @@
+   "private": true,
+   "version": "0.0.0",
+   "type": "module",
+   "scripts": {
+-    "dev": "vite",
+-    "build": "tsc -b && vite build",
+-    "preview": "vite preview",
+-    "lint": "eslint ."
++    "dev": "ssr-boost dev",
++    "build": "ssr-boost build",
++    "preview": "ssr-boost preview",
++    "lint": "eslint .",
++    "start:ssr": "ssr-boost start"
+   },
+   "dependencies": {
+     "react": "19.2.8",
+     "react-dom": "19.2.8",
+-    "react-router": "8.3.1"
++    "react-router": "8.3.1",
++    "@lomray/vite-ssr-boost": "^1.0.0"
+   },
+   "devDependencies": {
+     "@vitejs/plugin-react": "6.1.1",
+     "vite": "8.2.2",
+
+===================================================================
+--- a/src/main.tsx
++++ b/src/main.tsx
+@@ -1,16 +1,10 @@
++import entryClient from '@lomray/vite-ssr-boost/browser/entry'
+ import { StrictMode } from 'react'
+-import { createRoot } from 'react-dom/client'
+-import { createBrowserRouter, RouterProvider } from 'react-router'
+-import Home from '@/Home'
+ import App from '@/App'
++import type { FC, PropsWithChildren } from 'react'
++import routes from './routes.ssr'
+ import './index.css'
+ 
+-const routes = [
+-  { path: '/', Component: Home },
+-  { path: '/about', lazy: () => import('@/About') },
+-]
+-const router = createBrowserRouter(routes)
++const App_: FC<PropsWithChildren> = ({ children }) => <StrictMode><App>{children}</App></StrictMode>
+ 
+-createRoot(document.getElementById('root')!).render(
+-  <StrictMode><App><RouterProvider router={router} /></App></StrictMode>,
+-)
++void entryClient(App_, routes)
+
+===================================================================
+--- /dev/null
++++ b/src/routes.ssr.tsx
+@@ -0,0 +1,6 @@
++import Home from '@/Home'
++
++export default [
++  { path: '/', Component: Home },
++  { path: '/about', lazy: () => import('@/About') },
++] satisfies import('react-router').RouteObject[]
+
+===================================================================
+--- /dev/null
++++ b/src/server.ts
+@@ -0,0 +1,10 @@
++import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry'
++import { StrictMode } from 'react'
++import App from '@/App'
++import type { FC, PropsWithChildren } from 'react'
++import { createElement as ssrCreateElement } from 'react'
++import routes from './routes.ssr'
++
++const App_: FC<PropsWithChildren> = ({ children }) => ssrCreateElement(StrictMode, null, ssrCreateElement(App, null, children))
++
++export default entryServer(App_, routes)
+
+===================================================================
+--- a/vite.config.ts
++++ b/vite.config.ts
+@@ -1,9 +1,10 @@
++import SsrBoost from '@lomray/vite-ssr-boost/plugin'
+ import { defineConfig } from 'vite'
+ import { fileURLToPath, URL } from 'node:url'
+ import react from '@vitejs/plugin-react'
+ 
+ // Keep the React plugin and this comment.
+ export default defineConfig({
+   resolve: { alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) } },
+-  plugins: [react()],
++  plugins: [SsrBoost({ clientFile: 'src/main.tsx', serverFile: 'src/server.ts' }), react()],
+ })
+
+Dry run: no files written. Use --apply to write these changes.
+Next: npm install; then npx ssr-boost doctor."
+`;
+
+exports[`init > javascript has a complete dry-run diff and applies idempotently 1`] = `
+"===================================================================
+--- a/index.html
++++ b/index.html
+@@ -1,8 +1,8 @@
+ <!doctype html>
+ <html lang="en">
+   <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+   <body>
+-    <div id="root"></div>
++    <div id="root"><!--ssr-outlet--></div>
+     <script type="module" src="/src/main.jsx"></script>
+   </body>
+ </html>
+
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -3,17 +3,19 @@
+   "private": true,
+   "version": "0.0.0",
+   "type": "module",
+   "scripts": {
+-    "dev": "vite",
+-    "build": "vite build",
+-    "preview": "vite preview",
+-    "lint": "eslint ."
++    "dev": "ssr-boost dev",
++    "build": "ssr-boost build",
++    "preview": "ssr-boost preview",
++    "lint": "eslint .",
++    "start:ssr": "ssr-boost start"
+   },
+   "dependencies": {
+     "react": "19.2.8",
+     "react-dom": "19.2.8",
+-    "react-router": "8.3.1"
++    "react-router": "8.3.1",
++    "@lomray/vite-ssr-boost": "^1.0.0"
+   },
+   "devDependencies": {
+     "@vitejs/plugin-react": "6.1.1",
+     "vite": "8.2.2"
+
+===================================================================
+--- a/src/main.jsx
++++ b/src/main.jsx
+@@ -1,15 +1,8 @@
++import entryClient from '@lomray/vite-ssr-boost/browser/entry'
+ import { StrictMode } from 'react'
+-import { createRoot } from 'react-dom/client'
+-import { createBrowserRouter, RouterProvider } from 'react-router'
+-import Home from './Home'
++import routes from './routes.ssr'
+ import './index.css'
+ 
+-const routes = [
+-  { path: '/', Component: Home },
+-  { path: '/about', lazy: () => import('./About') },
+-]
+-const router = createBrowserRouter(routes)
++const App = ({ children }) => <StrictMode>{children}</StrictMode>
+ 
+-createRoot(document.getElementById('root')).render(
+-  <StrictMode><RouterProvider router={router} /></StrictMode>,
+-)
++void entryClient(App, routes)
+
+===================================================================
+--- /dev/null
++++ b/src/routes.ssr.jsx
+@@ -0,0 +1,6 @@
++import Home from './Home'
++
++export default [
++  { path: '/', Component: Home },
++  { path: '/about', lazy: () => import('./About') },
++]
+
+===================================================================
+--- /dev/null
++++ b/src/server.js
+@@ -0,0 +1,8 @@
++import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry'
++import { StrictMode } from 'react'
++import { createElement as ssrCreateElement } from 'react'
++import routes from './routes.ssr'
++
++const App = ({ children }) => ssrCreateElement(StrictMode, null, children)
++
++export default entryServer(App, routes)
+
+===================================================================
+--- a/vite.config.js
++++ b/vite.config.js
+@@ -1,7 +1,8 @@
++import SsrBoost from '@lomray/vite-ssr-boost/plugin'
+ import { defineConfig } from 'vite'
+ import react from '@vitejs/plugin-react'
+ 
+ // Keep the React plugin and this comment.
+ export default defineConfig({
+-  plugins: [react()],
++  plugins: [SsrBoost({ clientFile: 'src/main.jsx', serverFile: 'src/server.js', tsconfigAliases: false }), react()],
+ })
+
+Dry run: no files written. Use --apply to write these changes.
+Next: npm install; then npx ssr-boost doctor."
+`;
+
+exports[`init > root-inline has a complete dry-run diff and applies idempotently 1`] = `
+"===================================================================
+--- a/index.html
++++ b/index.html
+@@ -1,8 +1,8 @@
+ <!doctype html>
+ <html lang="en">
+   <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+   <body>
+-    <div id="root"></div>
++    <div id="root"><!--ssr-outlet--></div>
+     <script type="module" src="/src/main.tsx"></script>
+   </body>
+ </html>
+
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -3,17 +3,19 @@
+   "private": true,
+   "version": "0.0.0",
+   "type": "module",
+   "scripts": {
+-    "dev": "vite",
+-    "build": "tsc -b && vite build",
+-    "preview": "vite preview",
+-    "lint": "eslint ."
++    "dev": "ssr-boost dev",
++    "build": "ssr-boost build",
++    "preview": "ssr-boost preview",
++    "lint": "eslint .",
++    "start:ssr": "ssr-boost start"
+   },
+   "dependencies": {
+     "react": "19.2.8",
+     "react-dom": "19.2.8",
+-    "react-router": "8.3.1"
++    "react-router": "8.3.1",
++    "@lomray/vite-ssr-boost": "^1.0.0"
+   },
+   "devDependencies": {
+     "@vitejs/plugin-react": "6.1.1",
+     "vite": "8.2.2",
+
+===================================================================
+--- a/src/main.tsx
++++ b/src/main.tsx
+@@ -1,15 +1,9 @@
++import entryClient from '@lomray/vite-ssr-boost/browser/entry'
+ import { StrictMode } from 'react'
+-import { createRoot } from 'react-dom/client'
+-import { createBrowserRouter, RouterProvider } from 'react-router'
+-import Home from './Home'
++import type { FC, PropsWithChildren } from 'react'
++import routes from './routes.ssr'
+ import './index.css'
+ 
+-const routes = [
+-  { path: '/', Component: Home },
+-  { path: '/about', lazy: () => import('./About') },
+-]
+-const router = createBrowserRouter(routes)
++const App: FC<PropsWithChildren> = ({ children }) => <StrictMode>{children}</StrictMode>
+ 
+-createRoot(document.getElementById('root')!).render(
+-  <StrictMode><RouterProvider router={router} /></StrictMode>,
+-)
++void entryClient(App, routes)
+
+===================================================================
+--- /dev/null
++++ b/src/routes.ssr.tsx
+@@ -0,0 +1,6 @@
++import Home from './Home'
++
++export default [
++  { path: '/', Component: Home },
++  { path: '/about', lazy: () => import('./About') },
++] satisfies import('react-router').RouteObject[]
+
+===================================================================
+--- /dev/null
++++ b/src/server.ts
+@@ -0,0 +1,9 @@
++import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry'
++import { StrictMode } from 'react'
++import type { FC, PropsWithChildren } from 'react'
++import { createElement as ssrCreateElement } from 'react'
++import routes from './routes.ssr'
++
++const App: FC<PropsWithChildren> = ({ children }) => ssrCreateElement(StrictMode, null, children)
++
++export default entryServer(App, routes)
+
+===================================================================
+--- a/vite.config.ts
++++ b/vite.config.ts
+@@ -1,7 +1,8 @@
++import SsrBoost from '@lomray/vite-ssr-boost/plugin'
+ import { defineConfig } from 'vite'
+ import react from '@vitejs/plugin-react'
+ 
+ // Keep the React plugin and this comment.
+ export default defineConfig({
+-  plugins: [react()],
++  plugins: [SsrBoost({ clientFile: 'src/main.tsx', serverFile: 'src/server.ts' }), react()],
+ })
+
+Dry run: no files written. Use --apply to write these changes.
+Next: npm install; then npx ssr-boost doctor."
+`;
+
+exports[`init > src-export has a complete dry-run diff and applies idempotently 1`] = `
+"===================================================================
+--- a/package.json
++++ b/package.json
+@@ -3,17 +3,19 @@
+   "private": true,
+   "version": "0.0.0",
+   "type": "module",
+   "scripts": {
+-    "dev": "vite",
+-    "build": "tsc -b && vite build",
+-    "preview": "vite preview",
+-    "lint": "eslint ."
++    "dev": "ssr-boost dev",
++    "build": "ssr-boost build",
++    "preview": "ssr-boost preview",
++    "lint": "eslint .",
++    "start:ssr": "ssr-boost start"
+   },
+   "dependencies": {
+     "react": "19.2.8",
+     "react-dom": "19.2.8",
+-    "react-router": "8.3.1"
++    "react-router": "8.3.1",
++    "@lomray/vite-ssr-boost": "^1.0.0"
+   },
+   "devDependencies": {
+     "@vitejs/plugin-react": "6.1.1",
+     "vite": "8.2.2",
+
+===================================================================
+--- a/src/index.html
++++ b/src/index.html
+@@ -1,8 +1,8 @@
+ <!doctype html>
+ <html lang="en">
+   <head><meta charset="UTF-8" /><title>Vite + React</title></head>
+   <body>
+-    <div id="root"></div>
++    <div id="root"><!--ssr-outlet--></div>
+     <script type="module" src="/main.tsx"></script>
+   </body>
+ </html>
+
+===================================================================
+--- a/src/main.tsx
++++ b/src/main.tsx
+@@ -1,11 +1,9 @@
++import entryClient from '@lomray/vite-ssr-boost/browser/entry'
+ import { StrictMode } from 'react'
+-import { createRoot } from 'react-dom/client'
+-import { createBrowserRouter, RouterProvider } from 'react-router'
++import type { FC, PropsWithChildren } from 'react'
+ import { appRoutes as routes } from './routes'
+ import './index.css'
+ 
+-const router = createBrowserRouter(routes)
++const App: FC<PropsWithChildren> = ({ children }) => <StrictMode>{children}</StrictMode>
+ 
+-createRoot(document.getElementById('root')!).render(
+-  <StrictMode><RouterProvider router={router} /></StrictMode>,
+-)
++void entryClient(App, routes)
+
+===================================================================
+--- /dev/null
++++ b/src/server.ts
+@@ -0,0 +1,9 @@
++import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry'
++import { StrictMode } from 'react'
++import type { FC, PropsWithChildren } from 'react'
++import { createElement as ssrCreateElement } from 'react'
++import { appRoutes as routes } from './routes'
++
++const App: FC<PropsWithChildren> = ({ children }) => ssrCreateElement(StrictMode, null, children)
++
++export default entryServer(App, routes)
+
+===================================================================
+--- a/vite.config.ts
++++ b/vite.config.ts
+@@ -1,10 +1,11 @@
++import SsrBoost from '@lomray/vite-ssr-boost/plugin'
+ import { defineConfig } from 'vite'
+ import react from '@vitejs/plugin-react'
+ 
+ // Keep the React plugin and this comment.
+ export default defineConfig({
+   root: 'src',
+   publicDir: '../public',
+   build: { outDir: '../dist' },
+-  plugins: [react()],
++  plugins: [SsrBoost({ clientFile: 'main.tsx', serverFile: 'server.ts' }), react()],
+ })
+
+Dry run: no files written. Use --apply to write these changes.
+Next: npm install; then npx ssr-boost doctor."
+`;

--- a/__tests__/browser/stream-hydration.tsx
+++ b/__tests__/browser/stream-hydration.tsx
@@ -1,0 +1,78 @@
+import React, { Suspense, useState } from 'react';
+import type { Root } from 'react-dom/client';
+import { Await, useLoaderData } from 'react-router';
+import { afterEach, expect, it, vi } from 'vitest';
+import entry from '@browser/entry';
+import DataStream from '@core/data-stream';
+import { streamScript } from '@core/script';
+
+let root: Root | void;
+const App = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+const Counter = () => {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>Count {count}</button>;
+};
+const Page = () => {
+  const { slow } = useLoaderData() as { slow: Promise<string> };
+  return (
+    <main>
+      <Counter />
+      <Suspense fallback={<p>Loading users</p>}>
+        <Await resolve={slow}>{(value) => <p data-resolved>{value}</p>}</Await>
+      </Suspense>
+    </main>
+  );
+};
+const scripts = () => {
+  for (const script of [...document.querySelectorAll('script')]) {
+    Object.defineProperty(document, 'currentScript', { configurable: true, value: script });
+    new Function(script.textContent ?? '')();
+  }
+  Reflect.deleteProperty(document, 'currentScript');
+};
+
+afterEach(() => {
+  root?.unmount();
+  root = undefined;
+  document.body.innerHTML = '';
+  Reflect.deleteProperty(window, '__ssrBoostStream');
+  Reflect.deleteProperty(window, '__staticRouterHydrationData');
+  Reflect.deleteProperty(window, 'custom');
+  vi.restoreAllMocks();
+});
+
+it('hydrates and clicks the shell before deferred frames are applied', async () => {
+  let resolve!: (value: string) => void;
+  const slow = new Promise<string>((res) => {
+    resolve = res;
+  });
+  vi.spyOn(document, 'readyState', 'get').mockReturnValue('loading');
+  const routes = [{ id: 'root', path: '/', Component: Page, loader: () => ({ slow }) }];
+  const stream = new DataStream({
+    loaderData: { root: { slow } },
+    actionData: null,
+    errors: null,
+  } as never);
+  // Fizz's pending shell shape. Real Node/edge byte ordering is covered in the Node and edge integration suites.
+  document.body.innerHTML = `<div id="root">${stream.state(true)}<main><button>Count <!-- -->0</button><!--$?--><template id="B:0"></template><p>Loading users</p><!--/$--></main>${streamScript(['shell'])}</div>`;
+  Reflect.set(window, 'custom', { ready: true });
+  scripts();
+  const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  root = await entry(App, routes, {
+    init: async ({ router }) => {
+      expect(Reflect.get(window, 'custom')).toEqual({ ready: true });
+      expect((router.state.loaderData['root'] as any).slow).toBeInstanceOf(Promise);
+    },
+  });
+  document.querySelector('button')!.click();
+  await vi.waitFor(() => {
+    expect(document.querySelector('button')!.textContent).toBe('Count 1');
+  });
+  expect(document.body.textContent).toContain('Loading users');
+  expect(errors).not.toHaveBeenCalled();
+  resolve('Users: 3');
+  await stream.done;
+  document.getElementById('root')!.insertAdjacentHTML('beforeend', stream.take());
+  scripts();
+  expect(errors).not.toHaveBeenCalled();
+});

--- a/__tests__/core/data-stream.ts
+++ b/__tests__/core/data-stream.ts
@@ -1,0 +1,231 @@
+import { data, type StaticHandlerContext } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import receiveStream from '@browser/stream';
+import DataStream from '@core/data-stream';
+import { streamScript } from '@core/script';
+import Diagnostics from '@services/diagnostics';
+
+const context = (loaderData: unknown, actionData: unknown = null) =>
+  ({ loaderData, actionData, errors: null }) as StaticHandlerContext;
+const deferred = () => {
+  let resolve!: (value: any) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+const runScripts = (html: string) => {
+  for (const [, code] of html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)) {
+    new Function('window', code)(window);
+  }
+};
+
+afterEach(() => {
+  Reflect.deleteProperty(window, '__ssrBoostStream');
+  Reflect.deleteProperty(window, '__staticRouterHydrationData');
+});
+
+describe('loader/action stream codec', () => {
+  it.each(['before', 'after'])(
+    'restores stable placeholders when entry runs %s the scripts',
+    async (entryTime) => {
+      const slow = deferred();
+      const stream = new DataStream(
+        context(
+          { root: slow.promise, nested: [{ slow: slow.promise }] },
+          { root: { slow: slow.promise } },
+        ),
+      );
+      const receiver = entryTime === 'before' ? receiveStream() : undefined;
+      runScripts(await stream.state(false));
+      const state = (await (receiver ?? receiveStream()).ready) as any;
+      expect(state.loaderData.root).toBeInstanceOf(Promise);
+      expect(state.loaderData.root).toBe(state.loaderData.nested[0].slow);
+      expect(state.actionData.root.slow).toBe(state.loaderData.root);
+      slow.resolve({ nested: Promise.resolve({ answer: 42 }) });
+      await stream.done;
+      runScripts(await stream.take());
+      const result = await state.loaderData.root;
+      expect(result.nested).toBeInstanceOf(Promise);
+      expect(await result.nested).toEqual({ answer: 42 });
+    },
+  );
+
+  it.each(['before', 'after'])(
+    'restores settlements preceding footer initialization when entry runs %s the scripts',
+    async (entryTime) => {
+      const slow = deferred();
+      const stream = new DataStream(context({ root: { slow: slow.promise } }));
+      const receiver = entryTime === 'before' ? receiveStream() : undefined;
+      slow.resolve({ nested: Promise.resolve({ answer: 42 }) });
+      await stream.done;
+      runScripts(stream.take());
+      runScripts(stream.state(false));
+      const state = (await (receiver ?? receiveStream()).ready) as any;
+      expect(state.loaderData.root.slow).toBeInstanceOf(Promise);
+      const result = await state.loaderData.root.slow;
+      expect(result.nested).toBeInstanceOf(Promise);
+      expect(await result.nested).toEqual({ answer: 42 });
+    },
+  );
+
+  it('supports the same value matrix initially and inside settlements', async () => {
+    const value = {
+      json: { string: 'value', number: 3, boolean: true, null: null, array: [1, null] },
+      date: new Date('2026-09-01'),
+      map: new Map([[{ key: 1 }, ['value']]]),
+      set: new Set([1, 'two']),
+      missing: undefined,
+      big: 9007199254740993n,
+      regex: /<script>/gi,
+    };
+    const slow = deferred();
+    const stream = new DataStream(
+      context({ root: { value, slow: slow.promise } }, { root: { value } }),
+    );
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root.value).toEqual(value);
+    expect(state.actionData.root.value).toEqual(value);
+    slow.resolve(value);
+    await stream.done;
+    runScripts(await stream.take());
+    expect(await state.loaderData.root.slow).toEqual(value);
+    expect(Object.hasOwn(state.loaderData.root.value, 'missing')).toBe(true);
+  });
+
+  it.each([
+    [new TypeError('ordinary failure'), { message: 'ordinary failure', name: 'TypeError' }],
+    [
+      { status: 409, statusText: 'Conflict', data: { reason: 'duplicate' }, internal: false },
+      { message: 'Conflict', status: 409, statusText: 'Conflict', data: { reason: 'duplicate' } },
+    ],
+    [
+      data({ reason: 'invalid' }, { status: 422, statusText: 'Unprocessable' }),
+      {
+        message: 'Unprocessable',
+        status: 422,
+        statusText: 'Unprocessable',
+        data: { reason: 'invalid' },
+      },
+    ],
+  ])('preserves rejection details %# without stacks by default', async (error, expected) => {
+    const slow = deferred();
+    const stream = new DataStream(context({}, { root: { slow: slow.promise } }));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    slow.reject(error);
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.actionData.root.slow).rejects.toMatchObject(expected);
+    expect(
+      (await state.actionData.root.slow.catch((failure: unknown) => failure)).stack,
+    ).toBeUndefined();
+  });
+
+  it('includes stacks only when diagnostics are enabled', async () => {
+    const slow = deferred();
+    const stream = new DataStream(context({ root: slow.promise }), new Diagnostics('/stack'));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    const error = new Error('with stack');
+    slow.reject(error);
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.loaderData.root).rejects.toHaveProperty('stack', error.stack);
+  });
+
+  it('escapes script terminators, comments, separators, keys and nonce attributes', async () => {
+    const attack = '</script><!--\u2028\u2029';
+    const slow = deferred();
+    const stream = new DataStream(
+      context({ [attack]: { slow: slow.promise, attack } }),
+      undefined,
+      '\"<>&',
+    );
+    const initial = await stream.state(false);
+    expect(initial.match(/<\/script>/g)).toHaveLength(2);
+    expect(initial).not.toContain('<!--');
+    expect(initial).not.toMatch(/[\u2028\u2029]/);
+    expect(initial).toContain('nonce="&#34;&#60;&#62;&#38;"');
+    runScripts(initial);
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData[attack].attack).toBe(attack);
+    slow.resolve({ attack });
+    await stream.done;
+    const settlement = await stream.take();
+    expect(settlement.match(/<\/script>/g)).toHaveLength(1);
+    expect(settlement).not.toContain('<!--');
+    runScripts(settlement);
+    expect(await state.loaderData[attack].slow).toEqual({ attack });
+  });
+
+  it('rejects pending promises on abort, ignores late settlements and emits one diagnostic', async () => {
+    const slow = deferred();
+    const warn = vi.fn();
+    const stream = new DataStream(
+      context({ root: slow.promise }),
+      new Diagnostics('/abort-codec', { warn }),
+    );
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    stream.abort();
+    stream.abort();
+    await stream.done;
+    runScripts(await stream.take());
+    await expect(state.loaderData.root).rejects.toThrow('SSR loader/action promise aborted');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('SSR_BOOST_STREAM_PROMISE_ABORTED');
+    slow.resolve('late');
+    await Promise.resolve();
+    expect(await stream.take()).toBe('');
+  });
+
+  it('waits for the parsed shell in early mode, including when shell arrives first', async () => {
+    const stream = new DataStream(context({ root: { title: 'early' } }));
+    const receiver = receiveStream();
+    const ready = vi.fn();
+    receiver.ready.then(ready);
+    runScripts(await stream.state(true));
+    await Promise.resolve();
+    expect(ready).not.toHaveBeenCalled();
+    runScripts(streamScript(['shell']));
+    await receiver.ready;
+    expect(ready).toHaveBeenCalled();
+  });
+
+  it('keeps prototype-shaped user keys as own data properties', async () => {
+    const value = JSON.parse('{"__proto__":{"polluted":true},"constructor":"safe"}');
+    const stream = new DataStream(context({ root: value }));
+    runScripts(await stream.state(false));
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root).toEqual(value);
+    expect(Object.getPrototypeOf(state.loaderData.root)).toBe(Object.prototype);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+});
+
+describe('stream data diagnostics', () => {
+  it('continues warning about unsupported functions, symbols, classes and cycles', async () => {
+    class Model {
+      value = 1;
+    }
+    const cycle: any = {};
+    cycle.self = cycle;
+    const warn = vi.fn();
+    const stream = new DataStream(
+      context({ root: { fn: () => 1, symbol: Symbol('x'), model: new Model(), cycle } }),
+      new Diagnostics('/unsupported-codec', { warn }),
+    );
+    runScripts(stream.state(false));
+    expect(warn).toHaveBeenCalledTimes(4);
+    expect(
+      warn.mock.calls.every(([message]) => message.includes('SSR_BOOST_LOADER_NOT_SERIALIZABLE')),
+    ).toBe(true);
+    const state = (await receiveStream().ready) as any;
+    expect(state.loaderData.root.fn).toBeUndefined();
+    expect(state.loaderData.root.cycle.self).toBe(state.loaderData.root.cycle);
+  });
+});

--- a/__tests__/core/diagnostics.ts
+++ b/__tests__/core/diagnostics.ts
@@ -71,17 +71,19 @@ afterEach(() => {
 
 describe('createHandler diagnostics', () => {
   it.each(['GET', 'POST'])('identifies the route and nested %s data path', async (method) => {
-    const handler = fixture({}, undefined, { items: [{ result: Promise.resolve(1) }] });
+    const handler = fixture({}, undefined, { items: [{ result: () => 1 }] });
     await (await handler(request(method))).text();
     const kind = method === 'POST' ? 'actionData' : 'loaderData';
     expect(messages()).toContain(
-      `[ssr-boost] SSR_BOOST_LOADER_NOT_SERIALIZABLE: Route "${pathname.slice(1)}" at ${kind}["${pathname.slice(1)}"].items[0].result: Promise is not JSON-serializable. See ${docs}ssr_boost_loader_not_serializable`,
+      `[ssr-boost] SSR_BOOST_LOADER_NOT_SERIALIZABLE: Route "${pathname.slice(1)}" at ${kind}["${pathname.slice(1)}"].items[0].result: function is not JSON-serializable. See ${docs}ssr_boost_loader_not_serializable`,
     );
   });
 
-  it('warns about BigInt before JSON serialization throws', async () => {
-    await expect(fixture({}, undefined, { count: 1n })(request())).rejects.toThrow(/BigInt/);
-    expect(messages()[0]).toContain('.count: BigInt is not JSON-serializable');
+  it('supports promises and BigInt without diagnostics', async () => {
+    await (
+      await fixture({}, undefined, { count: 1n, pending: Promise.resolve(1) })(request())
+    ).text();
+    expect(messages()).toEqual([]);
   });
 
   it('checks getState, including values omitted by the state builder', async () => {
@@ -262,7 +264,7 @@ describe('createHandler diagnostics', () => {
     }
   });
 
-  it('emits all six documented codes once across requests and handler instances', async () => {
+  it('deduplicates the six state/output codes across requests and handler instances', async () => {
     pathname = '/diagnostics-proof';
     const options = {
       getHtml: () => ({ header: '<html><head></head><body>', footer: undefined as never }),
@@ -275,7 +277,7 @@ describe('createHandler diagnostics', () => {
     };
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const handler = fixture(options, ['<head></head>', '<main>body</main>'], {
-        pending: Promise.resolve(1),
+        unsupported: () => 1,
       });
       await (await handler(request())).text();
       await (await handler(request())).text();

--- a/__tests__/core/html-boundary.ts
+++ b/__tests__/core/html-boundary.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import htmlBoundary from '@core/html-boundary';
+
+describe('HTML stream insertion boundaries', () => {
+  it('does not insert scripts in split tags, quotes, comments or raw text', () => {
+    const observe = htmlBoundary();
+    const feed = (value: string) => observe(new TextEncoder().encode(value));
+    expect(feed('<main title="hel')).toBe(false);
+    expect(feed('lo > wor')).toBe(false);
+    expect(feed('ld">')).toBe(true);
+    expect(feed('<!-- foo >')).toBe(false);
+    expect(feed('-->')).toBe(true);
+    expect(feed('<script>const x = "<p>')).toBe(false);
+    expect(feed('";</scr')).toBe(false);
+    expect(feed('ipt>')).toBe(true);
+    expect(feed('<style>p{color:red}')).toBe(false);
+    expect(feed('</style>')).toBe(true);
+    expect(feed('text spl')).toBe(false);
+    expect(feed('it</main>')).toBe(true);
+  });
+});

--- a/__tests__/doctor.ts
+++ b/__tests__/doctor.ts
@@ -1,0 +1,338 @@
+// @vitest-environment node
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { copyFixture, writeFixture } from '@__helpers__/project-fixture';
+import runDoctor, {
+  inspectProject,
+  reactCopies,
+  resolveNpmCli,
+  supportBundle,
+  TESTED_MATRIX,
+} from '@cli/doctor';
+import runInit from '@cli/init';
+import { libraryPackage } from '@cli/project';
+
+const directories: string[] = [];
+const installed = {
+  '@lomray/vite-ssr-boost': libraryPackage().version,
+  react: '19.2.8',
+  'react-dom': '19.2.8',
+  'react-router': '8.3.1',
+  vite: '8.2.2',
+};
+const fixture = () => {
+  const root = copyFixture('root-inline');
+  directories.push(root);
+  runInit({ root, apply: true });
+  for (const [name, version] of Object.entries(installed)) {
+    writeFixture(
+      root,
+      `node_modules/${name}/package.json`,
+      JSON.stringify({ name, version, engines: { node: '>=22.12.0' } }),
+    );
+  }
+  return root;
+};
+const mutate = (root: string, file: string, edit: (text: string) => string) =>
+  writeFixture(root, file, edit(fs.readFileSync(path.join(root, file), 'utf8')));
+const check = (root: string, name: string) =>
+  inspectProject({ root }).checks.find((row) => row.name === name)!;
+
+beforeEach(() => {
+  vi.spyOn(childProcess, 'execFileSync').mockReturnValue(
+    JSON.stringify({
+      dependencies: { react: { version: '19.2.8' }, 'react-dom': { version: '19.2.8' } },
+    }),
+  );
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  directories
+    .splice(0)
+    .forEach((directory) => fs.rmSync(directory, { recursive: true, force: true }));
+  process.exitCode = 0;
+});
+
+describe('doctor', () => {
+  it.each([
+    { label: 'npm_execpath before either bundled layout', available: [0, 1, 2], selected: 0 },
+    { label: 'Unix runtime layout before Windows layout', available: [1, 2], selected: 1 },
+    { label: 'Windows runtime layout', available: [2], selected: 2 },
+    { label: 'bare npm only when no CLI exists', available: [], selected: undefined },
+  ])('resolves $label and preserves the React-copy result', ({ available, selected }) => {
+    const candidates = [
+      path.resolve('/npm-execpath/bin/npm-cli.js'),
+      path.join(
+        path.dirname(process.execPath),
+        '..',
+        'lib',
+        'node_modules',
+        'npm',
+        'bin',
+        'npm-cli.js',
+      ),
+      path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    ];
+    vi.stubEnv('npm_execpath', candidates[0]);
+    vi.spyOn(fs, 'existsSync').mockImplementation((file) =>
+      available.some((index) => file === candidates[index]),
+    );
+    const npmCli = selected === undefined ? undefined : candidates[selected];
+    expect(resolveNpmCli()).toBe(npmCli);
+    const root = path.resolve('/app');
+    expect(reactCopies(root)).toEqual({ react: 1, 'react-dom': 1 });
+    const args = ['ls', 'react', 'react-dom', '--json', '--all', '--long'];
+    expect(childProcess.execFileSync).toHaveBeenCalledWith(
+      npmCli ? process.execPath : 'npm',
+      npmCli ? [npmCli, ...args] : args,
+      expect.objectContaining({ cwd: root, shell: false }),
+    );
+  });
+
+  it('uses the runtime npm when npm_execpath is unset', () => {
+    vi.stubEnv('npm_execpath', undefined);
+    const npmCli = path.join(
+      path.dirname(process.execPath),
+      '..',
+      'lib',
+      'node_modules',
+      'npm',
+      'bin',
+      'npm-cli.js',
+    );
+    vi.spyOn(fs, 'existsSync').mockImplementation((file) => file === npmCli);
+    expect(resolveNpmCli()).toBe(npmCli);
+  });
+
+  it('keeps the published matrix synchronized with the actual CI matrix', () => {
+    const workflow = fs.readFileSync('.github/workflows/react-compatibility.yml', 'utf8');
+    const rows = [
+      ...workflow.matchAll(/- react: '([^']+)'\s+router: '([^']+)'\s+vite: '([^']+)'/g),
+    ].map(([, react, router, vite]) => ({ react, router, vite }));
+    expect(TESTED_MATRIX).toEqual(rows);
+  });
+
+  it('prints JSON, reports every check ok, and exits zero for a migrated project', () => {
+    const root = fixture();
+    const info = vi.spyOn(console, 'info');
+    runDoctor({ root, json: true });
+    expect(process.exitCode).toBe(0);
+    const report = JSON.parse(info.mock.calls[0][0]) as ReturnType<typeof inspectProject>;
+    expect(report.checks.every((row) => row.status === 'ok' && row.fix)).toBe(true);
+    expect(report.routes).toEqual([
+      { id: '0', path: '/' },
+      { id: '1', path: '/about' },
+    ]);
+    expect(report.adapter).toBe('express');
+  });
+
+  it.each(Object.keys(installed))('reports a missing %s version as an error', (name) => {
+    const root = fixture();
+    fs.rmSync(path.join(root, 'node_modules', name), { recursive: true });
+    expect(check(root, `version:${name}`).status).toBe('error');
+  });
+
+  it.each(TESTED_MATRIX)('accepts the exact tested row %j', (row) => {
+    const root = fixture();
+    for (const [name, version] of Object.entries({
+      react: row.react,
+      'react-dom': row.react,
+      'react-router': row.router,
+      vite: row.vite,
+    })) {
+      mutate(root, `node_modules/${name}/package.json`, (code) =>
+        JSON.stringify({ ...JSON.parse(code), version }),
+      );
+    }
+    expect(check(root, 'compatibility').status).toBe('ok');
+  });
+
+  it('reports one compatibility warning and names the installed trio and closest tested row', () => {
+    const root = fixture();
+    mutate(root, 'node_modules/react-router/package.json', (code) =>
+      code.replace('8.3.1', '7.18.3'),
+    );
+    const report = inspectProject({ root });
+    expect(report.checks.filter((item) => item.status === 'warn')).toEqual([
+      expect.objectContaining({
+        name: 'compatibility',
+        message:
+          'React 19.2.8 + Router 7.18.3 + Vite 8.2.2 is not a tested row; closest: React 19.2.8 + Router 7.18.3 + Vite 7.3.6',
+      }),
+    ]);
+    expect(
+      report.checks
+        .filter((item) => item.name.startsWith('version:'))
+        .every((item) => item.status === 'ok'),
+    ).toBe(true);
+    expect(report.checks.every((item) => !item.fix.includes('\n'))).toBe(true);
+    runDoctor({ root, json: true });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('includes a mismatched React DOM version in the compatibility warning', () => {
+    const root = fixture();
+    mutate(root, 'node_modules/react-dom/package.json', (code) => code.replace('19.2.8', '18.2.0'));
+    expect(check(root, 'compatibility')).toMatchObject({
+      status: 'warn',
+      message: expect.stringContaining('React 19.2.8 (React DOM 18.2.0)'),
+    });
+  });
+
+  it('checks peer ranges independently of matrix compatibility', () => {
+    const root = fixture();
+    mutate(root, 'node_modules/react/package.json', (code) => code.replace('19.2.8', '17.0.2'));
+    expect(check(root, 'version:react')).toMatchObject({
+      status: 'error',
+      message: expect.stringContaining('@lomray/vite-ssr-boost requires react: >=18.2.0'),
+    });
+    mutate(root, 'node_modules/react-dom/package.json', (code) =>
+      JSON.stringify({ ...JSON.parse(code), peerDependencies: { react: '^19.2.8' } }),
+    );
+    expect(check(root, 'version:react').message).toContain('react-dom requires react: ^19.2.8');
+    expect(check(root, 'version:vite').status).toBe('ok');
+  });
+
+  it('checks installed dependency engines as well as the app engine', () => {
+    const root = fixture();
+    mutate(root, 'node_modules/react-router/package.json', (code) =>
+      JSON.stringify({ ...JSON.parse(code), engines: { node: '>=999' } }),
+    );
+    expect(check(root, 'node')).toMatchObject({
+      status: 'error',
+      message: expect.stringContaining('react-router: >=999'),
+    });
+  });
+
+  it.each([
+    ['package', 'package.json', () => '{invalid'],
+    [
+      'node',
+      'package.json',
+      (code: string) => JSON.stringify({ ...JSON.parse(code), engines: { node: '>=999' } }),
+    ],
+    ['vite-plugin', 'vite.config.ts', () => 'export default { plugins: [] };'],
+    [
+      'html-module',
+      'index.html',
+      (code: string) => code.replace('type="module"', 'type="text/plain"'),
+    ],
+    ['html-outlet', 'index.html', (code: string) => code.replace('<!--ssr-outlet-->', '')],
+    [
+      'html-outlet',
+      'index.html',
+      (code: string) => code.replace('<!--ssr-outlet-->', '<!--ssr-outlet--><!--ssr-outlet-->'),
+    ],
+    ['browser-entry', 'src/main.tsx', () => 'export default {};'],
+    ['server-entry', 'src/server.ts', () => 'export default {};'],
+    ['routes', 'src/routes.ssr.tsx', () => 'export default makeRoutes();'],
+    ['scripts', 'package.json', (code: string) => code.replace('ssr-boost build', 'vite build')],
+  ] as const)('fails %s with a one-line fix', (name, file, edit) => {
+    const root = fixture();
+    mutate(root, file, edit);
+    const result = check(root, name);
+    expect(result.status).toBe('error');
+    expect(result.fix).toBeTruthy();
+    if (name === 'routes')
+      expect(result.message).toMatch(/routes.ssr.tsx:1:16: Unsupported routes array/);
+    runDoctor({ root, json: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('counts physical duplicate React copies, including equal versions, and ignores deduped references', () => {
+    const root = fixture();
+    vi.mocked(childProcess.execFileSync).mockReturnValue(
+      JSON.stringify({
+        dependencies: {
+          react: { version: '19.2.8', path: `${root}/react` },
+          'react-dom': {
+            version: '19.2.8',
+            path: `${root}/dom`,
+            dependencies: { react: { version: '19.2.8', path: `${root}/react` } },
+          },
+          component: { dependencies: { react: { version: '19.2.8', path: `${root}/duplicate` } } },
+        },
+      }),
+    );
+    expect(reactCopies(root)).toEqual({ react: 2, 'react-dom': 1 });
+    expect(check(root, 'react-copies').status).toBe('error');
+    vi.mocked(childProcess.execFileSync).mockImplementation(() => {
+      throw new Error('npm unavailable');
+    });
+    expect(check(root, 'react-copies').status).toBe('error');
+  });
+
+  it('reports robots policies and size budgets as information without editing them', () => {
+    const root = fixture();
+    expect(check(root, 'robots').message).toContain('No robots.txt');
+    expect(check(root, 'size-budget')).toMatchObject({
+      status: 'ok',
+      info: true,
+      message: 'No size budget script (informational)',
+    });
+    writeFixture(root, 'public/robots.txt', 'User-agent: *\nDisallow: /\n');
+    expect(check(root, 'robots')).toMatchObject({ status: 'ok', info: true });
+    expect(check(root, 'robots').message).toContain('blocks crawling');
+    writeFixture(root, 'public/robots.txt', 'User-agent: *\nAllow: /\n');
+    expect(check(root, 'robots').message).toContain('custom/allow');
+    mutate(root, 'package.json', (code) =>
+      JSON.stringify({
+        ...JSON.parse(code),
+        scripts: { ...JSON.parse(code).scripts, 'size:check': 'node scripts/size-budget.mjs' },
+      }),
+    );
+    expect(check(root, 'size-budget').message).toBe('Size budget script present');
+    expect(fs.readFileSync(path.join(root, 'public/robots.txt'), 'utf8')).toContain('Allow: /');
+  });
+
+  it('reports bundle write failures and counts markers inside inline scripts like the SSR shell splitter', () => {
+    const root = fixture();
+    mutate(
+      root,
+      'index.html',
+      (code) => code + '<script>const marker = "<!--ssr-outlet-->";</script>',
+    );
+    expect(check(root, 'html-outlet').status).toBe('error');
+    const info = vi.spyOn(console, 'info');
+    runDoctor({ root, json: true, bundle: 'missing-directory/support.json' });
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(info.mock.calls.at(-1)![0]).checks.at(-1)).toMatchObject({
+      name: 'bundle',
+      status: 'error',
+    });
+  });
+
+  it('writes only allowlisted structural support data and recorded diagnostic codes', () => {
+    const root = fixture();
+    writeFixture(root, '.env', 'SECRET=secret-environment-value\n');
+    writeFixture(
+      root,
+      'dist/ssr-boost-diagnostics.json',
+      JSON.stringify({
+        codes: ['SSR_BOOST_OUTLET_MISSING', 'secret-recorded-value'],
+        cookie: 'session=secret-cookie-value',
+      }),
+    );
+    writeFixture(
+      root,
+      'src/routes.ssr.tsx',
+      "export default [{ id: 'about', path: '/about', handle: { data: 'secret-app-value' }, lazy: () => import('./About') }];",
+    );
+    const report = inspectProject({ root });
+    report.checks.push({
+      name: 'routes',
+      status: 'error',
+      fix: 'Use static routes.',
+      message: 'secret-error-value',
+    });
+    expect(JSON.stringify(supportBundle(report))).not.toMatch(/secret-|session=/);
+    runDoctor({ root, bundle: 'support.json', json: true });
+    const bundle = fs.readFileSync(path.join(root, 'support.json'), 'utf8');
+    expect(bundle).not.toMatch(/secret-|session=/);
+    expect(JSON.parse(bundle).diagnosticCodes).toEqual(['SSR_BOOST_OUTLET_MISSING']);
+    expect(JSON.parse(bundle).routes).toEqual([{ id: 'about', path: '/about' }]);
+  });
+});

--- a/__tests__/init.ts
+++ b/__tests__/init.ts
@@ -1,0 +1,262 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyFixture, writeFixture } from '@__helpers__/project-fixture';
+import runInit, { planInit } from '@cli/init';
+import { MANUAL_GUIDE } from '@cli/project';
+
+const directories: string[] = [];
+const fixture = (layout = 'root-inline') => {
+  const root = copyFixture(layout);
+  directories.push(root);
+  return root;
+};
+const contents = (root: string) =>
+  Object.fromEntries(
+    fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((file) => fs.statSync(path.join(root, file)).isFile())
+      .sort()
+      .map((file) => [file, fs.readFileSync(path.join(root, file), 'utf8')]),
+  );
+
+afterEach(() => {
+  directories
+    .splice(0)
+    .forEach((directory) => fs.rmSync(directory, { recursive: true, force: true }));
+  process.exitCode = 0;
+  vi.restoreAllMocks();
+});
+
+describe('init', () => {
+  it.each(['root-inline', 'src-export', 'javascript', 'alias-wrapper'])(
+    '%s has a complete dry-run diff and applies idempotently',
+    (layout) => {
+      const root = fixture(layout);
+      const before = contents(root);
+      const info = vi.spyOn(console, 'info');
+      runInit({ root });
+      expect(process.exitCode).not.toBe(1);
+      expect(info.mock.calls.map(([line]) => line).join('\n')).toMatchSnapshot();
+      expect(contents(root)).toEqual(before);
+      const plan = planInit({ root });
+      runInit({ root, apply: true });
+      for (const change of plan)
+        expect(fs.readFileSync(path.join(root, change.file), 'utf8')).toBe(change.after);
+      const applied = contents(root);
+      expect(planInit({ root })).toEqual([]);
+      runInit({ root, apply: true });
+      expect(contents(root)).toEqual(applied);
+    },
+  );
+
+  it.each([
+    ['named', '{ routes }', 'routes', './routes', 'export const routes'],
+    [
+      'named alias',
+      '{ appRoutes as pageRoutes }',
+      'pageRoutes',
+      './routes',
+      'export const appRoutes',
+    ],
+    ['default', 'routes', 'routes', './routes', 'const routes'],
+    ['default alias with extension', 'pageRoutes', 'pageRoutes', './routes.ts', 'const routes'],
+  ])(
+    'preserves the %s route binding and original module specifier',
+    (_label, binding, local, specifier, declaration) => {
+      const root = fixture('src-export');
+      const file = path.join(root, 'src/routes.ts');
+      let routes = fs.readFileSync(file, 'utf8').replace('export const appRoutes', declaration);
+      if (declaration === 'const routes') routes += '\nexport default routes\n';
+      fs.writeFileSync(file, routes);
+      const main = path.join(root, 'src/main.tsx');
+      const original = `import ${binding} from '${specifier}'`;
+      fs.writeFileSync(
+        main,
+        fs
+          .readFileSync(main, 'utf8')
+          .replace("import { appRoutes as routes } from './routes'", original)
+          .replace('createBrowserRouter(routes)', `createBrowserRouter(${local})`),
+      );
+      const plan = planInit({ root });
+      for (const name of ['src/main.tsx', 'src/server.ts']) {
+        const output = plan.find((change) => change.file === name)!.after;
+        expect(output).toContain(original);
+        expect(output).not.toContain('routes as routes');
+        expect(output).toContain(`(App, ${local})`);
+      }
+    },
+  );
+
+  it.each(['strict', 'fragment', 'shorthand', 'none', 'namespace', 'react-default'])(
+    'generates a shared explicit App for a %s wrapper in TS and JS',
+    (wrapper) => {
+      for (const layout of ['root-inline', 'javascript']) {
+        const root = fixture(layout);
+        const isTS = layout === 'root-inline';
+        const main = path.join(root, `src/main.${isTS ? 'tsx' : 'jsx'}`);
+        let code = fs.readFileSync(main, 'utf8');
+        if (wrapper === 'namespace' || wrapper === 'react-default')
+          code = code
+            .replace(
+              "import { StrictMode } from 'react'",
+              `import ${wrapper === 'namespace' ? '* as React' : 'React'} from 'react'`,
+            )
+            .replaceAll('StrictMode', 'React.Fragment');
+        if (wrapper === 'fragment') code = code.replaceAll('StrictMode', 'Fragment');
+        if (wrapper === 'shorthand')
+          code = code.replace('<StrictMode>', '<>').replace('</StrictMode>', '</>');
+        if (wrapper === 'none')
+          code = code.replace('<StrictMode>', '').replace('</StrictMode>', '');
+        fs.writeFileSync(main, code);
+        const plan = planInit({ root });
+        const browser = plan.find((change) =>
+          change.file.endsWith(isTS ? 'main.tsx' : 'main.jsx'),
+        )!.after;
+        const server = plan.find((change) =>
+          change.file.endsWith(isTS ? 'server.ts' : 'server.js'),
+        )!.after;
+        const tag =
+          wrapper === 'strict'
+            ? 'StrictMode'
+            : wrapper === 'fragment'
+              ? 'Fragment'
+              : ['namespace', 'react-default'].includes(wrapper)
+                ? 'React.Fragment'
+                : '';
+        expect(browser).toContain(
+          `const App${isTS ? ': FC<PropsWithChildren>' : ''} = ({ children }) => <${tag}>{children}</${tag}>`,
+        );
+        expect(server).toContain(
+          `const App${isTS ? ': FC<PropsWithChildren>' : ''} = ({ children }) => ssrCreateElement(${tag || 'ssrFragment'}, null, children)`,
+        );
+        expect(browser).toContain('entryClient(App, routes)');
+        expect(server).toContain('entryServer(App, routes)');
+        if (!isTS) {
+          expect(browser + server).not.toMatch(/import type|PropsWithChildren|\bFC\b/);
+        }
+      }
+    },
+  );
+
+  it.each([
+    [{ dev: 'vite --host' }, { dev: 'ssr-boost dev' }],
+    [{ develop: 'vite --host' }, { develop: 'ssr-boost dev' }],
+    [{}, { develop: 'ssr-boost dev' }],
+    [
+      { dev: 'vite', develop: 'custom-command' },
+      { dev: 'ssr-boost dev', develop: 'custom-command' },
+    ],
+  ])('selects the existing development script: %j', (before, after) => {
+    const root = fixture();
+    const file = path.join(root, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+    fs.writeFileSync(file, JSON.stringify({ ...pkg, scripts: { ...before, lint: 'eslint .' } }));
+    const change = planInit({ root }).find((item) => item.file === 'package.json')!;
+    expect(JSON.parse(change.after).scripts).toEqual({
+      ...after,
+      lint: 'eslint .',
+      build: 'ssr-boost build',
+      'start:ssr': 'ssr-boost start',
+    });
+  });
+
+  it('supports explicit entry and exported routes overrides', () => {
+    const root = fixture('src-export');
+    expect(planInit({ root, entry: 'src/main.tsx', routes: 'src/routes.ts' })).toEqual(
+      planInit({ root }),
+    );
+  });
+
+  it.each([
+    [
+      'no router',
+      'src/main.tsx',
+      "import App from './App'; export default App;",
+      /createBrowserRouter calls \(0\)/,
+    ],
+    [
+      'JSX BrowserRouter',
+      'src/main.tsx',
+      "import { BrowserRouter } from 'react-router'; const app = <BrowserRouter />;",
+      /JSX BrowserRouter/,
+    ],
+    [
+      'multiple entries',
+      'index.html',
+      '<div id="root"></div><script type="module" src="/a.ts"></script><script type="module" src="/b.ts"></script>',
+      /module entries \(2\)/,
+    ],
+    ['base', 'vite.config.ts', "export default { base: '/app/', plugins: [] };", /Vite base/],
+    ['existing server', 'src/server.ts', 'export default "mine";', /existing server entry/],
+    [
+      'missing root',
+      'index.html',
+      '<div id="app"></div><script type="module" src="/src/main.tsx"></script>',
+      /root element/,
+    ],
+    ['runtime config', 'vite.config.ts', 'export default getConfig();', /Vite configuration/],
+  ])('stops without writes for %s', (_name, file, text, error) => {
+    const root = fixture();
+    writeFixture(root, file, text);
+    const before = contents(root);
+    const stderr = vi.spyOn(console, 'error');
+    runInit({ root, apply: true });
+    expect(process.exitCode).toBe(1);
+    expect(stderr.mock.calls.flat().join('\n')).toMatch(error);
+    expect(stderr.mock.calls.flat().join('\n')).toContain(MANUAL_GUIDE);
+    expect(contents(root)).toEqual(before);
+  });
+
+  it.each([
+    [
+      'createBrowserRouter(routes)',
+      "createBrowserRouter(routes, { basename: '/app' })",
+      /router options/,
+    ],
+    ["document.getElementById('root')!", "document.getElementById('root')!, {}", /React mount/],
+    ['router={router}', 'router={router} fallbackElement={<p>Loading</p>}', /RouterProvider props/],
+    ['const router =', 'const unrelated = 1; const router =', /additional browser startup/],
+  ])('rejects bootstrap settings it cannot preserve: %s', (before, after, expected) => {
+    const root = fixture();
+    const file = path.join(root, 'src/main.tsx');
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace(before, after));
+    expect(() => planInit({ root })).toThrow(expected);
+  });
+
+  it.each([
+    'https://example.com/main.tsx',
+    '//example.com/main.tsx',
+    '/src/main.tsx?import',
+    '/src/main.tsx#app',
+  ])(
+    'rejects non-local entry URLs, including query/fragment characters after the path: %s',
+    (src) => {
+      const root = fixture();
+      const file = path.join(root, 'index.html');
+      fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('/src/main.tsx', src));
+      expect(() => planInit({ root })).toThrow('non-local browser entry URL');
+    },
+  );
+
+  it('anchors the protocol-relative URL alternative to the start of the entry', () => {
+    const root = fixture();
+    const file = path.join(root, 'index.html');
+    fs.writeFileSync(
+      file,
+      fs.readFileSync(file, 'utf8').replace('/src/main.tsx', '/src//main.tsx'),
+    );
+    expect(planInit({ root }).some((change) => change.file === 'src/main.tsx')).toBe(true);
+  });
+
+  it('keeps CRLF, quotes, comments and plugins in untouched code', () => {
+    const root = fixture();
+    const file = path.join(root, 'vite.config.ts');
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace(/'/g, '"').replace(/\n/g, '\r\n'));
+    const diff = planInit({ root }).find((change) => change.file === 'vite.config.ts')!;
+    expect(diff.after).toContain('import SsrBoost from "@lomray/vite-ssr-boost/plugin"\r\n');
+    expect(diff.after).toContain('// Keep the React plugin and this comment.\r\n');
+    expect(diff.after).toContain('react()]');
+  });
+});

--- a/__tests__/integration/adapter-conformance.tsx
+++ b/__tests__/integration/adapter-conformance.tsx
@@ -6,7 +6,7 @@ import Fastify from 'fastify';
 import { Hono } from 'hono';
 import React, { Suspense } from 'react';
 import type { RouteObject } from 'react-router';
-import { createStaticHandler, redirect } from 'react-router';
+import { Await, createStaticHandler, redirect, useActionData, useLoaderData } from 'react-router';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import adapterEdge from '@adapters/edge';
 import adapterExpress from '@adapters/express';
@@ -33,6 +33,19 @@ interface IRuntimeFactory {
   renderer: TRenderToStream;
 }
 
+const DeferredPage = () => {
+  const action = useActionData() as { slow: Promise<string> } | undefined;
+  const loader = useLoaderData() as { slow: Promise<string> };
+  return (
+    <Suspense fallback={<p>loader fallback</p>}>
+      <Await resolve={(action ?? loader).slow}>{(value) => <p data-deferred>{value}</p>}</Await>
+    </Suspense>
+  );
+};
+const deferredLoader = () => ({
+  slow: new Promise<string>((resolve) => setTimeout(() => resolve('adapter deferred'), 35)),
+});
+
 const Broken = (): never => {
   throw new Error('conformance render failure');
 };
@@ -44,6 +57,7 @@ const Recoverable = () => (
 
 const createSsrHandler = (renderToStream: TRenderToStream, onAbort: () => void): TSsrHandler => {
   const routes: RouteObject[] = [
+    { path: '/deferred', Component: DeferredPage, loader: deferredLoader, action: deferredLoader },
     ...[204, 205, 304].map((status) => ({
       Component: () => <ResponseStatus status={status} />,
       path: `/status-${status}`,
@@ -134,7 +148,7 @@ const createSsrHandler = (renderToStream: TRenderToStream, onAbort: () => void):
           context.response.headers.append('Set-Cookie', 'router=1; Path=/');
         }
 
-        return {};
+        return { isStream: context.request.headers.get('user-agent') !== 'Googlebot' };
       },
       onShellError: ({ error }) => `<p data-shell-error>${error.message}</p>`,
       prepare: async ({ executionContext }) => {
@@ -270,6 +284,22 @@ describe.each(factories)('$name SSR conformance', ({ renderer, start }) => {
 
   afterAll(async () => {
     await runtime.close();
+  });
+
+  it.each(['GET', 'POST'])('transfers deferred %s data through the adapter', async (method) => {
+    const response = await runtime.request('/deferred', { method });
+    const html = await response.text();
+    expect(html).toContain('SSRBPromise');
+    expect(html).toContain('["resolve",0');
+    expect(html).toContain('<p data-deferred');
+    expect(html).toContain('adapter deferred');
+  });
+
+  it('buffers deferred HTML for bots', async () => {
+    const response = await runtime.request('/deferred', { headers: { 'User-Agent': 'Googlebot' } });
+    const html = await response.text();
+    expect(html).toContain('adapter deferred');
+    expect(html).not.toContain('<!--$?-->');
   });
 
   it('streams identical HTML, status, headers and cookies', async () => {

--- a/__tests__/integration/data-stream-edge.tsx
+++ b/__tests__/integration/data-stream-edge.tsx
@@ -1,0 +1,6 @@
+// @vitest-environment node
+import testDataStream from '@__helpers__/data-stream';
+import renderToStream from '@edge/render-to-stream';
+
+// React 18's Node and Web Fizz renderers must not share a React context instance.
+testDataStream('edge', renderToStream);

--- a/__tests__/integration/data-stream-node.tsx
+++ b/__tests__/integration/data-stream-node.tsx
@@ -1,0 +1,6 @@
+// @vitest-environment node
+import testDataStream from '@__helpers__/data-stream';
+import renderToStream from '@node/render-to-stream';
+
+// React 18's Node and Web Fizz renderers must not share a React context instance.
+testDataStream('node', renderToStream);

--- a/__tests__/integration/express-react-stream.tsx
+++ b/__tests__/integration/express-react-stream.tsx
@@ -6,7 +6,7 @@ import type { PropsWithChildren } from 'react';
 import React, { Suspense } from 'react';
 import express from 'express';
 import compression from 'compression';
-import { redirect } from 'react-router';
+import { Await, redirect, useLoaderData } from 'react-router';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import entry from '@adapters/express/entry';
@@ -134,8 +134,32 @@ describe('Express real React stream contract', () => {
       req.end();
     });
 
+  it('streams loader promises and early hydration through the managed entry', async () => {
+    const { body } = await request('/deferred');
+    expect(body).toContain('managed deferred');
+    expect(body).toContain('SSRBPromise');
+    expect(body).toContain('["resolve",0');
+    expect(body).toContain('["shell"]');
+    expect(body.indexOf('window.__staticRouterHydrationData')).toBeLessThan(body.indexOf('<main>'));
+    expect(body).toContain('nonce="managed-nonce"');
+  });
+
   beforeAll(async () => {
     const prepared = entry(App, [
+      {
+        path: '/deferred',
+        loader: () => ({
+          slow: new Promise<string>((resolve) => setTimeout(() => resolve('managed deferred'), 50)),
+        }),
+        Component: () => {
+          const { slow } = useLoaderData() as { slow: Promise<string> };
+          return (
+            <Suspense fallback={<p>pending loader</p>}>
+              <Await resolve={slow}>{(value) => <p data-loader>{value}</p>}</Await>
+            </Suspense>
+          );
+        },
+      },
       { path: '/timeout', Component: RecoverablePage },
       { path: '/disconnect', Component: RecoverablePage },
       { path: '/multipart', action: multipartAction, Component: () => <p>multipart rendered</p> },
@@ -197,6 +221,8 @@ describe('Express real React stream contract', () => {
         },
         {
           abortDelay: req.path === '/timeout' ? 50 : 2_000,
+          hydration: req.path === '/deferred' ? 'early' : 'footer',
+          nonce: 'managed-nonce',
           ...(req.path === '/multipart'
             ? {
                 getBody: () => {

--- a/__tests__/integration/init.ts
+++ b/__tests__/integration/init.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { expect, it } from 'vitest';
+import testInit, { assertNodeEngines } from '../../scripts/test-init.mjs';
+
+it('migrates a stock React TS app and serves every parser fixture with lazy CSS from the packed library', async () => {
+  await testInit();
+}, 240_000);
+
+it('explains an unsupported Node runtime before running the end-to-end build', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ssr-boost-engine-test-'));
+  try {
+    const dependency = path.join(root, 'node_modules/react-router');
+    fs.mkdirSync(dependency, { recursive: true });
+    fs.writeFileSync(
+      path.join(dependency, 'package.json'),
+      JSON.stringify({ name: 'react-router', engines: { node: '>=22.22.0' } }),
+    );
+    expect(() => assertNodeEngines(root, '22.21.0')).toThrow(
+      /Stock-app end-to-end precondition failed: Node 22\.21\.0.*react-router: >=22\.22\.0.*Use Node 22\.23\.2/,
+    );
+    expect(() => assertNodeEngines(root, '22.23.2')).not.toThrow();
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/__tests__/services/build-internals.ts
+++ b/__tests__/services/build-internals.ts
@@ -120,24 +120,30 @@ describe('Build internals', () => {
     let exitHandler!: (code: number) => void;
     let closeHandler!: (code: number) => void;
     let errorHandler!: (message: string) => void;
-    let stderrDataHandler!: (buff: Uint8Array) => void;
+    const stderrDataHandlers: ((buff: Uint8Array) => void)[] = [];
     const command = {
       on: vi.fn((event: string, handler: (...args: any[]) => void) => {
         if (event === 'exit') exitHandler = handler as never;
         if (event === 'close') closeHandler = handler as never;
         if (event === 'error') errorHandler = handler as never;
       }),
-      stdout: { pipe: vi.fn() },
+      stdout: { pipe: vi.fn(), on: vi.fn() },
       stderr: {
         pipe: vi.fn(),
         on: vi.fn((event: string, handler: (buff: Uint8Array) => void) => {
-          if (event === 'data') stderrDataHandler = handler;
+          if (event === 'data') stderrDataHandlers.push(handler);
         }),
       },
     };
 
     const result = service.promisifyProcess(command as never, true);
-    stderrDataHandler(new TextEncoder().encode('WARNING found'));
+    stderrDataHandlers.forEach((handler) =>
+      handler(new TextEncoder().encode('WARNING SSR_BOOST_OUTLET_')),
+    );
+    stderrDataHandlers.forEach((handler) =>
+      handler(new TextEncoder().encode('MISSING cookie=secret-build-data')),
+    );
+    expect([...service.diagnosticCodes]).toEqual(['SSR_BOOST_OUTLET_MISSING']);
     exitHandler(0);
     closeHandler(0);
     errorHandler('err');
@@ -173,31 +179,73 @@ describe('Build internals', () => {
     expect(processStopMock).toHaveBeenCalled();
 
     service.runPreviewMode();
-    const listener = stdout.on.mock.calls[0][1];
-    listener(new TextEncoder().encode('built in 123ms'));
+    stdout.on.mock.calls.forEach(([, listener]) =>
+      listener(new TextEncoder().encode('built in 123ms')),
+    );
     expect(createDevMarkerMock).toHaveBeenCalled();
   });
 
-  it('should run full build flow', async () => {
-    const service = prepareService({
-      focusOnly: 'all',
-      isUnlockRobots: true,
-      onFinish: vi.fn(),
-    });
-    vi.spyOn(service, 'makeConfig').mockResolvedValue(undefined);
-    vi.spyOn(service, 'clearBuildFolder').mockImplementation(() => undefined);
-    vi.spyOn(service, 'spawnBuild').mockResolvedValue(undefined);
-    vi.spyOn(service, 'buildManifest').mockImplementation(() => undefined);
-    vi.spyOn(service, 'unlockRobots').mockImplementation(() => undefined);
+  it.each([
+    {
+      label: 'empty',
+      codes: [],
+      expected: '{\n  "codes": []\n}',
+    },
+    {
+      label: 'existing split warning',
+      codes: ['SSR_BOOST_OUTLET_MISSING'],
+      expected: '{\n  "codes": [\n    "SSR_BOOST_OUTLET_MISSING"\n  ]\n}',
+    },
+    {
+      label: 'all known codes in discovery order with duplicates',
+      codes: [
+        'SSR_BOOST_LOADER_NOT_SERIALIZABLE',
+        'SSR_BOOST_STATE_NOT_SERIALIZABLE',
+        'SSR_BOOST_OUTLET_MISSING',
+        'SSR_BOOST_HYDRATION_STATE_MISSING',
+        'SSR_BOOST_DUPLICATE_OUTPUT',
+        'SSR_BOOST_ONRESPONSE_INVALID_RETURN',
+        'SSR_BOOST_OUTLET_MISSING',
+      ],
+      expected: `{
+  "codes": [
+    "SSR_BOOST_DUPLICATE_OUTPUT",
+    "SSR_BOOST_HYDRATION_STATE_MISSING",
+    "SSR_BOOST_LOADER_NOT_SERIALIZABLE",
+    "SSR_BOOST_ONRESPONSE_INVALID_RETURN",
+    "SSR_BOOST_OUTLET_MISSING",
+    "SSR_BOOST_STATE_NOT_SERIALIZABLE"
+  ]
+}`,
+    },
+  ])(
+    'should preserve diagnostic manifest bytes through the full build: $label',
+    async ({ codes, expected }) => {
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+      const write = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+      const service = prepareService({
+        focusOnly: 'all',
+        isUnlockRobots: true,
+        onFinish: vi.fn(),
+      });
+      vi.spyOn(service, 'makeConfig').mockResolvedValue(undefined);
+      vi.spyOn(service, 'clearBuildFolder').mockImplementation(() => undefined);
+      vi.spyOn(service, 'spawnBuild').mockImplementation(async () => {
+        codes.forEach((code) => service.diagnosticCodes.add(code));
+      });
+      vi.spyOn(service, 'buildManifest').mockImplementation(() => undefined);
+      vi.spyOn(service, 'unlockRobots').mockImplementation(() => undefined);
 
-    await service.build();
+      await service.build();
+      expect(write).toHaveBeenCalledWith('/root/dist/ssr-boost-diagnostics.json', expected);
 
-    expect(viteResetCacheMock).toHaveBeenCalled();
-    expect(service.spawnBuild).toHaveBeenCalled();
-    expect(service.buildManifest).toHaveBeenCalled();
-    expect(service.unlockRobots).toHaveBeenCalled();
-    expect(createDevMarkerMock).toHaveBeenCalled();
-  });
+      expect(viteResetCacheMock).toHaveBeenCalled();
+      expect(service.spawnBuild).toHaveBeenCalled();
+      expect(service.buildManifest).toHaveBeenCalled();
+      expect(service.unlockRobots).toHaveBeenCalled();
+      expect(createDevMarkerMock).toHaveBeenCalled();
+    },
+  );
 
   it('should run manifest builder directly', () => {
     const service = prepareService();

--- a/__tests__/services/parse-routes.ts
+++ b/__tests__/services/parse-routes.ts
@@ -1,370 +1,127 @@
-import fs from 'fs';
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { parse } from '@babel/parser';
-import sinon from 'sinon';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  routesCode1Before,
-  routesCode2Before,
-  routesCode4Before,
-  routesDetailsCode,
-} from '@__mocks__/route-file';
-import { viteAliases } from '@__mocks__/vite-aliases';
+import { routeFixtures, writeFixture, writeRouteFixture } from '@__helpers__/project-fixture';
 import ParseRoutes from '@services/parse-routes';
 import ServerConfig from '@services/server-config';
+import SsrManifest from '@services/ssr-manifest';
 
-const clientEntrypoint = (hasAlias = false, isNamedImport = false) => `
-import entryClient from '@lomray/vite-ssr-boost/browser/entry';
-import ${isNamedImport ? '{ routes }' : 'routes'} from '${hasAlias ? '@' : './'}routes/index';
+const directories: string[] = [];
+const setup = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ssr-boost-routes-test-'));
+  directories.push(root);
+  const config = ServerConfig.init({}, { root, clientFile: 'client.ts' });
+  const parser = new ParseRoutes(config);
+  return { root, parser, config };
+};
 
-void entryClient(App, routes, {});
-`;
-const notLazyImport = '@pages/not-lazy';
-const rootDir = '/src';
-const clientFile = 'client.tsx';
-const arrayWrappers = [
-  ['plain array', '', ''],
-  ['satisfies', '', ' satisfies TRouteObject[]'],
-  ['as', '', ' as TRouteObject[]'],
-  ['as const', '', ' as const'],
-  ['parentheses', '(', ')'],
-  ['non-null assertion', '(', ')!'],
-  ['combined wrappers', '((', ' as const) satisfies TRouteObject[])!'],
-];
-const routeImports = `
-import type { TRouteObject } from '@lomray/vite-ssr-boost/interfaces/route-object';
-import NotLazyPage from '@pages/not-lazy';
-`;
-const childRoutes = `[
-  { Component: NotLazyPage },
-  { lazy: () => import('@pages/home') },
-]`;
+afterEach(() => {
+  directories.splice(0).forEach((root) => fs.rmSync(root, { force: true, recursive: true }));
+  (SsrManifest as unknown as { instance: unknown }).instance = null;
+});
 
-describe('parse-routes', () => {
-  const sandbox = sinon.createSandbox();
-  const serverConfig = ServerConfig.init(
-    { isProd: true, mode: 'production' },
-    { root: rootDir, clientFile },
-  );
-  const routesService = new ParseRoutes(serverConfig, viteAliases);
-
-  /**
-   * Helper to stub exist route file
-   */
-  const stubExistFiles = (): void => {
-    sandbox.stub(fs, 'existsSync').returns(true);
-    // @ts-expect-error no need implement all methods
-    sandbox.stub(fs, 'statSync').callsFake((filename) => {
-      // noinspection JSUnusedGlobalSymbols
-      return { isFile: () => Boolean(path.extname(filename as string)) };
-    });
-  };
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it('should not find client entrypoint and throw error', () => {
-    expect(() => routesService.parse()).toThrow('Unable to find routes file');
-  });
-
-  it('should not find routes import in client entrypoint and throw error', () => {
-    sandbox.stub(fs, 'readFileSync').returns(`
-    import entryClient from '@lomray/vite-ssr-boost/browser/entry';
-
-    void entryClient(App, routes, {});
-    `);
-
-    expect(() => routesService.parse()).toThrow('Unable to find routes file');
-  });
-
-  it('should parse ssr boost client entrypoint and find routes import', () => {
-    stubExistFiles();
-
-    const readFileSyncStub = sandbox.stub(fs, 'readFileSync').returns(clientEntrypoint(true));
-
-    const tree = routesService.parse();
-    const entrypointFile = readFileSyncStub.firstCall.firstArg as string;
-    const routeFile = readFileSyncStub.secondCall.firstArg as string;
-
-    expect(tree).to.deep.equal([]);
-    expect(entrypointFile).to.deep.equal(`${rootDir}/${clientFile}`);
-    expect(routeFile).to.deep.equal(`${rootDir}/routes/index.js`);
-  });
-
-  it('should parse route file', () => {
-    stubExistFiles();
-
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(routesCode4Before);
-
-    const tree = routesService.parse();
-
-    expect(tree).to.deep.equal([
-      {
-        index: 0,
-        import: '@components/layouts/app',
-        children: [
-          {
-            index: 0,
-            import: '',
-            children: [{ index: 0, import: '@pages/sign-in', children: [] }],
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('should parse multiple route files with async and static imports', () => {
-    stubExistFiles();
-
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(routesCode1Before)
-      .onThirdCall()
-      .returns(routesDetailsCode);
-
-    const tree = routesService.parse();
-
-    expect(tree).to.deep.equal([
-      {
-        index: 0,
-        import: '@components/layouts/app',
-        children: [
-          { index: 0, import: '@pages/home', children: [] },
-          {
-            index: 1,
-            import: '',
-            children: [
-              { index: 0, import: '@pages/details/index', children: [] },
-              { index: 1, import: '@pages/details/user', children: [] },
-            ],
-          },
-          { index: 2, import: '@pages/error-boundary', children: [] },
-          { index: 3, import: '@pages/nested-suspense', children: [] },
-          { index: 4, import: '@pages/redirect', children: [] },
-          { index: 5, import: '@pages/redirect', children: [] },
-          { index: 6, import: notLazyImport, children: [] },
-          { index: 7, import: notLazyImport, children: [] },
-          { index: 8, import: notLazyImport, children: [] },
-          { index: 9, import: notLazyImport, children: [] },
-          { index: 10, import: notLazyImport, children: [] },
-        ],
-      },
-    ]);
-  });
-
-  it('should parse route files with static imports: element', () => {
-    stubExistFiles();
-
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(routesCode2Before);
-
-    const tree = routesService.parse();
-
-    expect(tree).to.deep.equal([
-      { index: 0, import: notLazyImport, children: [] },
-      { index: 1, import: notLazyImport, children: [] },
-      { index: 2, import: notLazyImport, children: [] },
-      { index: 3, import: notLazyImport, children: [] },
-      { index: 4, import: notLazyImport, children: [] },
-    ]);
-  });
-
-  it('should parse route files with named imports', () => {
-    stubExistFiles();
-
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint(true, true))
-      .onSecondCall().returns(`
-        import NotLazyPage from '@pages/not-lazy';
-
-        const routes: TRouteObject[] = [
-          {
-            element: <NotLazyPage />,
-          },
-        ];
-        const anotherRoutes = [];
-
-        export { routes, anotherRoutes };
-      `);
-
-    const tree = routesService.parse();
-
-    expect(tree).to.deep.equal([{ index: 0, import: '@pages/not-lazy', children: [] }]);
-  });
-
-  describe.each(arrayWrappers)('%s', (_name, prefix, suffix) => {
-    it.each(['variable', 'named', 'default'])(
-      'should parse a %s export and nested children',
-      (kind) => {
-        stubExistFiles();
-        const array = `${prefix}[
-        { Component: NotLazyPage },
-        { children: ${prefix}${childRoutes}${suffix} },
-      ]${suffix}`;
-        const declaration =
-          kind === 'default'
-            ? `export default ${array};`
-            : `const routes = ${array}; export ${kind === 'named' ? '{ routes }' : 'default routes'};`;
-        sandbox
-          .stub(fs, 'readFileSync')
-          .onFirstCall()
-          .returns(clientEntrypoint(false, kind === 'named'))
-          .onSecondCall()
-          .returns(`${routeImports}${declaration}`);
-
-        expect(JSON.stringify(routesService.parse())).toBe(
-          JSON.stringify([
-            { index: 0, import: notLazyImport, children: [] },
-            {
-              index: 1,
-              import: '',
-              children: [
-                { index: 0, import: notLazyImport, children: [] },
-                { index: 1, import: '@pages/home', children: [] },
-              ],
-            },
-          ]),
-        );
-      },
-    );
-
-    it.each([true, false])(
-      'should preserve route transforms with path IDs enabled: %s',
-      (withPathId) => {
-        const plain = `${routeImports}const routes = [{ children: ${childRoutes} }];`;
-        const wrapped = `${routeImports}const routes = ${prefix}[
-        { children: ${prefix}${childRoutes}${suffix} }
-      ]${suffix};`;
-        const expected = ParseRoutes.handleRoutes(plain, withPathId);
-        const actual = ParseRoutes.handleRoutes(wrapped, withPathId);
-
-        expect(actual.match(/pathId: "[^"]+"/g)).toEqual(expected.match(/pathId: "[^"]+"/g));
-        expect(actual.match(/lazy: n\(\(\) => import\('[^']+'\)\)/g)).toEqual([
-          "lazy: n(() => import('@pages/home'))",
-        ]);
-        expect(actual.match(/import n from/g)).toHaveLength(1);
-      },
-    );
-  });
-
-  it.each([
-    ['TSTypeAssertion', '<TRouteObject[]>'],
-    ['ParenthesizedExpression', ''],
-  ])('should parse an explicit %s AST node', (nodeType, assertion) => {
-    stubExistFiles();
-    // JSX parsing normally represents parentheses as metadata and disallows angle assertions.
-    const code = `${routeImports}const routes = (${assertion}${childRoutes}); export default routes;`;
-    const ast = parse(code, {
-      sourceType: 'module',
-      createImportExpressions: true,
-      createParenthesizedExpressions: true,
-      plugins: ['typescript'],
-    });
-    const initializer = ast.program.body.find((node) => node.type === 'VariableDeclaration')
-      ?.declarations[0].init;
-    expect(initializer?.type).toBe('ParenthesizedExpression');
-    if (initializer?.type === 'ParenthesizedExpression') {
-      expect(initializer.expression.type).toBe(assertion ? nodeType : 'ArrayExpression');
-    }
-    const routesParser = routesService as unknown as {
-      parseFile: (filename: string) => ReturnType<typeof parse> | null;
+describe('ordinary route declarations', () => {
+  it.each(routeFixtures)('$name resolves the original module and route ID', (fixture) => {
+    const { root, parser, config } = setup();
+    writeRouteFixture(root, fixture);
+    const tree = parser.parse();
+    const manifest = SsrManifest.get(config) as unknown as {
+      getRoutesTreeIds: (tree: ReturnType<ParseRoutes['parse']>) => Record<string, string>;
     };
-    sandbox
-      .stub(routesParser, 'parseFile')
-      .onFirstCall()
-      .returns(parse(clientEntrypoint(), { sourceType: 'module' }))
-      .onSecondCall()
-      .returns(ast);
-
-    expect(routesService.parse()).toEqual([
-      { index: 0, import: notLazyImport, children: [] },
-      { index: 1, import: '@pages/home', children: [] },
-    ]);
-  });
-
-  it('should parse wrappers in imported children route files', () => {
-    stubExistFiles();
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(
-        `
-        import children from './details';
-        const routes = [{ children }] satisfies TRouteObject[];
-        export default routes;
-      `,
-      )
-      .onThirdCall()
-      .returns(`${routeImports}export default (${childRoutes} as const);`);
-
-    expect(routesService.parse()).toEqual([
+    const result = manifest.getRoutesTreeIds(tree);
+    const expectedId =
       {
-        index: 0,
-        import: '',
-        children: [
-          { index: 0, import: notLazyImport, children: [] },
-          { index: 1, import: '@pages/home', children: [] },
-        ],
+        'explicit-id': 'about',
+        'object-spread': 'about',
+        'computed-keys': 'about',
+        'skipped-position': '1-1',
+        'imported-children': '0-0',
+        'wrapped-arrays': '0-0',
+      }[fixture.name] ?? '0';
+    expect(result).toEqual({ [expectedId]: 'About' });
+  });
+
+  it.each([
+    ['', ''],
+    ['(', ')'],
+    ['', ' satisfies import("react-router").RouteObject[]'],
+    ['', ' as const'],
+    ['((', ' as const) satisfies import("react-router").RouteObject[])!'],
+  ])('unwraps array and children syntax %s ... %s', (prefix, suffix) => {
+    const { root, parser } = setup();
+    writeRouteFixture(root, {
+      routes: `const routes = ${prefix}[{ children: ${prefix}[{ lazy: () => import('./About') }]${suffix} }]${suffix}; export default routes;`,
+    });
+    expect(parser.parse()[0].children[0].import).toBe(path.join(root, 'About'));
+  });
+
+  it('follows named re-exports, local aliases, spread override order, and JSX modules', () => {
+    const { root, parser } = setup();
+    writeRouteFixture(root, {
+      routes: "export { routes as default } from './other';",
+      files: {
+        'other.tsx':
+          "import Page from './Page'; const common = { id: 'first', lazy: () => import('./About') }; const routes = [{ ...common, id: 'second' }, { element: <Page /> }]; export { routes };",
+        'Page.tsx': 'export default function Page() { return <p>Page</p>; }',
       },
+    });
+    expect(parser.parse()).toEqual([
+      { index: 0, id: 'second', import: path.join(root, 'About'), children: [] },
+      { index: 1, import: path.join(root, 'Page'), children: [] },
     ]);
   });
 
   it.each([
-    ['const routes = makeRoutes(); export default routes;', 'CallExpression'],
-    ['const routes = ({} as TRouteObject[])!; export default routes;', 'ObjectExpression'],
-    ['const routes = otherRoutes satisfies TRouteObject[]; export default routes;', 'Identifier'],
-    ['let routes; export default routes;', 'undefined'],
-  ])('should report the file and unwrapped node type for %s', (code, nodeType) => {
-    stubExistFiles();
-    const warnStub = sandbox.stub(serverConfig.getLogger(), 'warn');
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(code);
-
-    expect(() => routesService.parse()).toThrow(
-      `Expected routes array in /src/routes/index.js, received ${nodeType}.`,
+    ['export default makeRoutes();', 'routes array'],
+    ['export default [{ ...makeShared() }];', 'object spread'],
+    ['const key = "path"; export default [{ [key]: "/" }];', 'computed route key'],
+    ['export default [{ lazy: () => import(moduleName) }];', 'dynamic lazy import'],
+    ['export default [{ lazy: () => Promise.resolve({}) }];', 'lazy route result'],
+    ['export default [{ lazy: { Component: () => import("./About") } }];', 'lazy route'],
+    ['export default [{ children: makeChildren() }];', 'routes array'],
+    ['export default [{ id: Math.random() }];', 'route id'],
+    ['const shared = { ...shared }; export default [shared];', 'object spread'],
+    ['const routes = [{ children: routes }]; export default routes;', 'routes array'],
+    ['const routes = [...others]; export default routes;', 'route array spread'],
+    ['export default [{ children: missing }];', 'unresolved binding missing'],
+    ['const routes = other; const other = routes; export default routes;', 'circular binding'],
+    ['export default {};', 'routes array'],
+  ])('reports file, line and construct for %s', (routes, construct) => {
+    const { root, parser } = setup();
+    writeRouteFixture(root, { routes: `\n${routes}` });
+    expect(() => parser.parse()).toThrow(
+      new RegExp(`routes\\.ts:2:\\d+: Unsupported .*${construct}`),
     );
-    expect(warnStub.called).toBe(false);
   });
 
-  it.each([
-    ['export default createRoutes();', 'CallExpression'],
-    ['export default {} satisfies TRouteObject[];', 'ObjectExpression'],
-  ])('should warn once and return an empty result for %s', (code, nodeType) => {
-    stubExistFiles();
-    const warnStub = sandbox.stub(serverConfig.getLogger(), 'warn');
-    sandbox
-      .stub(fs, 'readFileSync')
-      .onFirstCall()
-      .returns(clientEntrypoint())
-      .onSecondCall()
-      .returns(code);
+  it('reports missing exports, imports and syntax without swallowing errors', () => {
+    const { root, parser } = setup();
+    writeRouteFixture(root, { routes: 'export const nothing = 1;' });
+    expect(() => parser.parse()).toThrow(/routes.ts:1:1: Unsupported missing export "default"/);
+    fs.rmSync(path.join(root, 'routes.ts'));
+    expect(() => parser.parse()).toThrow(/client.ts:4:\d+: Unsupported missing import/);
+    writeFixture(root, 'routes.ts', 'export default [');
+    expect(() => parser.parse()).toThrow(/routes.ts: Unexpected token/);
+  });
 
-    expect(routesService.parse()).toEqual([]);
-    expect(
-      warnStub.calledOnceWithExactly(
-        `Routes manifest: default export of /src/routes/index.js is a ${nodeType} and cannot be analyzed; lazy route assets will not be injected.`,
-      ),
-    ).toBe(true);
+  it('does not mistake an unrelated local entryClient function for the library entry', () => {
+    const { root, parser } = setup();
+    writeFixture(root, 'client.ts', 'function entryClient() {} entryClient();');
+    expect(() => parser.parse()).toThrow(/browser entry calls \(0\)/);
+  });
+
+  it('transforms computed lazy keys and async function/then imports once', () => {
+    for (const lazy of [
+      "() => import('./About')",
+      "async function () { return await import('./About'); }",
+      "() => import('./About').then(m => ({ Component: m.Component }))",
+    ]) {
+      const result = ParseRoutes.handleRoutes(`const routes = [{ ['lazy']: ${lazy} }];`, true);
+      expect(result).toContain('pathId: "./About"');
+      expect(result.match(/import n from/g)).toHaveLength(1);
+      expect(result.match(/\bn\(/g)).toHaveLength(1);
+    }
   });
 });

--- a/__tests__/services/path-normalize.ts
+++ b/__tests__/services/path-normalize.ts
@@ -33,10 +33,16 @@ describe('PathNormalize', () => {
       '.js',
       '.ts',
       '.tsx',
+      '.jsx',
+      '.mjs',
+      '.mts',
       '/index',
       '/index.js',
       '/index.ts',
       '/index.tsx',
+      '/index.jsx',
+      '/index.mjs',
+      '/index.mts',
     ]);
   });
 

--- a/browser-tests/data-stream.spec.mjs
+++ b/browser-tests/data-stream.spec.mjs
@@ -1,0 +1,60 @@
+import { test, expect, chromium } from '@playwright/test';
+
+for (const mode of ['Await', 'use']) {
+  test(`early shell is interactive within 300ms; ${mode} hydrates once and client loaders stay native`, async () => {
+    let browser;
+    try {
+      browser = await chromium.launch({ timeout: 10_000 });
+    } catch (error) {
+      const reason =
+        error.message.split('\n').find((line) => line.includes('Permission denied')) ||
+        error.message.split('\n')[0];
+      console.info(`SKIP Chromium: ${reason}`);
+      test.skip(true, `Chromium cannot launch in this environment: ${reason}`);
+      return;
+    }
+    try {
+      const page = await browser.newPage();
+      const errors = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      page.on('console', (message) => {
+        if (message.type() === 'error') errors.push(message.text());
+      });
+      await page.addInitScript(() => {
+        const observer = new MutationObserver(() => {
+          if (document.querySelector('button')) {
+            window.shellAt = performance.now();
+            observer.disconnect();
+          }
+        });
+        observer.observe(document, { childList: true, subtree: true });
+      });
+      // Warm the built entry, matching the cached async-entry timing regression.
+      await page.goto('http://127.0.0.1:4179/');
+      await page.getByRole('button', { name: 'Count 0' }).click();
+      await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+      await page.goto(`http://127.0.0.1:4179/deferred${mode === 'use' ? '?use=1' : ''}`, {
+        waitUntil: 'commit',
+      });
+      await page.getByRole('button', { name: 'Count 0' }).click({ timeout: 300 });
+      await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible({ timeout: 300 });
+      const interactiveMs = await page.evaluate(() => performance.now() - window.shellAt);
+      expect(interactiveMs).toBeLessThanOrEqual(300);
+      await expect(page.locator('[data-fallback]')).toBeVisible();
+      await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+      await expect(page.locator('[data-resolved]')).toHaveCount(1);
+      await expect(page.locator('[data-fallback]')).toHaveCount(0);
+      expect(errors).toEqual([]);
+      await page.getByRole('link', { name: 'Home', exact: true }).click();
+      await page.getByRole('link', { name: 'Deferred', exact: true }).click();
+      await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+      await expect(page.locator('[data-resolved]')).toHaveCount(1);
+      expect(errors).toEqual([]);
+      console.info(
+        `${mode}: shell interactive after ${Math.round(interactiveMs)}ms; no hydration errors or duplicates`,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,41 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/lomray-software/vite-ssr-boost",
-  "public_key": "pk_9IAtRK9ehH9s9ktsgMjAJ"
+  "public_key": "pk_9IAtRK9ehH9s9ktsgMjAJ",
+  "projectTitle": "Vite SSR BOOST",
+  "description": "SSR and streaming for existing Vite + React Router apps in Data mode, without Framework mode",
+  "branch": "prod",
+  "folders": ["docs"],
+  "excludeFolders": [
+    "__tests__",
+    "__mocks__",
+    "__helpers__",
+    "tests",
+    "scripts",
+    "src",
+    "lib",
+    "node_modules",
+    "./examples",
+    "./acceptance",
+    "docs/.vitepress",
+    "docs/public"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "LICENSE.md",
+    "PR_DESCRIPTION.md",
+    "SECURITY.md",
+    "SUPPORT.md"
+  ],
+  "rules": [
+    "For v8, use @lomray/vite-ssr-boost/adapters/express/entry for the managed Express server entry.",
+    "For v8, import the default createHandler from @lomray/vite-ssr-boost/core/handler for Fetch-based servers.",
+    "For v8, use @lomray/vite-ssr-boost/browser/entry for hydration or SPA mounting.",
+    "The @lomray/vite-ssr-boost/node/entry path was removed in 8.0.0. Never generate v8 examples importing it; consult the v7.1.0 index only for v7 applications.",
+    "Use React Router Data mode with route objects. Loader data must be JSON-serializable: nested promises become {}, and Await/use cannot hydrate loader promises."
+  ],
+  "previousVersions": [{ "tag": "v7.1.0" }]
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
           { text: 'Choosing an SSR Approach', link: '/guide/choosing' },
           { text: 'Rendering Modes', link: '/guide/rendering-modes' },
           { text: 'Routing', link: '/guide/routing' },
+          { text: 'Stream loader data', link: '/guide/data-streaming' },
           { text: 'Server Lifecycle', link: '/guide/server-lifecycle' },
           { text: 'Runtime Adapters', link: '/guide/runtime-adapters' },
           { text: 'Deployment', link: '/guide/deployment' },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: 'Introduction', link: '/' },
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Migrate an Existing SPA', link: '/guide/migrate-existing-spa' },
+          { text: 'Upgrade from 7 to 8', link: '/guide/upgrade-v8' },
           { text: 'Choosing an SSR Approach', link: '/guide/choosing' },
           { text: 'Rendering Modes', link: '/guide/rendering-modes' },
           { text: 'Routing', link: '/guide/routing' },
@@ -83,6 +84,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'AI Usage', link: '/ai-usage' },
+          { text: 'Support and versions', link: '/reference/support' },
           { text: 'Talking Points', link: '/reference/talking-points' },
           { text: 'Hydration order and streaming', link: '/reference/hydration-and-streaming' },
           { text: 'FAQ', link: '/reference/faq' },

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -33,6 +33,8 @@ Loader and action promises stream by default in Data mode. Return `{ fast, slow:
 
 ## Application guidance
 
+For an existing Vite + React Router app, run `ssr-boost init --dry-run` first and review every diff before `--apply`. After changing entries, routes, plugins, scripts, or dependencies, run `ssr-boost doctor --json`; resolve errors and inspect version warnings before building. See the [CLI reference](/api/cli) for `--root`, overrides and support bundles.
+
 - Keep lazy route imports statically analyzable.
 - Align Vite `base` with the server static middleware basename.
 - Use `onRequest` for app props scoped to a request.

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -29,7 +29,7 @@ A Fetch transport owns its development server, bundling, static assets and route
 
 ## Data loading contract
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
 ## Application guidance
 
@@ -45,7 +45,8 @@ Loader results are serialized with `JSON.stringify` into `window.__staticRouterH
 
 - The browser entry resolves matched lazy routes and waits for the SSR state before creating the router and hydrating.
 - `data-force-spa="1"` on the root forces SPA mounting.
-- Rendering aborts on timeout or request cancellation.
+- Rendering and pending router promises abort on timeout or request cancellation.
+- Early hydration requires an async client entry and custom state available at `onShellReady`; buffered bot rendering waits for all promises.
 - CLI focus selection uses `--focus-only`; use `--focus-only client` for SPA build and start.
 - Plugin `entrypoint` configures additional build surfaces.
 - The package does not implement RSC, Server Actions or file-system routing conventions.

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -18,11 +18,12 @@ The package declares `engines.node: ">=22.12.0"` and peers for Vite `>=5`, React
 - Fetch core: default export `createHandler` from `@lomray/vite-ssr-boost/core/handler`.
 - Transport adapters: `@lomray/vite-ssr-boost/adapters/node`, `adapters/express`, `adapters/fastify`, `adapters/hono` and `adapters/edge`, all under the package prefix.
 - Renderers: `@lomray/vite-ssr-boost/node/render-to-stream` and `@lomray/vite-ssr-boost/edge/render-to-stream`.
+- Node production helpers: `@lomray/vite-ssr-boost/node/production`.
 - CLI binary: `ssr-boost`.
 
 ## Default workflow and transport ownership
 
-Prefer the managed CLI for Vite development, HMR, asset manifests and production static files. It uses Express, and managed request/render hooks retain the live Express `req` and `res` objects. The removed `node/entry` path is not the v8 server entry.
+Prefer the managed CLI for Vite development, HMR, asset manifests and production static files. It uses Express, and managed request/render hooks retain the live Express `req` and `res` objects. `node/entry` was removed in 8.0.0; use `adapters/express/entry` for v8 and follow [Upgrade from 7 to 8](/guide/upgrade-v8).
 
 A Fetch transport owns its development server, bundling, static assets and route-asset injection. It can initialize `ServerConfig` from `@lomray/vite-ssr-boost/services/server-config` and inject manifest assets with `SsrManifest` from `@lomray/vite-ssr-boost/services/ssr-manifest`; see [Runtime adapters](/guide/runtime-adapters). The [custom-server example](https://github.com/Lomray-Software/vite-template/tree/example/custom-server) demonstrates this integration with Fastify in production and the managed CLI in development.
 
@@ -49,3 +50,19 @@ Loader results are serialized with `JSON.stringify` into `window.__staticRouterH
 - Plugin `entrypoint` configures additional build surfaces.
 - The package does not implement RSC, Server Actions or file-system routing conventions.
 - Use the [comparison guide](/guide/choosing) and its official sources for claims about other projects.
+
+## Machine-readable documentation
+
+The docs build generates [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt) and [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt) from the Markdown sources. The short file includes the package identity, the resolved release version when available, the public entrypoints and data-loading contract from this page, and an absolute URL for every documentation page. The full file concatenates those pages with their source URLs.
+
+Run `npm run docs:build` to regenerate both files in `docs/.vitepress/dist`. The version comes from `git describe --tags --match 'v*' --abbrev=0`, with the leading `v` removed. If tags are unavailable, the build falls back to `npm view @lomray/vite-ssr-boost version`; if that also fails, it omits the version line. The build reports which source it used. The docs workflow fetches full Git history and tags so CI can use the tag path. The source manifest's placeholder version is never used; semantic-release assigns the published package version in `lib/package.json` separately.
+
+Generation checks that every indexed URL has a built HTML page and reports the page/link counts. GitHub Pages deploys these files with the rest of the docs; generated copies are not checked in.
+
+## Keeping the Context7 index fresh
+
+[`context7.json`](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/context7.json) selects the `prod` branch and `docs/`. Context7 also includes root Markdown automatically; the filename exclusions leave `README.md` as the root source. Tests, scripts, package output and non-documentation examples are excluded, while `docs/examples/` stays indexed. The rules identify the v8 entrypoints and the removed `node/entry` path. The `v7.1.0` tag is configured as a separate previous version for v7 users. See the [Context7 configuration guide](https://context7.com/docs/library-owners).
+
+Maintainers set the optional repository Actions secret `CONTEXT7_API_KEY`. The [refresh workflow](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/.github/workflows/context7-refresh.yml) calls the [documented refresh API](https://context7.com/docs/integrations/github-actions) on published releases or manual dispatch. The `prod` release job also calls it as a reusable workflow: [events created with `GITHUB_TOKEN` do not start another workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow). This also refreshes docs-only changes after a successful `prod` release job.
+
+The API step uses a job environment variable in its condition, following [GitHub's optional-secret pattern](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets), so a missing key skips the request. The request refreshes the library's configured source; `context7.json` selects `prod`, so publishing a prerelease does not switch the main index to `staging`. After promoting documentation to `prod`, maintainers can dispatch the workflow to retry a failed refresh or refresh without a release. Check the workflow result and the [Context7 listing](https://context7.com/lomray-software/vite-ssr-boost) after indexing completes; a successful API request queues refresh work and does not prove parsing has finished.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -10,6 +10,96 @@ The CLI is the operational face of the package. It drives development, builds, p
 
 ## Main commands
 
+### `ssr-boost init`
+
+Adds SSR to an existing Vite + React Router Data-mode app. The default is a dry run:
+
+```bash
+npx ssr-boost init --dry-run
+npx ssr-boost init --apply
+npm install
+```
+
+Before installing the library, invoke it with `npx --package @lomray/vite-ssr-boost ssr-boost init`.
+
+| Option | Meaning |
+| --- | --- |
+| `--dry-run` | Print a unified diff of every proposed file; write nothing (default). |
+| `--apply` | Write the complete plan after validating it. Cannot be combined with `--dry-run`. |
+| `--root <dir>` | Project directory; defaults to the current directory. |
+| `--entry <file>` | Browser file relative to the project; must match the HTML module script. |
+| `--routes <file>` | Module with one exported route array, relative to the project. |
+
+Example output excerpt:
+
+```diff
+--- a/index.html
++++ b/index.html
+@@ -1 +1 @@
+-<div id="root"></div>
++<div id="root"><!--ssr-outlet--></div>
+```
+
+```text
+Dry run: no files written. Use --apply to write these changes.
+Next: npm install; then npx ssr-boost doctor.
+```
+
+The remaining diffs show the Vite plugin, browser/server entries, scripts and dependency, plus an extracted route module when the routes were inline. The CLI preserves surrounding source, quotes and line endings where possible; it does not require Prettier. It never installs dependencies. A second `--apply` prints `No changes: SSR is already initialized. Run ssr-boost doctor.`
+
+An existing `dev` script becomes `ssr-boost dev`; no duplicate `develop` is added. Without `dev`, the command updates or adds `develop`. It always sets `build` to `ssr-boost build` and adds `start:ssr` as `ssr-boost start`; a stock `vite preview` script becomes `ssr-boost preview`. Existing routes imports keep their module specifier and binding (for example, `import { routes } from './routes'`). `StrictMode`, Fragment, and unwrapped roots get an explicit App component in both entries to preserve the render tree without forwarding entry props to React built-ins.
+
+Unsupported layouts exit 1 before writing and include the [manual migration guide](/guide/migrate-existing-spa). See that guide for supported layouts and constraints, including custom bases and provider initialization.
+
+### `ssr-boost doctor`
+
+Inspects the project without importing application modules, executing Vite plugins, or reading environment files:
+
+```bash
+npx ssr-boost doctor
+npx ssr-boost doctor --json --root ./my-app
+npx ssr-boost doctor --bundle support.json
+```
+
+| Option | Meaning |
+| --- | --- |
+| `--json` | Print a JSON report instead of the check table. |
+| `--root <dir>` | Project directory; defaults to the current directory. |
+| `--bundle <file>` | Write a support bundle JSON, relative to the project directory (absolute paths also work). |
+
+Each table/JSON check has `name`, `status` (`ok`, `warn`, `error`), a message and a one-line `fix`. Exit status is **1 if any check is an error**, otherwise **0**. An `ok` fix describes how to maintain that condition.
+
+Table excerpt:
+
+```text
+status  check         message                                 fix
+ok      node          Node 22.23.2 satisfies engines           Use a Node version satisfying the package and app engines (CI uses 22.23.2).
+ok      vite-plugin   SsrBoost() is in the Vite plugins        Add SsrBoost() from @lomray/vite-ssr-boost/plugin to Vite plugins.
+error   html-outlet   index.html: expected one outlet, found 0 Place exactly one <!--ssr-outlet--> inside the root element.
+```
+
+JSON check excerpt:
+
+```json
+{
+  "name": "routes",
+  "status": "ok",
+  "message": "2 route IDs resolved",
+  "fix": "Use statically analyzable route objects; follow the file and line in the parser error."
+}
+```
+
+Checks cover readable package metadata; installed `@lomray/vite-ssr-boost`, React, React DOM, React Router and Vite versions; Node against the library, app and installed runtime engines; physical duplicate React copies via `npm ls react react-dom --json --all --long`; the imported Vite plugin; the HTML module script and exactly one outlet; both library entries; the actual route parser; and development/build/SSR scripts. Per-package `version:*` checks verify installation and peer ranges; missing packages or unsatisfied peer ranges are errors. A single `compatibility` check is `ok` only when React and React DOM, React Router, and Vite exactly match a row in the [compatibility workflow](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/.github/workflows/react-compatibility.yml). Otherwise it warns with the installed trio and closest tested row. The closest row has the most matching components, with ties resolved by proximity of React, Router, then Vite versions. Those rows ship with the CLI and a test prevents drift.
+
+```text
+warn  compatibility  React 19.2.8 + Router 7.18.3 + Vite 8.2.2 is not a tested row; closest: React 19.2.8 + Router 7.18.3 + Vite 7.3.6
+fix: Use React and React DOM 19.2.8, React Router 7.18.3, and Vite 7.3.6 for a tested combination.
+```
+
+The `robots` and `size-budget` checks have `info: true`: they report missing/custom/blocked crawl policies and the presence of a size budget script without changing policy or failing the check. Doctor uses static configuration analysis; configuration it cannot resolve gets an actionable error instead of executing arbitrary config code.
+
+The support bundle (`schemaVersion: 1`) includes versions, adapter, route IDs and literal paths, check names/statuses/fixes, and known diagnostic codes from the last recorded build. It omits raw error messages, npm trees, source code, cookies, environment values, loader/state data, and other application data. A pathless route or a dynamic path helper is represented by `path: null`; the tool does not execute path helpers. Successful managed builds record only known codes in `<outDir>/ssr-boost-diagnostics.json`, resetting the list for each build. An absent or invalid record yields an empty list. See [development diagnostics](/reference/diagnostics) for code meanings.
+
 ### `ssr-boost dev`
 
 Runs the development server.

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -46,6 +46,9 @@ The entry returns a render definition consumed by the runtime server. It include
 
 ```ts
 interface IEntrypointOptions<TAppProps> {
+  hydration?: 'footer' | 'early';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   onServerCreated?;
   onServerStarted?;
   onRequest?;

--- a/docs/guide/choosing.md
+++ b/docs/guide/choosing.md
@@ -19,7 +19,7 @@ The RSC implementations linked above have different release contracts: React Rou
 
 ## Loader data in vite-ssr-boost
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Use Suspense with `<Await>` or React 19 `use()` for slow fields, and opt into `hydration: 'early'` when the shell should become interactive before slow boundaries finish. See [Stream loader data](/guide/data-streaming) for the value matrix and custom-state constraint.
 
 ## Choose a project
 

--- a/docs/guide/data-streaming.md
+++ b/docs/guide/data-streaming.md
@@ -1,0 +1,127 @@
+# Stream loader data
+
+Loader and action promises stream to the browser by default in React Router **Data mode**. Return critical data immediately and leave slower fields as promises. Both `<Await>` and React 19 `use()` receive native promises during hydration. Client navigations run your loaders in the browser, where their promises remain native.
+
+## Return a promise
+
+```tsx
+import { Suspense } from 'react';
+import { Await, useLoaderData } from 'react-router';
+
+export function loader() {
+  return {
+    title: 'Deferred',
+    slow: new Promise<{ users: number }>((resolve) => {
+      setTimeout(() => resolve({ users: 3 }), 1500);
+    }),
+  };
+}
+
+export default function DeferredPage() {
+  const data = useLoaderData() as ReturnType<typeof loader>;
+  return (
+    <main>
+      <h1>{data.title}</h1>
+      <Suspense fallback={<p>Loading users…</p>}>
+        <Await resolve={data.slow} errorElement={<p>Could not load users.</p>}>
+          {(value) => <p>Users: {value.users}</p>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+}
+```
+
+The same structure works in an `action`, read with `useActionData()`. React Router awaits the loader/action's own return promise before rendering: return an object containing a promise to defer a field. The transport also handles a promise at the root of an individual `loaderData` or `actionData` entry, promises nested in plain objects and arrays, and promises introduced by resolved values, including further nesting. Repeated references to a promise share one browser promise within that response.
+
+For real requests, pass the loader's `request.signal` to `fetch`. Keep loader code usable during client navigation; put server-only work behind an API. Attach rejection handlers to work that might reject **before** `staticHandler.query()` finishes; transport handlers are installed after the query.
+
+This follows React Router's [Suspense usage](https://reactrouter.com/how-to/suspense) and [custom Data framework architecture](https://reactrouter.com/start/data/custom).
+
+## React 19 `use()`
+
+Keep the consumer inside its Suspense boundary:
+
+```tsx
+import { Suspense, use } from 'react';
+import { useLoaderData } from 'react-router';
+
+function Users({ promise }: { promise: Promise<{ users: number }> }) {
+  const value = use(promise);
+  return <p>Users: {value.users}</p>;
+}
+
+export default function DeferredPage() {
+  const data = useLoaderData() as { slow: Promise<{ users: number }> };
+  return (
+    <Suspense fallback={<p>Loading users…</p>}>
+      <Users promise={data.slow} />
+    </Suspense>
+  );
+}
+```
+
+Use `<Await>` on React 18. Rejected `use()` promises go to the nearest React error boundary; `<Await errorElement>` can render local failure UI and `useAsyncError()` reads its rejection.
+
+## Supported values
+
+Initial router data and every streamed resolution use the same [devalue](https://github.com/sveltejs/devalue) value codec, with custom promise and error reducers. The transport does not depend on React Router's internal codec exports.
+
+| Value | Browser result |
+| --- | --- |
+| JSON primitives, plain objects, arrays | Same values; own string keys are preserved, including `__proto__`. |
+| `undefined` | Preserved in objects and arrays. |
+| `Date` | A `Date`, including invalid dates. |
+| `Map`, `Set` | Native collections, with recursively decoded keys and values. |
+| `bigint` | A `bigint`, without numeric precision loss. |
+| `RegExp` | Same source and flags; `lastIndex` resets to zero. |
+| `NaN`, positive/negative infinity, `-0`, sparse arrays | Preserved by the codec. |
+| `Promise` | One native promise per request-local identity. |
+| Errors and route error responses | The fields described below; arbitrary custom properties are omitted. |
+| Functions, symbols, other class instances, WeakMap/WeakSet | Unsupported; diagnostics warn and these values decode as `undefined`. |
+| Circular references | Outside the supported contract; diagnostics warn even where the codec can preserve a cycle. Prefer acyclic route data. |
+
+Object identity is preserved within a value frame. Across separate settlement frames only promise identity is guaranteed. Codec features beyond this table, such as typed arrays and arbitrary custom types, are not part of the router-data contract. `getState` continues to use **JSON**, so its custom state must contain plain snapshots with no promises or rich values.
+
+## Rejections and aborts
+
+Ordinary errors retain `message` and `name`. React Router error responses and rejected `data(value, { status, statusText })` values retain `message`, `status`, `statusText` and `data`; reconstructed response errors also satisfy `isRouteErrorResponse`. Stacks are sent only when diagnostics are enabled. Rejections after the shell was sent cannot change the HTTP status.
+
+`abortDelay` defaults to 15 seconds and starts after routing/preparation. It remains active until both React and pending loader/action promises finish, including promises the component never reads. On timeout, pending browser promises reject with `SSR loader/action promise aborted before it settled.` before the response closes. Development diagnostics report `SSR_BOOST_STREAM_PROMISE_ABORTED`. Disconnects cancel rendering and discard queued data when the consumer is gone. Aborting the render does not stop arbitrary application promises; use request cancellation for their underlying work.
+
+## Hydrate the shell early
+
+Opt in on the managed entry's lifecycle configuration:
+
+```ts
+export default entryServer(App, routes, {
+  init: () => ({
+    hydration: 'early',
+    getState: ({ context }) => ({ app: { locale: context.appProps.locale } }),
+  }),
+});
+```
+
+For a Fetch handler, pass `hydration: 'early'` alongside `getHtml` and other `createHandler` options. Use an **async** client module script (`<script type="module" src="/client.ts" async>`); an ordinary module waits for the HTML response to finish parsing. Static assets, matched lazy modules and the client's `init` callback must also load quickly enough for early interaction.
+
+Early mode collects `getState` at `onShellReady`, sends custom state first and router state next in the initial shell block before React's body bytes, and waits for React's bootstrap marker at the end of the parsed shell before hydrating. Slow boundaries can still be pending while a shell button responds. Keep state local to shell controls; on React 18, wrap updates that change a still-hydrating boundary in `startTransition` to avoid forcing that boundary to client rendering.
+
+**Custom state needed for hydration must be available at `onShellReady`.** State created only when a slow boundary resolves needs the application's own state transport. Selective hydration cannot compensate for missing initial custom state. React's bootstrap marker prevents hydration of a partially parsed shell, even if that shell spans multiple network chunks.
+
+The default is `hydration: 'footer'`: custom state and router hydration state stay in the footer, in that order. Settlements can arrive before that initialization and before the entry; the queue retains them without starting hydration.
+
+## Bots, adapters and limits
+
+Choose buffered output for crawlers with the existing hook:
+
+```ts
+onRouterReady: ({ context: { request } }) => ({
+  isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+}),
+```
+
+`isStream: false` waits for all React boundaries and all router promises, then sends complete HTML with resolved data frames in the footer. Successful buffered renders have no pending `<!--$?-->` Suspense markers. This overrides early hydration timing. Bot detection remains your application's choice.
+
+The shared transport works with Node, managed Express, the Express Fetch adapter, Fastify, Hono and edge renderers. It reads React only under response demand and preserves cancellation. Inline state and settlement scripts escape HTML delimiters and U+2028/U+2029; the `nonce` render option is forwarded to React and every generated custom-state/router-data script. `bootstrapScriptContent` is also forwarded to React; early mode prefixes its shell marker to it. Supply trusted JavaScript only for that option.
+
+Keep all generated scripts and closing HTML in `onResponse` transforms. Proxies or compression buffers can delay browser interactivity even though the server emits the shell early. See [Hydration order and streaming](/reference/hydration-and-streaming) and [Server lifecycle](/guide/server-lifecycle).

--- a/docs/guide/migrate-existing-spa.md
+++ b/docs/guide/migrate-existing-spa.md
@@ -2,6 +2,27 @@
 
 Add SSR while keeping your React Router [Data-mode route objects](https://reactrouter.com/start/modes) and components. This guide follows the five-file change in the [minimal example README](https://github.com/Lomray-Software/vite-template/tree/example/minimal#from-a-plain-vite-spa-to-this-project).
 
+## Automatic: `npx ssr-boost init`
+
+For a Vite + React app using `createBrowserRouter` and route objects, preview the migration first:
+
+```bash
+npx ssr-boost init --dry-run
+npx ssr-boost init --apply
+npm install
+npx ssr-boost doctor
+npm run build
+npm run start:ssr
+```
+
+If the library is not installed yet, use `npx --package @lomray/vite-ssr-boost ssr-boost init --dry-run` (then repeat with `--apply`). This downloads the CLI to npm's cache; `init` itself never installs dependencies. With neither flag, `init` defaults to a dry run and prints a unified diff without creating files. `--root <dir>`, `--entry <file>` and `--routes <file>` select the project, browser entry and exported route module; file overrides are relative to the project directory.
+
+The command makes the five integration changes below: adds `SsrBoost()` while preserving existing plugins, inserts the outlet inside `#root`, replaces the browser bootstrap with the library entry, creates an Express server entry next to it, and updates the dependency and scripts. An existing `dev` script becomes `ssr-boost dev` without adding a duplicate `develop`; otherwise it updates or adds `develop`. It always sets `build` to `ssr-boost build` and adds `start:ssr` as `ssr-boost start`. A stock `preview` script also switches to `ssr-boost preview`. It preserves an imported App wrapper around `RouterProvider`. For `StrictMode`, a Fragment, or no wrapper, it creates an explicit App component in both entries so the browser and server render the same tree. Inline route declarations and their dependencies move into an additional `routes.ssr.tsx` (or JS/TS equivalent) module shared by both entries. Existing exported route modules stay in place, preserving their import specifiers and local bindings. Repeating `--apply` makes no further changes.
+
+Automatic migration supports TypeScript and JavaScript, root `index.html` and Vite `root: 'src'`, literal plugin arrays, static routes, and conventional aliases. It stops before writing for JSX `BrowserRouter`/`Routes`, missing or multiple `createBrowserRouter` calls, multiple HTML/build entries, runtime-generated Vite configuration, an existing server file, custom router options, wrappers requiring extra props, additional browser startup statements, or a Vite `base` other than `/`. The error identifies the file and construct and links to this manual reference. It does not invent metadata providers or request hooks: adapt those with the steps below when your app needs them.
+
+Run [`doctor --json`](/api/cli#ssr-boost-doctor) after further changes. Review browser globals in your components using the [pitfalls below](#pitfalls).
+
 ## Prerequisites
 
 - Node 22: the package declares `engines.node: ">=22.12.0"`; use Node 22.23.2 for this example and its tooling.
@@ -141,7 +162,7 @@ After — source: [package.json](https://github.com/Lomray-Software/vite-templat
 }
 ```
 
-Run `npm run develop` for development. Run `npm run build` and then `npm run start:ssr` to serve the SSR build.
+Run `npm run dev` if your app has a `dev` script, or `npm run develop` for the example above. Run `npm run build` and then `npm run start:ssr` to serve the SSR build.
 
 ## Data loading
 

--- a/docs/guide/migrate-existing-spa.md
+++ b/docs/guide/migrate-existing-spa.md
@@ -145,7 +145,7 @@ Run `npm run develop` for development. Run `npm run build` and then `npm run sta
 
 ## Data loading
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
 The [users page](https://github.com/Lomray-Software/vite-template/blob/example/minimal/src/pages/users/index.tsx) shows a loader that waits for its data before returning. Keep loader code usable in the browser for client navigation; call an API for server-only operations.
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -41,22 +41,29 @@ const routes: RouteObject[] = [
 ];
 ```
 
-The routes array may be typed with `satisfies TRouteObject[]` or `as TRouteObject[]`.
+Arrays and route objects can be wrapped with `satisfies`, `as`, parentheses or non-null assertions. The parser follows default and named import aliases, including `import boot from '.../browser/entry'` and `import { entry as boot } from '.../browser/entry'`. Both call `boot(App, routes)`.
 
-Not recommended for route analysis:
+Shared static objects, literal computed keys, explicit IDs, and imported child arrays are supported:
 
 ```tsx
-const importPath = './pages/home';
+import { childRoutes as children } from './children';
 
-const routes = [
-  {
-    path: '/home',
-    lazy: () => import(importPath),
-  },
-];
+const shared = { handle: { title: 'Account' } };
+export default [
+  { ...shared, ['id']: 'account', path: '/account', children },
+] satisfies import('react-router').RouteObject[];
 ```
 
-If route import detection matters for your build flow, keep lazy imports statically analyzable.
+Object spreads follow JavaScript override order. Static bindings and named re-exports are resolved across local modules and Vite aliases. Explicit `id` values are used for assets; generated IDs retain the original array positions, including below explicitly named parents. Routes without asset imports never renumber their siblings.
+
+Lazy values can be arrow functions or function expressions returning one literal `import()`, with optional `async`/`await` or `.then()` to select the module's `Component`. For example:
+
+```tsx
+{ path: '/account', lazy: async function () { return await import('./pages/account'); } }
+{ path: '/account', lazy: () => import('./pages/account').then(m => ({ Component: m.Account })) }
+```
+
+Runtime route factories, array spreads, computed keys that are not string literals, non-static IDs, cycles, conditional children and non-literal or multiple lazy imports produce one error naming the file, line and construct. Dynamic path helpers remain supported because paths do not select asset modules; doctor represents those paths as `null` in support bundles instead of executing application code.
 
 ## Loader and action promises
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -58,6 +58,10 @@ const routes = [
 
 If route import detection matters for your build flow, keep lazy imports statically analyzable.
 
+## Loader and action promises
+
+Return promises for slow fields, such as `{ title, slow: fetchUsers() }`, and render them inside Suspense with `<Await>` or React 19 `use()`. The server streams their settlements and the browser reconstructs promises before router creation. See [Stream loader data](/guide/data-streaming), including `hydration: 'early'` for shell interaction while boundaries are pending. Keep loaders usable in the browser for client navigations.
+
 ## `routesPath`
 
 `routesPath` helps the plugin detect where route declarations live. Use it when your route files are not obvious from the default project shape.

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -33,32 +33,7 @@ transforms streamed HTML. The core decodes split UTF-8 chunks safely before invo
 
 ### Migration notes
 
-Update imports relative to `@lomray/vite-ssr-boost/` (also applies to explicit `.js` imports):
-
-| Removed path | New path |
-| --- | --- |
-| `node/entry` | `adapters/express/entry` |
-| `node/server` | `adapters/express/server` |
-| `node/render` | `adapters/express/render` |
-| `node/create-fetch-request` | `adapters/express/create-request` |
-| `services/prepare-server` | `adapters/express/prepare-server` |
-
-The old `node/write-response` and `helpers/handle-response` internals are removed. The renderer now
-handles response composition and redirects through the Fetch core; custom Node transports can send
-the resulting `Response` with `node/write-fetch-response`.
-
-- The default shell-error page returns a generic HTTP 500 without exception messages. Use `onError`
-  for diagnostics or `onShellError` for a custom page.
-- Request/render hook failures reach Express error middleware through `next(error)`, rather than
-  falling through to a 404. Register error middleware after the SSR handler.
-- Unless explicitly overridden, rendered responses use React Router's status, including 404 for
-  unmatched routes. Previously these could be sent as 200.
-- Render timeouts and client/intentional cancellation report `onError` codes `timeout` and `cancel`.
-  The managed Express server logs these at info level. Unexpected errors retain their original error.
-- Parsed JSON and flat URL-encoded bodies work automatically. Nested form values and unsupported
-  custom or multipart parser results fail explicitly; use `getBody` as shown below.
-- Package exports support extensionless and explicit `.js` imports for the new paths, with matching
-  TypeScript declarations. Other module paths are unchanged.
+See [Upgrade from 7 to 8](/guide/upgrade-v8) for the complete import map, `onResponse` contract, `context.request`, Node requirement and changed error handling.
 
 Express and compression are optional dependencies installed by default. If your install command
 uses `--omit=optional`, install them explicitly:

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -83,6 +83,10 @@ Return:
 
 This is the place to switch between streaming and full-document rendering based on user agent, route match or any other request-level policy.
 
+## Promise streaming and hydration
+
+Loader/action promises stream by default. Set `hydration: 'early'` in the lifecycle configuration (or Fetch handler options) to hydrate the parsed shell while boundaries are pending. The early block contains `getState` custom state before router state, so custom state must be available at `onShellReady`. Default footer ordering remains custom state, router state, footer. `nonce` applies to React and all generated scripts; `bootstrapScriptContent` is forwarded with the early shell marker prepended when enabled. See [Stream loader data](/guide/data-streaming).
+
 ## `onShellReady`
 
 Replaces the template header or footer around the React stream. Generated hydration state is
@@ -147,6 +151,8 @@ The React render aborts when:
 - `abortDelay` is exceeded
 - the client disconnects before the response finishes
 - a source or destination stream fails
+
+Pending loader/action promises also reject on abort; connected browsers receive rejection scripts before closing. The timer remains active until both React and router promises finish, including unused data.
 
 The timer starts after loaders and `onRouterReady` finish. Use the loader's `request.signal` for
 outbound requests. Finishing the incoming request body does not cancel a response still streaming.

--- a/docs/guide/upgrade-v8.md
+++ b/docs/guide/upgrade-v8.md
@@ -1,0 +1,81 @@
+# Upgrade from 7 to 8
+
+Use this guide when upgrading an existing `@lomray/vite-ssr-boost` v7 application. If you are adding SSR to a Vite SPA for the first time, start with [Migrate an existing SPA](/guide/migrate-existing-spa).
+
+## Node requirement
+
+The package requires Node.js `>=22.12.0`, as declared by [`package.json` engines.node](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/package.json). Check the engine requirements of your chosen React Router and build tools as well. Raising this package requirement in the future is a breaking change under the [support policy](/reference/support).
+
+## Update the package and imports
+
+```bash
+npm install @lomray/vite-ssr-boost@^8
+```
+
+The following paths were removed in **8.0.0**. For the managed CLI, update the server entry:
+
+```ts
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+
+export default entryServer(App, routes, options);
+```
+
+Update imports relative to `@lomray/vite-ssr-boost/` (also applies to explicit `.js` imports):
+
+| Removed path | New path |
+| --- | --- |
+| `node/entry` | `adapters/express/entry` |
+| `node/server` | `adapters/express/server` |
+| `node/render` | `adapters/express/render` |
+| `node/create-fetch-request` | `adapters/express/create-request` |
+| `services/prepare-server` | `adapters/express/prepare-server` |
+
+The old `node/write-response` and `helpers/handle-response` internals are removed. The renderer now
+handles response composition and redirects through the Fetch core; custom Node transports can send
+the resulting `Response` with `node/write-fetch-response`.
+
+- The default shell-error page returns a generic HTTP 500 without exception messages. Use `onError`
+  for diagnostics or `onShellError` for a custom page.
+- Request/render hook failures reach Express error middleware through `next(error)`, rather than
+  falling through to a 404. Register error middleware after the SSR handler.
+- Unless explicitly overridden, rendered responses use React Router's status, including 404 for
+  unmatched routes. Previously these could be sent as 200.
+- Render timeouts and client/intentional cancellation report `onError` codes `timeout` and `cancel`.
+  The managed Express server logs these at info level. Unexpected errors retain their original error.
+- Parsed JSON and flat URL-encoded bodies work automatically. Nested form values and unsupported
+  custom or multipart parser results fail explicitly; use [`getBody`](/guide/runtime-adapters#request-bodies).
+- Package exports support extensionless and explicit `.js` imports for the new paths, with matching
+  TypeScript declarations. Other module paths are unchanged.
+
+The browser entry remains `@lomray/vite-ssr-boost/browser/entry`. Applications that own their transport can use the default `createHandler` export from `@lomray/vite-ssr-boost/core/handler`; follow [Runtime adapters](/guide/runtime-adapters) for server, asset and bundling responsibilities.
+
+Express and compression are optional dependencies installed by default. If you install with `--omit=optional`, install `express` and `compression` explicitly for the managed CLI.
+
+## Review `onResponse`
+
+The hook receives `{ context, html, isEnd }` and synchronously returns a string, `undefined` or nothing. It transforms decoded HTML chunks; split UTF-8 characters are preserved, but a chunk can still end partway through an HTML tag.
+
+- Regular chunks use `isEnd: false`. Return `undefined` or nothing to keep the original chunk, a string to replace it, or `''` to withhold it while buffering an unfinished token.
+- After the complete composed body, including the footer, the hook receives one final call with `html: ''` and `isEnd: true`. Return a string to append buffered content; `undefined` or `''` appends nothing.
+- This contract applies to streamed and buffered rendering (`isStream: false`). Hooks that ignore `isEnd` remain supported.
+
+For a request-scoped `@lomray/consistent-suspense` transform:
+
+```ts
+onResponse: ({ context: { appProps: { streamSuspense }, isStream }, html, isEnd }) => {
+  if (!isStream) return;
+  return isEnd ? streamSuspense.end() : streamSuspense.analyze(html);
+},
+```
+
+See the [server entry API](/api/server-entry#onresponse) for the full signature.
+
+## Review `context.request`
+
+The Express adapter's render-hook context now includes `request`, the Fetch `Request` used by React Router and the core. Use its `url`, `headers` and `signal` for Fetch-based request handling and cancellation. When constructing typed render-hook contexts in application code or fixtures, include this field.
+
+Managed Express request/render hooks retain the live Express `req` and `res`; keep Express-specific cookies, middleware and response takeover on those objects. `context.request` is available in render hooks, after the adapter converts the request; it is not an Express request and is not added to the earlier managed `onRequest` parameters. Fetch-core hooks use Web-standard requests and responses and do not emulate Express objects.
+
+## Check the upgraded application
+
+Run development and production builds, then check hydration, lazy-route JS/CSS, redirects, unmatched-route 404s, error middleware and any HTML transform. If you use parsed request bodies, streaming or cancellation, exercise those paths too. Loader results must remain JSON-serializable for first-paint hydration; nested promises are not hydrated by `<Await>` or `use()`. See the [data-loading contract](/guide/migrate-existing-spa#data-loading).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ hero:
     alt: Vite SSR BOOST logo
   actions:
     - theme: brand
-      text: Create an app
-      link: /guide/getting-started#create-a-new-app
-    - theme: alt
       text: Migrate a SPA
       link: /guide/migrate-existing-spa
+    - theme: alt
+      text: Create an app
+      link: /guide/getting-started#create-a-new-app
     - theme: alt
       text: GitHub
       link: https://github.com/Lomray-Software/vite-ssr-boost
@@ -40,12 +40,13 @@ features:
 
 ## Start with the managed server
 
-Create a new app with `npm create @lomray/ssr-app@latest my-app` to start from the minimal template. For an existing app, add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
+For an existing app, add `SsrBoost()` to the Vite plugins, use `@lomray/vite-ssr-boost/browser/entry` in the browser entry and `@lomray/vite-ssr-boost/adapters/express/entry` in the server entry. Create a new app with `npm create @lomray/ssr-app@latest my-app` to start from the minimal template. The CLI handles development, HMR, SSR builds and SPA builds. Use the [Fetch core and runtime adapters](/guide/runtime-adapters) when your application needs to own the transport and its asset integration.
 
 ## Read this first
 
 - [Choosing an SSR approach](/guide/choosing) compares routing, data and server ownership.
 - [Migrate an existing SPA](/guide/migrate-existing-spa) shows the five-file change from the minimal template.
+- [Upgrade from 7 to 8](/guide/upgrade-v8) covers changed imports, hooks and the Node requirement.
 - [Example projects](/examples/) describes the template branches.
 - [FAQ](/reference/faq) answers questions about RSC, SPA output and runtimes.
 - [Getting Started](/guide/getting-started) covers installation and entry files.

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -1,5 +1,7 @@
 # Development diagnostics
 
+Run [`ssr-boost doctor`](/api/cli#ssr-boost-doctor) to check project setup before investigating a runtime warning. Use `doctor --json` in automation and `doctor --bundle support.json` to collect versions, route structure, checks and recorded build codes without request data.
+
 Diagnostics catch state serialization and response-hook mistakes before they reach the browser.
 Each distinct warning is logged once per process through the existing logger, with a stable code,
 the affected route/key or file, and a link to its section below; managed development uses your

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -20,35 +20,31 @@ responses; invalid file-backed shells always throw, even with diagnostics disabl
 
 ### When it appears
 
-A loader or action returns a Promise, function, Map, Set, WeakMap, WeakSet, BigInt, Symbol, or class
-instance anywhere inside plain objects or arrays. The warning names the React Router route id and
-key path, such as `loaderData["details"].items[0].result`; Dates are reported as “hydrates as a string”,
-and circular references are reported too.
+A loader/action value or streamed resolution contains a function, symbol, unsupported class instance (including WeakMap/WeakSet), or circular reference. The warning identifies its route and key path. Promises, Dates, Maps, Sets, BigInts, RegExps and undefined are supported and do not trigger this warning.
 
 ### Why it matters
 
-Router hydration uses JSON, so a nested Promise or Map becomes `{}` and functions or symbols can
-disappear. BigInts and cycles make serialization throw, while Dates lose their Date methods after
-hydration.
+The [router data codec](/guide/data-streaming#supported-values) restores supported types. Unsupported values become `undefined`; custom class behavior is not transferred. Circular values are preserved within a frame but still warn so route data remains easy to inspect and reuse.
 
 ### How to fix
 
-Await loader data needed for the initial page and return plain JSON data at the reported path.
-Convert collections to arrays or objects, class instances to explicit data fields, and BigInts or
-Dates to strings with deliberate client-side reconstruction; keep streamed work in the application's
-Suspense mechanism instead of placing Promises in router hydration data.
+Return explicit data fields instead of functions or class instances, and remove cycles from your route data. Leave supported slow fields as promises and render them with Suspense and `<Await>` or React 19 `use()`.
+
+## SSR_BOOST_STREAM_PROMISE_ABORTED {#ssr_boost_stream_promise_aborted}
+
+A render timed out or was cancelled with loader/action promises still pending. The diagnostic names the route and pending count. Connected browsers receive rejection scripts before the response closes; cancelled response consumers discard queued frames. Increase `abortDelay` when the work legitimately needs longer, handle rejections with an error boundary, and pass the loader's `request.signal` to outbound fetches. The deadline starts after routing/preparation and also covers promises the React tree never reads. This diagnostic follows the development/explicit diagnostics settings above.
 
 ## SSR_BOOST_STATE_NOT_SERIALIZABLE {#ssr_boost_state_not_serializable}
 
 ### When it appears
 
-The object returned by `getState` contains one of the unsupported values listed above, including
+The object returned by `getState` contains a promise, function, symbol, bigint, Date, collection, class instance or cycle, including
 nested values inside arrays and plain objects. The warning identifies the request route and a path
 such as `$.store.items[0].createdAt`, even when the state builder would otherwise omit the value.
 
 ### Why it matters
 
-Custom state is serialized into browser scripts using JSON just like router state. A server store
+Custom state is serialized into browser scripts using JSON. Its value rules differ from router data. A server store
 containing class instances or collections can therefore hydrate with missing fields or changed types.
 
 ### How to fix

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -23,3 +23,7 @@ Choose [Next.js App Router](https://nextjs.org/docs/app) when you want its file-
 ## Does it work on Bun, Deno, Cloudflare?
 
 Yes, through the Fetch core, `@lomray/vite-ssr-boost/edge/render-to-stream` and `@lomray/vite-ssr-boost/adapters/edge`. Use the [runtime adapter integration](/guide/runtime-adapters#cloudflare-workers) with `Bun.serve`, `Deno.serve` or a Cloudflare Worker Fetch entry, and provide bundling, static assets and route-asset injection. Cloudflare bundles need the `workerd` and `worker` resolution conditions. The managed CLI and its Vercel/serverless output use Node and Express; they do not produce a Worker bundle.
+
+## Can `<Await>` and React 19 `use()` hydrate loader promises?
+
+Yes. Loader and action promises stream by default, including nested promises. The browser reconstructs them before creating the Data router. Enable `hydration: 'early'` to hydrate the shell while slow boundaries are pending; custom state must be ready at `onShellReady`. The default retains footer hydration. [Stream loader data](/guide/data-streaming) covers examples, errors and buffered crawler responses.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,5 +1,9 @@
 # FAQ
 
+## How do I add SSR or check an existing setup?
+
+Start with `npx ssr-boost init --dry-run`, review the diff, then use `--apply` and install dependencies. Follow the [automatic migration guide](/guide/migrate-existing-spa#automatic-npx-ssr-boost-init) for invocation before the library is installed and for unsupported layouts. Run [`ssr-boost doctor`](/api/cli#ssr-boost-doctor) after changes; `--json` is suitable for scripts, and `--bundle support.json` collects structural support information without request or environment data.
+
 ## Do I need React Server Components?
 
 No. vite-ssr-boost renders your React component tree through its SSR renderer and hydrates it in the browser. It does not implement React Server Components or Server Actions; use the [migration guide](/guide/migrate-existing-spa) to add SSR to route objects.

--- a/docs/reference/hydration-and-streaming.md
+++ b/docs/reference/hydration-and-streaming.md
@@ -37,9 +37,17 @@ The entry starts preloading the matched lazy routes while it waits. It awaits do
 
 The composed response sends the header, the React body stream and then this footer. Assigning router state releases the browser entry's wait, so the custom state must already be available at that point. The entry's `init` callback can then read that state.
 
+## Streamed loader and action data
+
+The [data stream](/guide/data-streaming) publishes stable promise placeholders in router initialization. Settlement scripts can arrive before initialization or the async entry: `window.__ssrBoostStream` buffers frames until its receiver is installed. The entry decodes the initial state and reconstructs native promises before `createRouter`.
+
+In default footer mode, custom state comes first in the footer, followed by the router hydration assignment and encoded initialization. Earlier settlement frames do not release the document wait. The assignment is an internal stream marker until the entry replaces it with decoded state.
+
+With `hydration: 'early'`, custom state and router state are emitted in the shell block before React body bytes. `getState` must already have everything hydration needs at `onShellReady`. The entry waits for React's bootstrap script at the end of the parsed shell before hydrating; it then allows slow boundaries to finish independently. This works across split shell chunks and requires an async client module. `isStream: false` still waits for complete React HTML and resolved data and uses the footer.
+
 ## Custom servers and `onResponse`
 
-Keep the generated footer in the same HTML response, after the React body, and complete the response. Do not send state in a separate request or withhold the final chunk. Replacing the footer through `onShellReady` preserves the generated state scripts and their order.
+Keep the generated state and settlement scripts in the same HTML response and complete it. Default mode keeps hydration state after the React body; early mode sends it with the shell. Do not send state in a separate request or withhold the final chunk. Replacing the footer through `onShellReady` preserves the generated state scripts and their order.
 
 [`src/core/transform-html.ts`](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/src/core/transform-html.ts) applies `onResponse` to decoded HTML chunks:
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -1,0 +1,35 @@
+# Support and versions
+
+Policy effective **5 September 2026**.
+
+## Supported versions
+
+| Release line | Maintenance commitment | Through (inclusive) |
+| --- | --- | --- |
+| Latest 8.x minor | Bug fixes and security fixes | 5 September 2027 |
+| 7.1.x | Security backports | 5 March 2027 |
+
+When a new 8.x minor ships, upgrade to that minor to continue receiving bug and security fixes. The 7.1.x line receives security backports during its stated window.
+
+## Upstream compatibility
+
+For every new stable major of React, React Router or Vite, we will publish a **supported**, **investigating** or **unsupported** statement within **30 days** of its release. We will publish that statement in GitHub Discussions or Releases and link to the tested combinations where applicable. A permissive peer dependency range alone is not a support statement.
+
+## Response commitments
+
+- We will provide a human acknowledgment of a GitHub issue within **five business days**.
+- We will provide a human acknowledgment of a security report within **two business days**. Follow the [security reporting policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SECURITY.md) to report privately.
+
+These are acknowledgment targets; the time needed to investigate and resolve a report depends on its scope. Business days are Monday through Friday, excluding public holidays observed by the responding maintainer.
+
+Issues explicitly labeled `needs-reproduction` receive an inactivity reminder after 30 days and may be closed 14 days later. Issues labeled `bug`, `confirmed` or `enhancement`, and all pull requests, are exempt. Add the requested reproduction and reopen the issue, or ask a maintainer to reopen it in a comment.
+
+## Deprecations and breaking changes
+
+We will announce deprecations at least **90 days** and **two minor releases** before removal, and remove deprecated APIs only in a **major release**. Both notice periods must be satisfied. Raising the package's Node.js requirement counts as a breaking change and requires a major release.
+
+## Maintenance updates
+
+We will publish a short maintenance note **each month**, beginning in **September 2026**, in [GitHub Discussions](https://github.com/Lomray-Software/vite-ssr-boost/discussions) or [Releases](https://github.com/Lomray-Software/vite-ssr-boost/releases). Each note will cover maintenance activity and compatibility status, including months with no release.
+
+See the [repository support policy](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/SUPPORT.md), [tested compatibility combinations](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/README.md#compatibility) and [Upgrade from 7 to 8](/guide/upgrade-v8).

--- a/docs/reference/talking-points.md
+++ b/docs/reference/talking-points.md
@@ -21,9 +21,9 @@ The managed Express CLI is the default path for Vite development, HMR, static as
 
 ## Data loading
 
-Loader results are serialized with `JSON.stringify` into `window.__staticRouterHydrationData`, so a loader must return plain data for the first paint. Nested promises become `{}`; `<Await>` or `use()` cannot hydrate those loader promises. For streamed or deferred data, follow the [prod branch pattern](https://github.com/Lomray-Software/vite-template/tree/prod): component-level Suspense with a request-scoped cache, `getState`, `@lomray/consistent-suspense` and `@lomray/react-mobx-manager`.
+Loader and action promises stream by default in Data mode. Return `{ fast, slow: fetchSlow() }` and consume `slow` inside Suspense with `<Await>` or React 19 `use()`. The browser reconstructs native promises before creating the router; client navigation loaders keep their native promises. See [Stream loader data](/guide/data-streaming) for the supported value matrix, errors and opt-in `hydration: 'early'`. Custom `getState` snapshots still use JSON.
 
-The browser entry waits for document readiness or the router state assignment, together with matched lazy route preloads, before creating the router. Custom state is written before router state in the footer; see [Hydration order and streaming](/reference/hydration-and-streaming) for the timing and the `onResponse` contract.
+The browser entry waits for document readiness or the router state assignment, together with matched lazy route preloads, before creating the router. Custom state is written before router state in the footer by default. `hydration: 'early'` publishes both at shell-ready and waits for React's parsed-shell marker; see [Hydration order and streaming](/reference/hydration-and-streaming) for the timing and the `onResponse` contract.
 
 ## Who this is for
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
+        "devalue": "^5.9.2",
         "hoist-non-react-statics": "^3.3.2",
         "json5": "^2.2.3"
       },
@@ -27,6 +28,7 @@
         "@lomray/eslint-config": "^7.0.0",
         "@lomray/eslint-config-react": "^7.0.0",
         "@lomray/prettier-config": "^3.0.0",
+        "@playwright/test": "^1.63.0",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
         "@testing-library/react": "^16.3.3",
@@ -3206,6 +3208,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -7769,6 +7787,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -14202,6 +14226,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plimit-lit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,11 @@
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
         "devalue": "^5.9.2",
+        "diff": "^9.0.0",
         "hoist-non-react-statics": "^3.3.2",
-        "json5": "^2.2.3"
+        "json5": "^2.2.3",
+        "parse5": "^8.0.1",
+        "semver": "^7.8.5"
       },
       "bin": {
         "ssr-boost": "cli.js"
@@ -40,6 +43,7 @@
         "@types/node": "^22.20.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.7",
+        "@types/semver": "^7.8.0",
         "@types/serve-static": "^2.2.0",
         "@types/sinon": "^22.0.0",
         "@vitest/coverage-v8": "^5.0.0",
@@ -5088,6 +5092,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -7812,7 +7823,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
       "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -7926,7 +7936,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -13980,7 +13989,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -15388,7 +15396,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -69,11 +69,13 @@
     "test:bun": "bun scripts/test-bun.mjs",
     "test:template": "npm run build && node scripts/test-template.mjs",
     "test:coverage": "vitest run --coverage",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:browser": "playwright test --config playwright.config.mjs"
   },
   "dependencies": {
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
+    "devalue": "^5.9.2",
     "hoist-non-react-statics": "^3.3.2",
     "json5": "^2.2.3"
   },
@@ -91,6 +93,7 @@
     "@lomray/eslint-config": "^7.0.0",
     "@lomray/eslint-config-react": "^7.0.0",
     "@lomray/prettier-config": "^3.0.0",
+    "@playwright/test": "^1.63.0",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
     "@testing-library/react": "^16.3.3",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,11 @@
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "devalue": "^5.9.2",
+    "diff": "^9.0.0",
     "hoist-non-react-statics": "^3.3.2",
-    "json5": "^2.2.3"
+    "json5": "^2.2.3",
+    "parse5": "^8.0.1",
+    "semver": "^7.8.5"
   },
   "optionalDependencies": {
     "compression": "^1.8.1",
@@ -105,6 +108,7 @@
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
+    "@types/semver": "^7.8.0",
     "@types/serve-static": "^2.2.0",
     "@types/sinon": "^22.0.0",
     "@vitest/coverage-v8": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lomray/vite-ssr-boost",
   "version": "1.0.0",
-  "description": "Vite plugin for create awesome SSR or SPA applications on React.",
+  "description": "SSR and streaming for existing Vite + React Router apps in Data mode, without Framework mode",
   "type": "module",
   "exports": {
     "./node/production": {
@@ -32,7 +32,12 @@
     "vite",
     "plugin",
     "react",
-    "ssr"
+    "ssr",
+    "react-router",
+    "server-side-rendering",
+    "data-router",
+    "streaming",
+    "spa"
   ],
   "publishConfig": {
     "access": "public"
@@ -51,7 +56,7 @@
     "build": "rollup -c",
     "build:watch": "rollup -c -w",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:build": "vitepress build docs && node scripts/build-llms.mjs",
     "docs:preview": "vitepress preview docs",
     "release": "npm run build && cd lib && npm publish",
     "lint:check": "eslint . --max-warnings=0",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './browser-tests',
+  workers: 1,
+  timeout: 30_000,
+  reporter: 'list',
+  webServer: {
+    command: 'node scripts/browser-server.mjs',
+    url: 'http://127.0.0.1:4179',
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ export default {
     'node:zlib',
     'node:url',
     'node:http',
+    'node:module',
     'node:https',
     '@babel/types',
   ],
@@ -58,7 +59,16 @@ export default {
     terser(),
     copy({
       targets: [
-        { src: 'package.json', dest: dest },
+        {
+          src: 'package.json',
+          dest,
+          transform(contents) {
+            const metadata = JSON.parse(contents.toString());
+            // Published consumers and directory packing do not need checkout Git hooks.
+            delete metadata.scripts.prepare;
+            return `${JSON.stringify(metadata, null, 2)}\n`;
+          },
+        },
         { src: 'README.md', dest: dest },
         { src: 'SECURITY.md', dest: dest },
         { src: 'LICENSE', dest: dest },

--- a/scripts/browser-server.mjs
+++ b/scripts/browser-server.mjs
@@ -1,0 +1,83 @@
+import http from 'node:http';
+import { once } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'vite';
+import express from 'express';
+import adapterNode from '../lib/adapters/node.js';
+
+const directory = await mkdtemp(join(tmpdir(), 'ssr-boost-browser-'));
+const root = resolve('__fixtures__/browser-template');
+const config = {
+  configFile: false,
+  root,
+  logLevel: 'warn',
+  resolve: {
+    alias: { '@lomray/vite-ssr-boost': resolve('lib') },
+    dedupe: ['react', 'react-dom', 'react-router'],
+  },
+};
+await build({ ...config, build: { outDir: join(directory, 'client'), emptyOutDir: true } });
+// Bundle the server so its temporary output doesn't need its own node_modules tree.
+await build({
+  ...config,
+  ssr: { noExternal: true },
+  build: { ssr: join(root, 'server.jsx'), outDir: join(directory, 'server'), emptyOutDir: true },
+});
+const document = await readFile(join(directory, 'client/index.html'), 'utf8');
+const [header, footer] = document.split('<!--ssr-outlet-->');
+const { handler } = await import(pathToFileURL(join(directory, 'server/server.js')).href);
+const app = express();
+app.get('/api/slow', (_, response) => response.json({ users: 3 }));
+app.use(
+  '/assets',
+  express.static(join(directory, 'client/assets'), { maxAge: '1h', immutable: true }),
+);
+app.use(adapterNode(handler({ header, footer })));
+const upstream = http.createServer(app).listen(0, '127.0.0.1');
+await once(upstream, 'listening');
+const port = upstream.address().port;
+const proxy = http
+  .createServer((request, response) => {
+    const forward = () => {
+      if (response.destroyed) return;
+      // Preserve Host: SSR loader API requests must also travel through this proxy.
+      const pending = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          path: request.url,
+          method: request.method,
+          headers: request.headers,
+        },
+        (result) => {
+          response.writeHead(result.statusCode, result.headers);
+          result.pipe(response);
+        },
+      );
+      pending.on('error', () => {
+        if (!response.destroyed) response.writeHead(502).end();
+      });
+      response.on('close', () => pending.destroy());
+      request.pipe(pending);
+    };
+    if (request.url.startsWith('/api/slow')) setTimeout(forward, 2000);
+    else forward();
+  })
+  .listen(Number(process.env.BROWSER_TEST_PORT || 4179), '127.0.0.1');
+await once(proxy, 'listening');
+console.info(`Browser fixture ready: http://127.0.0.1:${proxy.address().port}`);
+const stop = async () => {
+  proxy.closeAllConnections();
+  upstream.closeAllConnections();
+  await Promise.all([
+    new Promise((resolve) => proxy.close(resolve)),
+    new Promise((resolve) => upstream.close(resolve)),
+  ]);
+  await rm(directory, { recursive: true, force: true });
+  process.exit(0);
+};
+process.once('SIGTERM', stop);
+process.once('SIGINT', stop);

--- a/scripts/build-llms.mjs
+++ b/scripts/build-llms.mjs
@@ -1,0 +1,84 @@
+import { execFileSync } from 'node:child_process';
+import { access, readFile, readdir, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const root = new URL('../', import.meta.url);
+const docs = new URL('docs/', root);
+const dist = new URL('.vitepress/dist/', docs);
+const site = 'https://lomray-software.github.io/vite-ssr-boost/';
+const pkg = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const readVersion = (command, args) => {
+  try {
+    return execFileSync(command, args, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 30_000,
+    }).trim();
+  } catch {
+    return '';
+  }
+};
+const tagVersion = readVersion('git', ['describe', '--tags', '--match', 'v*', '--abbrev=0'])
+  .replace(/^v/, '');
+const version = tagVersion || readVersion('npm', ['view', pkg.name, 'version']);
+const versionSource = tagVersion ? 'git describe' : 'npm view';
+const files = (await readdir(docs, { recursive: true }))
+  .filter((file) => file.endsWith('.md') && !file.split('/').some((part) => part.startsWith('.')))
+  .sort();
+const pages = [];
+
+for (const file of files) {
+  const source = await readFile(new URL(file, docs), 'utf8');
+  const html = file.replace(/\.md$/, '.html');
+  const route = file.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '');
+  const url = new URL(route, site).href;
+  const title = source.match(/^# (.+)$/m)?.[1] ?? (file === 'index.md' ? 'Vite SSR BOOST' : route);
+
+  // Keep clean URLs aligned with VitePress output, including nested index pages.
+  try {
+    await access(new URL(html, dist));
+  } catch {
+    throw new Error(`Missing built page for ${url}: ${html}`);
+  }
+
+  pages.push({ title, url, source });
+}
+
+const grounding = await readFile(new URL('ai-usage.md', docs), 'utf8');
+const section = (heading) => {
+  const content = grounding.split(`## ${heading}\n`)[1]?.split('\n## ')[0].trim();
+
+  if (!content) {
+    throw new Error(`Missing AI grounding section: ${heading}`);
+  }
+
+  // These source sections use site-root links; make them usable outside the docs site.
+  return `## ${heading}\n\n${content.replace(/\]\(\/(?!\/)/g, `](${site}`)}`;
+};
+const introduction = [
+  '# Vite SSR BOOST',
+  `> ${pkg.description}`,
+  `Package: \`${pkg.name}\``,
+  ...(version ? [`Version: \`${version}\``] : []),
+  section('Public entrypoints'),
+  section('Data loading contract'),
+].join('\n\n');
+const index = `${introduction}\n\n## Documentation\n\n${pages
+  .map(({ title, url }) => `- [${title}](${url})`)
+  .join('\n')}\n`;
+const full = `${introduction}\n\n${pages
+  .map(({ url, source }) => `---\n\nSource: ${url}\n\n${source.trim()}`)
+  .join('\n\n')}\n`;
+
+await writeFile(new URL('llms.txt', dist), index);
+await writeFile(new URL('llms-full.txt', dist), full);
+
+process.stdout.write(
+  (version
+    ? `Documentation version: ${version} (source: ${versionSource})\n`
+    : 'Documentation version: omitted (git tags and npm registry unavailable)\n') +
+    `llms.txt: ${pages.length} page links, ${Buffer.byteLength(index)} bytes\n` +
+    `llms-full.txt: ${pages.length} concatenated pages, ${Buffer.byteLength(full)} bytes\n` +
+    `Verified ${pages.length}/${pages.length} page links resolve in ${fileURLToPath(dist)}\n`,
+);

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -6,7 +6,9 @@ import { build } from 'esbuild';
 // KB means 1024 bytes throughout. Recalibrate only for an intentional size change:
 // per entry = ceil(measured KB * 1.25 * 4) / 4; combined = measured KB + 1.
 const BROWSER_GZIP_BUDGETS_KB = {
-  'browser/entry': 1,
+  // B1: 3127 measured bytes, up from 685. Hard cap: at most 3 KiB growth.
+  'browser/entry': (685 + 3 * 1024) / 1024,
+  'browser/stream': 3.25,
   'components/navigate': 0.5,
   'components/only-client': 0.5,
   'components/render-client': 2.25,
@@ -19,7 +21,7 @@ const BROWSER_GZIP_BUDGETS_KB = {
   'helpers/import-route': 2.5,
   'interfaces/fc-route': 0.25,
 };
-const COMBINED_GZIP_BUDGET_KB = 4410 / 1024; // 3386 measured bytes + 1024 bytes.
+const COMBINED_GZIP_BUDGET_KB = 6817 / 1024; // 5793 measured bytes + 1024 bytes.
 
 const projectRoot = process.cwd();
 const lib = resolve(projectRoot, 'lib');

--- a/scripts/test-core-no-optional.mjs
+++ b/scripts/test-core-no-optional.mjs
@@ -73,7 +73,7 @@ try {
 
   runNpm([
     'install',
-    '--offline',
+    '--prefer-offline',
     '--omit=optional',
     '--legacy-peer-deps',
     '--ignore-scripts',

--- a/scripts/test-init.mjs
+++ b/scripts/test-init.mjs
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import semver from 'semver';
+
+const repository = fileURLToPath(new URL('..', import.meta.url));
+
+const copyFixture = (root, name) => {
+  const source = path.join(repository, '__fixtures__', 'init', name);
+  for (const file of fs.readdirSync(source, { recursive: true })) {
+    if (!file.endsWith('.txt')) continue;
+    const destination = path.join(root, file.slice(0, -4));
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(source, file), destination);
+  }
+};
+
+const port = async () => {
+  const server = net.createServer().listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port: value } = server.address();
+  server.close();
+  await once(server, 'close');
+  return value;
+};
+
+const stop = async (child) => {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const closed = once(child, 'close');
+  child.kill('SIGTERM');
+  const timeout = setTimeout(() => child.kill('SIGKILL'), 3000);
+  try { await closed; } finally { clearTimeout(timeout); }
+};
+
+/** Fail before packing/building when this runtime cannot run the installed dependency tree. */
+export function assertNodeEngines(root = repository, version = process.versions.node) {
+  const failures = [];
+  const visited = new Set();
+  const inspect = (directory) => {
+    const location = fs.realpathSync(directory);
+    if (visited.has(location)) return;
+    visited.add(location);
+    const file = path.join(directory, 'package.json');
+    if (fs.existsSync(file)) {
+      const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (pkg.engines?.node && !semver.satisfies(version, pkg.engines.node)) {
+        failures.push(`${pkg.name ?? 'app'}: ${pkg.engines.node}`);
+      }
+    }
+    const modules = path.join(directory, 'node_modules');
+    if (!fs.existsSync(modules)) return;
+    for (const name of fs.readdirSync(modules)) {
+      if (name.startsWith('.')) continue;
+      const dependency = path.join(modules, name);
+      if (!fs.statSync(dependency).isDirectory()) continue;
+      if (name.startsWith('@')) {
+        for (const scoped of fs.readdirSync(dependency)) inspect(path.join(dependency, scoped));
+      } else inspect(dependency);
+    }
+  };
+  inspect(root);
+  assert.equal(failures.length, 0, `Stock-app end-to-end precondition failed: Node ${version} does not satisfy installed dependencies' engines: ${[...new Set(failures)].join('; ')}. Use Node 22.23.2 (the verified runtime) or another version satisfying these ranges before running this test.`);
+}
+
+/** Exercise published CLI entrypoints, actual Vite builds, and HTTP output. */
+export default async function testInit() {
+  assertNodeEngines();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ssr-boost-init-e2e-'));
+  const env = { ...process.env, HUSKY: '0', npm_config_ignore_scripts: 'true' };
+  delete env.NO_COLOR;
+  // No shell commands, no lifecycle scripts, and a PID-owned server in each proof.
+  const run = (program, args, cwd = root) => {
+    try {
+      return execFileSync(program, args, { cwd, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 180000, maxBuffer: 16 * 1024 * 1024 });
+    } catch (error) {
+      throw new Error(`${program} ${args.join(' ')} failed (${error.status}):\n${error.stdout ?? ''}\n${error.stderr ?? ''}`, { cause: error });
+    }
+  };
+  const write = (file, code) => {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.writeFileSync(path.join(root, file), code);
+  };
+  const cli = path.join(root, 'node_modules', '@lomray', 'vite-ssr-boost', 'cli.js');
+  const verify = async (label) => {
+    run(process.execPath, [cli, 'build']);
+    const available = await port();
+    const child = spawn(process.execPath, [cli, 'start', '--port', String(available)], { cwd: root, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let output = '';
+    child.stdout.on('data', (chunk) => { output += chunk; });
+    child.stderr.on('data', (chunk) => { output += chunk; });
+    try {
+      const origin = `http://127.0.0.1:${available}`;
+      let response;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        if (child.exitCode !== null || child.signalCode !== null) throw new Error(output);
+        try {
+          response = await fetch(`${origin}/about`, { signal: AbortSignal.timeout(2000) });
+          break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      }
+      assert.ok(response, `${label}: server did not start\n${output}`);
+      const html = await response.text();
+      assert.equal(response.status, 200, `${label}: ${html}\n${output}`);
+      assert.match(html, /About route rendered on server/, label);
+      assert.match(html, /window\.__staticRouterHydrationData/, label);
+      assert.match(html, /<script[^>]+type="module"[^>]+src=|<script[^>]+src=[^>]+type="module"/, label);
+      const styles = [...html.matchAll(/<link\b[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*>/g)];
+      assert.ok(styles.length, `${label}: lazy stylesheet link missing\n${html}`);
+      const css = await Promise.all(styles.map(async ([, href]) => {
+        const asset = await fetch(new URL(href, origin));
+        assert.equal(asset.status, 200);
+        return asset.text();
+      }));
+      assert.ok(css.some((code) => code.includes('.about-page')), `${label}: lazy route's own stylesheet was lost`);
+      const doctor = JSON.parse(run(process.execPath, [cli, 'doctor', '--json', '--bundle', 'support.json']));
+      assert.ok(doctor.checks.every((check) => check.status === 'ok'), `${label}: ${JSON.stringify(doctor.checks)}`);
+      console.info(`${label}: SSR deep link, hydration, lazy CSS, and doctor passed`);
+    } finally {
+      await stop(child);
+    }
+  };
+  try {
+    run('npm', ['run', 'build'], repository);
+    const packed = JSON.parse(run('npm', ['pack', path.join(repository, 'lib'), '--ignore-scripts', '--json', '--pack-destination', root], repository))[0].filename;
+    copyFixture(root, 'stock-react-ts');
+    // Start with the vendored create-vite React TS counter, then add Data-mode routes.
+    let main = fs.readFileSync(path.join(root, 'src/main.tsx'), 'utf8');
+    main = main.replace("import App from './App.tsx'", "import App from './App.tsx'\nimport { createBrowserRouter, RouterProvider } from 'react-router'\n\nconst routes = [\n  { path: '/', Component: App },\n  { path: '/about', lazy: () => import('./About') },\n]\nconst router = createBrowserRouter(routes)").replace('<StrictMode><App /></StrictMode>', '<StrictMode><RouterProvider router={router} /></StrictMode>');
+    write('src/main.tsx', main);
+    write('src/About.tsx', "import './about.css'\nexport function Component() { return <h1 className=\"about-page\">About route rendered on server</h1> }\n");
+    write('src/about.css', '.about-page { color: rgb(1, 2, 3); }\n');
+    // init must also work before the app has installed the library.
+    run(process.execPath, [path.join(repository, 'lib/cli.js'), 'init', '--root', root, '--apply'], repository);
+    const packageFile = path.join(root, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
+    const packages = ['react', 'react-dom', 'react-router', 'vite', '@babel/parser', '@babel/traverse', '@babel/generator', '@babel/types'];
+    for (const name of packages) {
+      const version = JSON.parse(fs.readFileSync(path.join(repository, 'node_modules', name, 'package.json'), 'utf8')).version;
+      if (name === 'vite' || name.startsWith('@babel')) pkg.devDependencies[name] = version;
+      else pkg.dependencies[name] = version;
+    }
+    const viteMajor = Number(pkg.devDependencies.vite.split('.')[0]);
+    pkg.devDependencies['@vitejs/plugin-react'] = viteMajor >= 8 ? '6.1.1' : viteMajor === 7 ? '^5.1.0' : '^4.7.0';
+    pkg.dependencies['@lomray/vite-ssr-boost'] = `file:./${packed}`;
+    write('package.json', JSON.stringify(pkg, null, 2));
+    run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund']);
+    assertNodeEngines(root);
+    env.PATH = `${path.join(root, 'node_modules', '.bin')}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${env.PATH}`;
+    run(process.execPath, [path.join(root, 'node_modules/typescript/bin/tsc'), '--noEmit']);
+    assert.match(run(process.execPath, [cli, 'init', '--apply']), /No changes/);
+    await verify('stock create-vite react-ts + Data router');
+
+    const dependencyPackage = fs.readFileSync(packageFile, 'utf8');
+    for (const layout of ['root-inline', 'src-export', 'javascript', 'alias-wrapper']) {
+      for (const file of ['src', 'index.html', 'vite.config.ts', 'vite.config.js', 'tsconfig.json']) {
+        fs.rmSync(path.join(root, file), { recursive: true, force: true });
+      }
+      copyFixture(root, layout);
+      write('package.json', dependencyPackage);
+      run(process.execPath, [cli, 'init', '--apply']);
+      await verify(`init layout ${layout}`);
+    }
+    // Built-ins and an unwrapped RouterProvider must also work through the generated App.
+    for (const wrapper of ['fragment', 'none']) {
+      for (const file of ['src', 'index.html', 'vite.config.ts', 'tsconfig.json']) {
+        fs.rmSync(path.join(root, file), { recursive: true, force: true });
+      }
+      copyFixture(root, 'root-inline');
+      write('package.json', dependencyPackage);
+      let main = fs.readFileSync(path.join(root, 'src/main.tsx'), 'utf8');
+      main = main.replace('<StrictMode>', wrapper === 'fragment' ? '<>' : '').replace('</StrictMode>', wrapper === 'fragment' ? '</>' : '');
+      write('src/main.tsx', main);
+      run(process.execPath, [cli, 'init', '--apply']);
+      await verify(`init wrapper ${wrapper}`);
+    }
+    // Return to the conventional root config before exercising the parser cases.
+    write('vite.config.ts', "import SsrBoost from '@lomray/vite-ssr-boost/plugin';\nimport react from '@vitejs/plugin-react';\nexport default { plugins: [SsrBoost({ clientFile: 'src/main.tsx', serverFile: 'src/server.ts' }), react()] };\n");
+
+    // Each parser compatibility fixture must preserve its lazy CSS in an actual SSR response.
+    for (const filename of fs.readdirSync(path.join(repository, '__fixtures__/routes'))) {
+      const fixture = JSON.parse(fs.readFileSync(path.join(repository, '__fixtures__/routes', filename), 'utf8'));
+      write('src/main.tsx', `import { Fragment as App } from 'react';\n${fixture.client ?? "import boot from '@lomray/vite-ssr-boost/browser/entry';\nimport routes from './routes';\nvoid boot(App, routes);\n"}`);
+      write('src/routes.ts', fixture.routes);
+      write('src/server.ts', "import entry from '@lomray/vite-ssr-boost/adapters/express/entry';\nimport { Fragment } from 'react';\nimport routes from './routes-server';\nexport default entry(Fragment, routes);\n");
+      write('src/routes-server.ts', filename === 'named-alias.json' ? "export { list as default } from './routes';\n" : "export { default } from './routes';\n");
+      for (const [file, code] of Object.entries(fixture.files ?? {})) write(`src/${file}`, code);
+      await verify(filename.replace('.json', ''));
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await testInit();
+}

--- a/src/adapters/express/entry.tsx
+++ b/src/adapters/express/entry.tsx
@@ -28,6 +28,9 @@ export interface IEntrypointOptions<TAppProps = Record<string, any>> extends Pic
   | 'onError'
   | 'getState'
   | 'getBody'
+  | 'hydration'
+  | 'nonce'
+  | 'bootstrapScriptContent'
 > {
   onServerCreated?: (app: Express, serverApi: ServerApi) => Promise<void> | void;
   onServerStarted?: (app: Express, serverApi: ServerApi, server: Server) => Promise<void> | void;

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -44,6 +44,9 @@ export interface IRenderParams<TAppProps = Record<string, any>> {
 }
 
 export interface IRenderOptions<TAppProps = Record<string, any>> {
+  hydration?: 'early' | 'footer';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   abortDelay?: number;
   getBody?: (request: ExpressRequest) => BodyInit | null | undefined;
   onRouterReady?: (params: {
@@ -174,6 +177,9 @@ async function render(
     onError,
     getBody,
     getState,
+    hydration,
+    nonce,
+    bootstrapScriptContent,
     abortDelay = 15000,
   }: IRenderOptions,
 ): Promise<void> {
@@ -223,6 +229,9 @@ async function render(
       coreContext,
       {
         abortDelay,
+        hydration,
+        nonce,
+        bootstrapScriptContent,
 
         /**
          * Read custom state through the legacy request context.

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -137,3 +137,5 @@ async function entry<TAppProps>(
 }
 
 export default entry;
+
+export { entry };

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import type { DataRouter, RouteObject } from 'react-router';
 import { createBrowserRouter, matchRoutes, RouterProvider } from 'react-router';
+import receiveStream from '@browser/stream';
 import { IS_SSR_MODE } from '@constants/common';
 import type { TRouteObject } from '@interfaces/route-object';
 
@@ -81,6 +82,7 @@ async function entry<TAppProps>(
     rootId = 'root',
   }: IEntryClientOptions<TAppProps> = {},
 ): Promise<ReactDOM.Root | void> {
+  const stream = IS_SSR_MODE ? receiveStream() : undefined;
   const documentReady = waitForDocument();
   const lazyMatches = matchRoutes(
     routes as RouteObject[],
@@ -108,6 +110,13 @@ async function entry<TAppProps>(
         }
       }),
     ]);
+  }
+
+  const hydration = Reflect.get(window, '__staticRouterHydrationData') as
+    { __ssrBoostStream?: boolean } | undefined;
+
+  if (stream && hydration?.__ssrBoostStream) {
+    Reflect.set(window, '__staticRouterHydrationData', await stream.ready);
   }
 
   const router = createRouter(routes as RouteObject[], routerOptions);

--- a/src/browser/stream.ts
+++ b/src/browser/stream.ts
@@ -1,0 +1,95 @@
+import { parse } from 'devalue';
+
+type TFrame = ['init', string, boolean] | ['resolve' | 'reject', number, string] | ['shell'];
+interface IDeferred {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+}
+
+/** Install before waiting for the document: inline frames may precede the async entry. */
+const receiveStream = (): { ready: Promise<unknown> } => {
+  const target = window as typeof window & { __ssrBoostStream?: TFrame[] };
+  const queue = (target.__ssrBoostStream ??= []);
+  const promises = new Map<number, IDeferred>();
+  let hasShell = false;
+  let isEarly = false;
+  let isInitialized = false;
+  let state: unknown;
+  let resolveReady!: (value: unknown) => void;
+  let rejectReady!: (reason: unknown) => void;
+  const ready = new Promise<unknown>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  /** Return the same native promise for every occurrence of an identity. */
+  const deferred = (id: number): IDeferred => {
+    let pending = promises.get(id);
+
+    if (!pending) {
+      let resolve!: IDeferred['resolve'];
+      let reject!: IDeferred['reject'];
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
+      void promise.catch(() => undefined);
+      pending = { promise, resolve, reject };
+      promises.set(id, pending);
+    }
+
+    return pending;
+  };
+
+  /** Revive native promises synchronously before router creation or a settlement. */
+  const value = (payload: string): unknown =>
+    parse(payload, {
+      SSRBPromise: ([id]: [number]) => deferred(id).promise,
+      SSRBObject: (entries: [string, unknown][]) => Object.fromEntries(entries),
+      SSRBError: (entries: [string, unknown][]) => {
+        const data = Object.fromEntries(entries);
+        const error = Object.assign(new Error('Streamed loader/action rejection'), data);
+
+        if (!data.stack) {
+          delete error.stack;
+        }
+
+        return error;
+      },
+      SSRBUndefined: () => undefined,
+    });
+
+  /** Inline scripts and the buffered queue are processed in document order. */
+  queue.push = (...frames): number => {
+    for (const frame of frames) {
+      try {
+        if (frame[0] === 'shell') {
+          hasShell = true;
+        } else if (frame[0] === 'init') {
+          state = value(frame[1]);
+          [, , isEarly] = frame;
+          isInitialized = true;
+        } else {
+          deferred(frame[1])[frame[0]](value(frame[2]));
+        }
+
+        if (isInitialized && (!isEarly || hasShell)) {
+          resolveReady(state);
+        }
+      } catch (error) {
+        rejectReady(error);
+        promises.forEach((pending) => pending.reject(error));
+      }
+    }
+
+    return 0;
+  };
+  queue.push(...queue.splice(0));
+  void ready.catch(() => undefined);
+
+  return { ready };
+};
+
+export default receiveStream;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,8 +4,10 @@ import { readFileSync } from 'fs';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import runBuild from '@cli/build';
+import runDoctor from '@cli/doctor';
 import onKeyPress from '@cli/helpers/keyboard-input';
 import viteResetCache from '@cli/helpers/vite-reset-cache';
+import runInit from '@cli/init';
 import type {
   IBuildActionParams,
   IBuildAmplifyActionParams,
@@ -331,5 +333,23 @@ program
       isOptimize,
     });
   });
+
+program
+  .command('doctor')
+  .description('Inspect SSR setup and report actionable checks.')
+  .option('--json', 'Print machine-readable JSON.')
+  .option('--root <dir>', 'Project directory.')
+  .option('--bundle <file>', 'Write an allowlisted support bundle JSON.')
+  .action(runDoctor);
+
+program
+  .command('init')
+  .description('Add SSR to an existing Vite + React Router app (dry run by default).')
+  .option('--dry-run', 'Print every change without writing files.')
+  .option('--apply', 'Write the proposed changes.')
+  .option('--root <dir>', 'Project directory.')
+  .option('--entry <file>', 'Browser entry relative to the project directory.')
+  .option('--routes <file>', 'Module exporting the route array.')
+  .action(runInit);
 
 program.parse();

--- a/src/cli/diagnostic-codes.ts
+++ b/src/cli/diagnostic-codes.ts
@@ -1,0 +1,11 @@
+/** Codes safe to record in a build support bundle. Never record warning payloads. */
+const DIAGNOSTIC_CODES = [
+  'SSR_BOOST_LOADER_NOT_SERIALIZABLE',
+  'SSR_BOOST_STATE_NOT_SERIALIZABLE',
+  'SSR_BOOST_OUTLET_MISSING',
+  'SSR_BOOST_HYDRATION_STATE_MISSING',
+  'SSR_BOOST_DUPLICATE_OUTPUT',
+  'SSR_BOOST_ONRESPONSE_INVALID_RETURN',
+];
+
+export default DIAGNOSTIC_CODES;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,519 @@
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import semver from 'semver';
+import DIAGNOSTIC_CODES from '@cli/diagnostic-codes';
+import {
+  libraryPackage,
+  objectProperty,
+  readConfig,
+  readHtml,
+  readPackage,
+  stringValue,
+} from '@cli/project';
+import type { IPackage, TProjectConfig } from '@cli/project';
+import PLUGIN_NAME from '@constants/plugin-name';
+import ParseRoutes from '@services/parse-routes';
+import type { TRoutesTree } from '@services/parse-routes';
+import ServerConfig from '@services/server-config';
+import SourceFiles from '@services/source-files';
+
+export interface IDoctorOptions {
+  root?: string;
+  json?: boolean;
+  bundle?: string;
+}
+
+export interface ICheck {
+  name: string;
+  status: 'ok' | 'warn' | 'error';
+  message: string;
+  fix: string;
+  info?: boolean;
+}
+
+export interface IDoctorReport {
+  versions: Record<string, string | null>;
+  adapter: string | null;
+  routes: { id: string; path: string | null }[];
+  checks: ICheck[];
+  diagnosticCodes: string[];
+}
+
+// Kept in lockstep with .github/workflows/react-compatibility.yml by a unit test.
+export const TESTED_MATRIX = [
+  { react: '18.2.0', router: '7.18.3', vite: '6.4.3' },
+  { react: '19.2.8', router: '7.18.3', vite: '7.3.6' },
+  { react: '19.2.8', router: '8.3.1', vite: '8.2.2' },
+];
+
+interface INpmTree {
+  version?: string;
+  path?: string;
+  deduped?: boolean;
+  dependencies?: Record<string, INpmTree>;
+}
+
+/** Prefer npm's own CLI, then the npm bundled beside the current Node runtime. */
+export const resolveNpmCli = (): string | undefined => {
+  const directory = path.dirname(process.execPath);
+  const candidates = [
+    process.env.npm_execpath,
+    path.join(directory, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.join(directory, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+
+  return candidates.find((candidate) => candidate && fs.existsSync(candidate));
+};
+
+/** Inspect npm's dependency tree, counting physical copies rather than dependants. */
+export const reactCopies = (root: string): { react: number; 'react-dom': number } => {
+  let output: string;
+
+  try {
+    const npmCli = resolveNpmCli();
+    const args = ['ls', 'react', 'react-dom', '--json', '--all', '--long'];
+
+    output = childProcess.execFileSync(
+      npmCli ? process.execPath : 'npm',
+      npmCli ? [npmCli, ...args] : args,
+      {
+        cwd: root,
+        shell: false,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 20_000,
+        maxBuffer: 8 * 1024 * 1024,
+      },
+    );
+  } catch (error) {
+    const failed = error as { stdout?: string; signal?: string };
+
+    if (!failed.stdout || failed.signal) {
+      throw new Error(
+        'npm ls failed; install dependencies and rerun npm ls react react-dom --json.',
+      );
+    }
+
+    output = String(failed.stdout);
+  }
+
+  const copies = { react: new Set<string>(), 'react-dom': new Set<string>() };
+  const visit = (node: INpmTree, directory: string): void => {
+    for (const [name, dependency] of Object.entries(node.dependencies ?? {})) {
+      const location = dependency.path ?? path.join(directory, 'node_modules', name);
+
+      if ((name === 'react' || name === 'react-dom') && dependency.version && !dependency.deduped) {
+        copies[name].add(fs.existsSync(location) ? fs.realpathSync(location) : location);
+      }
+
+      visit(dependency, location);
+    }
+  };
+
+  visit(JSON.parse(output) as INpmTree, root);
+
+  return { react: copies.react.size, 'react-dom': copies['react-dom'].size };
+};
+
+/** Match React Router's position-based fallback IDs, even below an explicitly named parent. */
+const routeDetails = (routes: TRoutesTree[], parent = ''): IDoctorReport['routes'] =>
+  routes.flatMap((route) => {
+    const position = [parent, String(route.index)].filter(Boolean).join('-');
+
+    return [
+      { id: route.id ?? position, path: route.path ?? null },
+      ...routeDetails(route.children, position),
+    ];
+  });
+
+/** Read-only project inspection. The JSON schema is also usable from automation. */
+export const inspectProject = (options: IDoctorOptions = {}): IDoctorReport => {
+  const root = path.resolve(options.root ?? process.cwd());
+  const checks: ICheck[] = [];
+  const versions: IDoctorReport['versions'] = { node: process.versions.node };
+  const report: IDoctorReport = {
+    versions,
+    adapter: null,
+    routes: [],
+    checks,
+    diagnosticCodes: [],
+  };
+  const check = (name: string, fix: string, inspect: () => string, info = false): void => {
+    try {
+      checks.push({ name, status: 'ok', message: inspect(), fix, ...(info ? { info } : {}) });
+    } catch (error) {
+      checks.push({
+        name,
+        status: 'error',
+        message: (error as Error).message,
+        fix,
+        ...(info ? { info } : {}),
+      });
+    }
+  };
+  let pkg: IPackage = {};
+
+  check('package', 'Run doctor in the app directory or set --root.', () => {
+    pkg = readPackage(path.join(root, 'package.json'));
+
+    return 'package.json is readable';
+  });
+
+  const require = createRequire(path.join(root, 'package.json'));
+  const packages = [PLUGIN_NAME, 'react', 'react-dom', 'react-router', 'vite'];
+  const ownPackage = libraryPackage();
+  const engines: Record<string, string> = { [PLUGIN_NAME]: ownPackage.engines!.node! };
+  const peers: Record<string, Record<string, string>> = { app: pkg.peerDependencies ?? {} };
+
+  for (const name of packages) {
+    check(
+      `version:${name}`,
+      `Install ${name} at a version satisfying the installed packages’ peer ranges.`,
+      () => {
+        const metadata = readPackage(require.resolve(`${name}/package.json`));
+        const version = semver.valid(metadata.version);
+
+        peers[name] =
+          metadata.peerDependencies ??
+          (name === PLUGIN_NAME ? (ownPackage.peerDependencies ?? {}) : {});
+
+        versions[name] = version;
+
+        if (!version) {
+          throw new Error(`${name} has no valid installed version`);
+        }
+
+        if (metadata.engines?.node) {
+          engines[name] = metadata.engines.node;
+        }
+
+        return `${name} ${version}`;
+      },
+    );
+
+    versions[name] ??= null;
+  }
+
+  for (const item of checks.filter(
+    (row) => row.name.startsWith('version:') && row.status === 'ok',
+  )) {
+    const name = item.name.slice('version:'.length);
+    const failures = Object.entries(peers).flatMap(([dependant, ranges]) =>
+      ranges[name] && !semver.satisfies(versions[name]!, ranges[name])
+        ? [`${dependant} requires ${name}: ${ranges[name]}`]
+        : [],
+    );
+
+    if (failures.length) {
+      item.status = 'error';
+      item.message += `; ${failures.join('; ')}`;
+    }
+  }
+
+  const matches = (row: (typeof TESTED_MATRIX)[number]): number =>
+    Number(versions.react === row.react && versions['react-dom'] === row.react) +
+    Number(versions['react-router'] === row.router) +
+    Number(versions.vite === row.vite);
+  const distance = (installed: string | null, tested: string): number => {
+    const version = semver.parse(installed);
+    const target = semver.parse(tested)!;
+
+    return version
+      ? Math.abs(version.major - target.major) * 1_000_000 +
+          Math.abs(version.minor - target.minor) * 1_000 +
+          Math.abs(version.patch - target.patch)
+      : Number.MAX_SAFE_INTEGER;
+  };
+  // Prefer the most matching components, then nearest React, Router, and Vite versions.
+  const [closest] = [...TESTED_MATRIX].sort(
+    (left, right) =>
+      matches(right) - matches(left) ||
+      distance(versions.react, left.react) - distance(versions.react, right.react) ||
+      distance(versions['react-dom'], left.react) - distance(versions['react-dom'], right.react) ||
+      distance(versions['react-router'], left.router) -
+        distance(versions['react-router'], right.router) ||
+      distance(versions.vite, left.vite) - distance(versions.vite, right.vite),
+  );
+  const trio = `React ${versions.react ?? 'missing'}${versions['react-dom'] !== versions.react ? ` (React DOM ${versions['react-dom'] ?? 'missing'})` : ''} + Router ${versions['react-router'] ?? 'missing'} + Vite ${versions.vite ?? 'missing'}`;
+  const isTested = matches(closest) === 3;
+
+  checks.push({
+    name: 'compatibility',
+    status: isTested ? 'ok' : 'warn',
+    message: isTested
+      ? `${trio} is a tested row`
+      : `${trio} is not a tested row; closest: React ${closest.react} + Router ${closest.router} + Vite ${closest.vite}`,
+    fix: `Use React and React DOM ${closest.react}, React Router ${closest.router}, and Vite ${closest.vite} for a tested combination.`,
+  });
+
+  check(
+    'node',
+    'Use a Node version satisfying the package and app engines (CI uses 22.23.2).',
+    () => {
+      if (pkg.engines?.node) {
+        engines.app = pkg.engines.node;
+      }
+
+      const failures = Object.entries(engines).filter(
+        ([, range]) => !semver.satisfies(process.versions.node, range),
+      );
+
+      if (failures.length) {
+        throw new Error(
+          `Node ${process.versions.node} does not satisfy ${failures.map(([name, range]) => `${name}: ${range}`).join(', ')}`,
+        );
+      }
+
+      return `Node ${process.versions.node} satisfies engines`;
+    },
+  );
+
+  check('react-copies', 'Run npm dedupe and align React/React DOM dependency versions.', () => {
+    const copies = reactCopies(root);
+
+    if (copies.react !== 1 || copies['react-dom'] !== 1) {
+      throw new Error(`React copies: ${copies.react}; React DOM copies: ${copies['react-dom']}`);
+    }
+
+    return 'One physical copy each of React and React DOM';
+  });
+
+  let config: TProjectConfig | undefined;
+
+  check('vite-plugin', 'Add SsrBoost() from @lomray/vite-ssr-boost/plugin to Vite plugins.', () => {
+    config = readConfig(root);
+
+    if (!config.plugin) {
+      throw new Error('Vite plugins do not contain the imported SsrBoost() plugin');
+    }
+
+    return 'SsrBoost() is in the Vite plugins';
+  });
+
+  const viteRoot =
+    config?.viteRoot ??
+    (fs.existsSync(path.join(root, 'index.html')) ? root : path.join(root, 'src'));
+  const indexFile = path.resolve(
+    viteRoot,
+    stringValue(config?.option('indexFile')) ?? 'index.html',
+  );
+  const clientFile = stringValue(config?.option('clientFile')) ?? 'client.ts';
+  const serverFile = stringValue(config?.option('serverFile')) ?? 'server.ts';
+
+  check(
+    'html-module',
+    'Keep one local <script type="module" src="..."> pointing to the configured clientFile.',
+    () => {
+      const html = readHtml(indexFile);
+
+      if (html.entries.length !== 1) {
+        throw new Error(
+          `${path.relative(root, indexFile)}: expected one module script, found ${html.entries.length}`,
+        );
+      }
+
+      const src = html.attribute(html.entries[0], 'src');
+
+      if (
+        !src ||
+        /^(?:\w+:|\/\/)/.test(src) ||
+        path.resolve(
+          src.startsWith('/') ? viteRoot : path.dirname(indexFile),
+          src.replace(/^\//, ''),
+        ) !== path.resolve(viteRoot, clientFile)
+      ) {
+        throw new Error(
+          `${path.relative(root, indexFile)}: module script does not match clientFile`,
+        );
+      }
+
+      return 'Module script matches the browser entry';
+    },
+  );
+
+  check('html-outlet', 'Place exactly one <!--ssr-outlet--> inside the root element.', () => {
+    const html = readHtml(indexFile);
+
+    if (html.outlets !== 1) {
+      throw new Error(
+        `${path.relative(root, indexFile)}: expected one <!--ssr-outlet-->, found ${html.outlets}`,
+      );
+    }
+
+    return 'Exactly one SSR outlet';
+  });
+
+  const sources = new SourceFiles(config?.aliases);
+
+  for (const [kind, file, expected] of [
+    ['browser', clientFile, 'browser/entry'],
+    ['server', serverFile, 'adapters/express/entry'],
+  ]) {
+    check(
+      `${kind}-entry`,
+      `Create the ${kind} entry and import ${PLUGIN_NAME}/${expected}.`,
+      () => {
+        const imports = sources
+          .read(path.resolve(viteRoot, file))
+          .ast.program.body.filter((node) => node.type === 'ImportDeclaration');
+
+        if (
+          !imports.some(
+            (node) => node.source.value.replace(/\.js$/, '') === `${PLUGIN_NAME}/${expected}`,
+          )
+        ) {
+          throw new Error(`${file}: missing library ${expected} import`);
+        }
+
+        if (kind === 'server') {
+          report.adapter = 'express';
+        }
+
+        return `${file} imports ${expected}`;
+      },
+    );
+  }
+
+  check(
+    'routes',
+    'Use statically analyzable route objects; follow the file and line in the parser error.',
+    () => {
+      report.routes = routeDetails(
+        new ParseRoutes(
+          ServerConfig.init({}, { root: viteRoot, clientFile }),
+          config?.aliases,
+        ).parse(true),
+      );
+
+      return `${report.routes.length} route IDs resolved`;
+    },
+  );
+
+  check(
+    'scripts',
+    'Set dev (or develop)="ssr-boost dev", build="ssr-boost build", start:ssr="ssr-boost start".',
+    () => {
+      const scripts = pkg.scripts ?? {};
+      const missing = [
+        ['dev', scripts.dev ?? scripts.develop],
+        ['build', scripts.build],
+        ['start', scripts['start:ssr'] ?? scripts.start],
+      ].filter(
+        ([command, value]) =>
+          !new RegExp(`(?:^|\\s)ssr-boost\\s+${command}(?:\\s|$)`).test(value ?? ''),
+      );
+
+      if (missing.length) {
+        throw new Error(
+          `Scripts missing ssr-boost commands: ${missing.map(([command]) => command).join(', ')}`,
+        );
+      }
+
+      return 'Development, build, and SSR start scripts use ssr-boost';
+    },
+  );
+
+  check(
+    'robots',
+    'Review public/robots.txt for your deployment; use build --unlock-robots only when intended.',
+    () => {
+      const publicDir =
+        stringValue(config ? objectProperty(config.node, 'publicDir') : undefined) ?? 'public';
+      const file = path.resolve(viteRoot, publicDir, 'robots.txt');
+
+      if (!fs.existsSync(file)) {
+        return 'No robots.txt policy (report only)';
+      }
+
+      return /^Disallow:\s*\/\s*$/im.test(fs.readFileSync(file, 'utf8'))
+        ? 'robots.txt blocks crawling at / (report only)'
+        : 'robots.txt contains a custom/allow policy (report only)';
+    },
+    true,
+  );
+
+  check(
+    'size-budget',
+    'Add a size:check or test:size script with an application bundle budget.',
+    () =>
+      Object.keys(pkg.scripts ?? {}).some((name) => /(?:^|:)size(?::|$)/.test(name))
+        ? 'Size budget script present'
+        : 'No size budget script (informational)',
+    true,
+  );
+
+  const build = config ? objectProperty(config.node, 'build') : undefined;
+  const outDir =
+    build?.type === 'ObjectExpression' ? stringValue(objectProperty(build, 'outDir')) : undefined;
+  const diagnosticsFile = path.resolve(viteRoot, outDir ?? 'dist', 'ssr-boost-diagnostics.json');
+
+  if (fs.existsSync(diagnosticsFile)) {
+    try {
+      const recorded: unknown = JSON.parse(fs.readFileSync(diagnosticsFile, 'utf8'));
+      const codes: unknown =
+        recorded && typeof recorded === 'object' ? Reflect.get(recorded, 'codes') : undefined;
+
+      report.diagnosticCodes = Array.isArray(codes)
+        ? DIAGNOSTIC_CODES.filter((code) => codes.includes(code))
+        : [];
+    } catch {
+      // A stale or unrelated file is not evidence of diagnostic codes.
+    }
+  }
+
+  return report;
+};
+
+/** Support bundles contain an allowlist, never raw messages, npm output, env, or source. */
+export const supportBundle = (report: IDoctorReport) => ({
+  schemaVersion: 1,
+  versions: report.versions,
+  adapter: report.adapter,
+  routes: report.routes,
+  checks: report.checks.map(({ name, status, fix, info }) => ({
+    name,
+    status,
+    fix,
+    ...(info ? { info } : {}),
+  })),
+  diagnosticCodes: report.diagnosticCodes,
+});
+
+const runDoctor = (options: IDoctorOptions = {}): void => {
+  const report = inspectProject(options);
+
+  if (options.bundle) {
+    try {
+      fs.writeFileSync(
+        path.resolve(options.root ?? process.cwd(), options.bundle),
+        `${JSON.stringify(supportBundle(report), null, 2)}\n`,
+      );
+    } catch {
+      report.checks.push({
+        name: 'bundle',
+        status: 'error',
+        message: 'Cannot write the support bundle.',
+        fix: 'Choose a writable file in an existing directory for --bundle.',
+      });
+    }
+  }
+
+  if (options.json) {
+    console.info(JSON.stringify(report, null, 2));
+  } else {
+    console.table(
+      report.checks.map(({ status, name, message, fix }) => ({
+        status,
+        check: name,
+        message,
+        fix,
+      })),
+    );
+  }
+
+  process.exitCode = report.checks.some((check) => check.status === 'error') ? 1 : 0;
+};
+
+export default runDoctor;

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,791 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Node, CallExpression, ImportDeclaration } from '@babel/types';
+import { createTwoFilesPatch } from 'diff';
+import {
+  editText,
+  format,
+  libraryPackage,
+  MANUAL_GUIDE,
+  objectProperty,
+  readConfig,
+  readHtml,
+  readPackage,
+  stringValue,
+} from '@cli/project';
+import type { IEdit } from '@cli/project';
+import PLUGIN_NAME from '@constants/plugin-name';
+import ParseRoutes from '@services/parse-routes';
+import SourceFiles, { sourceError, unwrap, walk } from '@services/source-files';
+import type { ISourceValue } from '@services/source-files';
+
+export interface IInitOptions {
+  root?: string;
+  entry?: string;
+  routes?: string;
+  dryRun?: boolean;
+  apply?: boolean;
+}
+
+export interface IFileChange {
+  file: string;
+  before: string;
+  after: string;
+}
+
+/** Relative module specifier, valid for both TypeScript and JavaScript. */
+const relativeImport = (from: string, to: string): string => {
+  const relative = path.relative(path.dirname(from), to).split(path.sep).join('/');
+
+  return relative.startsWith('.') ? relative : `./${relative}`;
+};
+
+/** Binding references used when extracting an inline route array. */
+const namesIn = (node: Node): Set<string> => {
+  const names = new Set<string>();
+
+  walk(node, (child) => {
+    if (child.type === 'Identifier' || child.type === 'JSXIdentifier') {
+      names.add(child.name);
+    }
+  });
+
+  return names;
+};
+
+/** Keep just the imported bindings needed by the extracted route module. */
+const importText = (
+  node: ImportDeclaration,
+  names: Set<string>,
+  source: string,
+  quote: string,
+  semicolon: string,
+): string => {
+  const specifiers = node.specifiers.filter((specifier) => names.has(specifier.local.name));
+  const defaults = specifiers
+    .filter((specifier) => specifier.type === 'ImportDefaultSpecifier')
+    .map((specifier) => specifier.local.name);
+  const namespaces = specifiers
+    .filter((specifier) => specifier.type === 'ImportNamespaceSpecifier')
+    .map((specifier) => `* as ${specifier.local.name}`);
+  const named = specifiers.flatMap((specifier) => {
+    if (specifier.type !== 'ImportSpecifier') {
+      return [];
+    }
+
+    const imported =
+      specifier.imported.type === 'Identifier'
+        ? specifier.imported.name
+        : `${quote}${specifier.imported.value}${quote}`;
+
+    return [
+      `${specifier.importKind === 'type' ? 'type ' : ''}${imported}${imported === specifier.local.name ? '' : ` as ${specifier.local.name}`}`,
+    ];
+  });
+  const bindings = [
+    ...defaults,
+    ...namespaces,
+    ...(named.length ? [`{ ${named.join(', ')} }`] : []),
+  ];
+
+  return bindings.length
+    ? `import ${node.importKind === 'type' ? 'type ' : ''}${bindings.join(', ')} from ${quote}${source}${quote}${semicolon}`
+    : '';
+};
+
+/** Find a usable export of a route array without importing the module. */
+const arrayExports = (
+  sources: SourceFiles,
+  file: string,
+): { name: string; value: ISourceValue }[] => {
+  const names: string[] = [];
+
+  for (const node of sources.read(file).ast.program.body) {
+    if (node.type === 'ExportDefaultDeclaration') {
+      names.push('default');
+    }
+
+    if (node.type === 'ExportNamedDeclaration') {
+      if (node.declaration?.type === 'VariableDeclaration') {
+        names.push(
+          ...node.declaration.declarations.flatMap((declaration) =>
+            declaration.id.type === 'Identifier' ? [declaration.id.name] : [],
+          ),
+        );
+      }
+
+      names.push(
+        ...node.specifiers.map((specifier) =>
+          specifier.exported.type === 'Identifier'
+            ? specifier.exported.name
+            : specifier.exported.value,
+        ),
+      );
+    }
+  }
+
+  return names.flatMap((name) => {
+    const value = sources.exported(file, name);
+
+    return value.node.type === 'ArrayExpression' ? [{ name, value }] : [];
+  });
+};
+
+/** Build all edits first. A failed analysis leaves even --apply completely untouched. */
+export const planInit = (options: IInitOptions = {}): IFileChange[] => {
+  const root = path.resolve(options.root ?? process.cwd());
+  const config = readConfig(root);
+  const { newline, quote, semicolon } = format(config.code);
+  const changes: IFileChange[] = [];
+  const add = (file: string, after: string): void => {
+    const before = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+
+    if (before !== after) {
+      changes.push({ file: path.relative(root, file).split(path.sep).join('/'), before, after });
+    }
+  };
+  const base = objectProperty(config.node, 'base');
+
+  if (base && stringValue(base) !== '/') {
+    throw sourceError(config.file, base, 'Vite base; automatic migration currently maps only /');
+  }
+
+  if (config.node.properties.some((property) => property.type === 'SpreadElement')) {
+    throw sourceError(config.file, config.node, 'spread Vite configuration');
+  }
+
+  const build = objectProperty(config.node, 'build');
+  const rollup =
+    build?.type === 'ObjectExpression' ? objectProperty(build, 'rollupOptions') : undefined;
+
+  if (
+    config.option('entrypoint') ||
+    (rollup?.type === 'ObjectExpression' && objectProperty(rollup, 'input'))
+  ) {
+    throw sourceError(config.file, rollup, 'multiple or custom build entries');
+  }
+
+  const indexFile = path.resolve(
+    config.viteRoot,
+    stringValue(config.option('indexFile')) ?? 'index.html',
+  );
+  const html = readHtml(indexFile);
+
+  if (html.entries.length !== 1 || !html.attribute(html.entries[0], 'src')) {
+    throw sourceError(
+      indexFile,
+      undefined,
+      `module entries (${html.entries.length}); expected one external module script`,
+    );
+  }
+
+  const src = html.attribute(html.entries[0], 'src')!;
+
+  if (/(?:^(?:\w+:|\/\/))|[?#]/.test(src)) {
+    throw sourceError(indexFile, undefined, 'non-local browser entry URL');
+  }
+
+  const detectedEntry = path.resolve(
+    src.startsWith('/') ? config.viteRoot : path.dirname(indexFile),
+    src.replace(/^\//, ''),
+  );
+  const entry = options.entry ? path.resolve(root, options.entry) : detectedEntry;
+
+  if (entry !== detectedEntry) {
+    throw sourceError(indexFile, undefined, '--entry does not match the module script');
+  }
+
+  const sources = new SourceFiles(config.aliases);
+  const { code, ast } = sources.read(entry);
+  const entryFormat = format(code);
+  const q = entryFormat.quote;
+  const end = entryFormat.semicolon;
+  const nl = entryFormat.newline;
+  const isTS = /\.[cm]?tsx?$/.test(entry);
+  const server = path.resolve(path.dirname(entry), `server.${isTS ? 'ts' : 'js'}`);
+  const isAlready = ast.program.body.some(
+    (node) =>
+      node.type === 'ImportDeclaration' &&
+      node.source.value.replace(/\.js$/, '') === `${PLUGIN_NAME}/browser/entry`,
+  );
+
+  if (isAlready) {
+    if (!config.plugin || html.outlets !== 1 || !fs.existsSync(server)) {
+      throw sourceError(
+        entry,
+        undefined,
+        'partially configured SSR app; finish the migration using doctor',
+      );
+    }
+
+    return [];
+  }
+
+  if (fs.existsSync(server)) {
+    throw sourceError(server, undefined, 'existing server entry; refusing to overwrite');
+  }
+
+  if (html.roots.length !== 1 || !html.roots[0].sourceCodeLocation?.endTag || html.outlets > 1) {
+    throw sourceError(
+      indexFile,
+      undefined,
+      'root element; expected exactly one empty element with id="root"',
+    );
+  }
+
+  const rootLocation = html.roots[0].sourceCodeLocation;
+  const rootContents = html.code.slice(
+    rootLocation.startTag!.endOffset,
+    rootLocation.endTag!.startOffset,
+  );
+
+  if (rootContents.replace('<!--ssr-outlet-->', '').trim()) {
+    throw sourceError(indexFile, undefined, 'non-empty root element');
+  }
+
+  const calls: CallExpression[] = [];
+  const renders: CallExpression[] = [];
+
+  walk(ast, (node) => {
+    if (node.type !== 'CallExpression') {
+      return;
+    }
+
+    if (node.callee.type === 'Identifier') {
+      const imported = sources.import(entry, node.callee.name);
+
+      if (
+        imported?.exported === 'createBrowserRouter' &&
+        ['react-router', 'react-router-dom'].includes(imported.source)
+      ) {
+        calls.push(node);
+      }
+    }
+
+    if (
+      node.callee.type === 'MemberExpression' &&
+      node.callee.property.type === 'Identifier' &&
+      node.callee.property.name === 'render'
+    ) {
+      renders.push(node);
+    }
+  });
+
+  if (calls.length !== 1) {
+    throw sourceError(
+      entry,
+      calls[1],
+      `createBrowserRouter calls (${calls.length}); JSX BrowserRouter/Routes and router factories need manual migration`,
+    );
+  }
+
+  const [call] = calls;
+
+  if (call.arguments.length !== 1 || renders.length !== 1) {
+    throw sourceError(
+      entry,
+      call,
+      'router options or multiple React roots; migrate their settings manually',
+    );
+  }
+
+  const [render] = renders;
+  const rootCall =
+    render.callee.type === 'MemberExpression'
+      ? sources.resolve({ node: render.callee.object, file: entry }).node
+      : undefined;
+
+  if (
+    rootCall?.type !== 'CallExpression' ||
+    rootCall.callee.type !== 'Identifier' ||
+    sources.import(entry, rootCall.callee.name)?.source !== 'react-dom/client' ||
+    sources.import(entry, rootCall.callee.name)?.exported !== 'createRoot' ||
+    rootCall.arguments.length !== 1 ||
+    render.arguments.length !== 1
+  ) {
+    throw sourceError(
+      entry,
+      rootCall,
+      'React mount; use createRoot(element).render(...) without custom options',
+    );
+  }
+
+  // Reproduce the root tree in both environments. Built-ins must not receive entry props.
+  const rendered = unwrap(render.arguments[0]);
+  let provider = rendered;
+  const wrappers: { tag: string; builtin: boolean }[] = [];
+  const wrapperImports = new Map<ImportDeclaration, Set<string>>();
+
+  while (provider?.type === 'JSXElement' || provider?.type === 'JSXFragment') {
+    if (provider.type === 'JSXElement') {
+      const { name } = provider.openingElement;
+      const member =
+        name.type === 'JSXMemberExpression' && name.object.type === 'JSXIdentifier'
+          ? name
+          : undefined;
+      const local =
+        name.type === 'JSXIdentifier'
+          ? name.name
+          : member?.object.type === 'JSXIdentifier'
+            ? member.object.name
+            : undefined;
+      const namespace = ast.program.body.find(
+        (node): node is ImportDeclaration =>
+          node.type === 'ImportDeclaration' &&
+          node.specifiers.some(
+            (specifier) =>
+              specifier.type === 'ImportNamespaceSpecifier' && specifier.local.name === local,
+          ),
+      );
+      const binding = local
+        ? (sources.import(entry, local) ??
+          (namespace
+            ? {
+                declaration: namespace,
+                source: namespace.source.value,
+                exported: '*',
+              }
+            : undefined))
+        : undefined;
+      const isBuiltin =
+        binding?.source === 'react' &&
+        ['StrictMode', 'Fragment'].includes(member?.property.name ?? binding.exported);
+
+      if (
+        !member &&
+        binding?.exported === 'RouterProvider' &&
+        ['react-router', 'react-router-dom'].includes(binding.source)
+      ) {
+        break;
+      }
+
+      if (
+        !local ||
+        !binding ||
+        (member && !isBuiltin) ||
+        provider.openingElement.attributes.length
+      ) {
+        throw sourceError(
+          entry,
+          provider,
+          'App wrapper; use an imported component without additional props',
+        );
+      }
+
+      const names = wrapperImports.get(binding.declaration) ?? new Set<string>();
+
+      names.add(local);
+      wrapperImports.set(binding.declaration, names);
+      wrappers.push({
+        tag: member ? `${local}.${member.property.name}` : local,
+        builtin: isBuiltin,
+      });
+    } else {
+      wrappers.push({ tag: '', builtin: true });
+    }
+
+    const children = provider.children.filter(
+      (child) => child.type !== 'JSXText' || child.value.trim(),
+    );
+
+    if (children.length !== 1) {
+      throw sourceError(entry, provider, 'App wrapper; expected exactly one RouterProvider child');
+    }
+
+    [provider] = children;
+  }
+
+  if (provider?.type !== 'JSXElement') {
+    throw sourceError(
+      entry,
+      rendered,
+      'React root; expected an imported RouterProvider with optional App, StrictMode or Fragment wrappers',
+    );
+  }
+
+  const [routerAttribute] = provider.openingElement.attributes;
+
+  if (
+    provider.openingElement.attributes.length !== 1 ||
+    routerAttribute?.type !== 'JSXAttribute' ||
+    routerAttribute.name.name !== 'router' ||
+    routerAttribute.value?.type !== 'JSXExpressionContainer' ||
+    sources.resolve({ node: routerAttribute.value.expression, file: entry }).node !== call
+  ) {
+    throw sourceError(
+      entry,
+      provider,
+      'RouterProvider props; use the detected router without additional props',
+    );
+  }
+
+  let appImport = [...wrapperImports]
+    .map(([declaration, names]) => importText(declaration, names, declaration.source.value, q, end))
+    .join(nl);
+  let serverAppImport = appImport;
+  let appDeclaration = '';
+  let serverAppDeclaration = '';
+  let appName = wrappers[0]?.tag ?? 'App';
+
+  if (wrappers.length !== 1 || wrappers[0].builtin) {
+    const reserved = new Set([...wrapperImports.values()].flatMap((names) => [...names]));
+    const argument = unwrap(call.arguments[0]);
+
+    if (argument?.type === 'Identifier') {
+      reserved.add(argument.name);
+    }
+
+    const unique = (name: string): string => {
+      let result = name;
+
+      while (reserved.has(result)) {
+        result += '_';
+      }
+
+      reserved.add(result);
+
+      return result;
+    };
+
+    appName = unique('App');
+    const fc = unique('FC');
+    const props = unique('PropsWithChildren');
+    const createElement = unique('ssrCreateElement');
+    const fragment = unique('ssrFragment');
+    const typeImport = isTS
+      ? `import type { ${fc === 'FC' ? fc : `FC as ${fc}`}, ${props === 'PropsWithChildren' ? props : `PropsWithChildren as ${props}`} } from ${q}react${q}${end}`
+      : '';
+    const tree = wrappers.length ? wrappers : [{ tag: '', builtin: true }];
+    const jsx = tree.reduceRight((child, { tag }) => `<${tag}>${child}</${tag}>`, '{children}');
+    const expression = tree.reduceRight(
+      (child, { tag }) => `${createElement}(${tag || fragment}, null, ${child})`,
+      'children',
+    );
+    const definition = `const ${appName}${isTS ? `: ${fc}<${props}>` : ''} = ({ children }) => `;
+
+    appImport = [appImport, typeImport].filter(Boolean).join(nl);
+    serverAppImport = [
+      appImport,
+      `import { createElement as ${createElement}${tree.some(({ tag }) => !tag) ? `, Fragment as ${fragment}` : ''} } from ${q}react${q}${end}`,
+    ]
+      .filter(Boolean)
+      .join(nl);
+    serverAppDeclaration = `${definition}${expression}${end}${nl}`;
+    // A .ts/.js entry cannot contain JSX; use the same React tree through createElement.
+    appDeclaration = /\.[jt]sx$/.test(entry)
+      ? `${definition}${jsx}${end}${nl}`
+      : serverAppDeclaration;
+
+    if (!/\.[jt]sx$/.test(entry)) {
+      appImport = serverAppImport;
+    }
+  }
+
+  const originalRoutes = sources.resolve({ node: call.arguments[0], file: entry });
+  let routeValue = originalRoutes;
+  let routeModule = routeValue.file;
+  let routeExport =
+    routeModule !== entry
+      ? arrayExports(sources, routeModule).find((item) => item.value.node === routeValue.node)?.name
+      : undefined;
+
+  if (options.routes) {
+    routeModule = sources.filename(
+      relativeImport(entry, path.resolve(root, options.routes)),
+      entry,
+    );
+    const exports = arrayExports(sources, routeModule);
+
+    if (exports.length !== 1) {
+      throw sourceError(
+        routeModule,
+        undefined,
+        `exported route arrays (${exports.length}); --routes needs one exported array`,
+      );
+    }
+
+    routeValue = exports[0].value;
+    routeExport = exports[0].name;
+  }
+
+  new ParseRoutes({} as never).parseValue(sources, routeValue, true);
+
+  const moved = new Set<Node>();
+
+  if (!routeExport) {
+    const source = sources.read(routeValue.file);
+    const names = namesIn(routeValue.node);
+    let previousSize = -1;
+
+    while (previousSize !== names.size) {
+      previousSize = names.size;
+
+      for (const statement of source.ast.program.body) {
+        const declaration =
+          statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+        const declared =
+          declaration?.type === 'VariableDeclaration'
+            ? declaration.declarations.flatMap((item) =>
+                item.id.type === 'Identifier' ? [item.id.name] : [],
+              )
+            : declaration?.type === 'FunctionDeclaration' && declaration.id
+              ? [declaration.id.name]
+              : [];
+
+        if (declaration && declared.some((name) => names.has(name))) {
+          if (
+            declaration.start! <= routeValue.node.start! &&
+            declaration.end! >= routeValue.node.end!
+          ) {
+            continue;
+          }
+
+          moved.add(statement);
+          namesIn(declaration).forEach((name) => names.add(name));
+        }
+      }
+    }
+
+    const pieces: string[] = [];
+
+    for (const statement of source.ast.program.body) {
+      if (statement.type === 'ImportDeclaration') {
+        const text = importText(statement, names, statement.source.value, q, end);
+
+        if (text) {
+          pieces.push(text);
+        }
+      } else if (moved.has(statement)) {
+        pieces.push(source.code.slice(statement.start!, statement.end!));
+      }
+    }
+
+    const extension = path.extname(routeValue.file);
+
+    routeModule = path.resolve(path.dirname(routeValue.file), `routes.ssr${extension}`);
+
+    if (fs.existsSync(routeModule)) {
+      throw sourceError(routeModule, undefined, 'existing extracted routes file');
+    }
+
+    pieces.push(
+      `export default ${source.code.slice(routeValue.node.start!, routeValue.node.end!)}${isTS ? " satisfies import('react-router').RouteObject[]" : ''}${end}`,
+    );
+    add(routeModule, `${pieces.join(nl + nl)}${nl}`);
+    routeExport = 'default';
+  }
+
+  // Accept only the bootstrap and declarations that feed its route array; do not discard startup code.
+  for (const statement of ast.program.body) {
+    if (statement.type === 'VariableDeclaration' && statement.declarations.length !== 1) {
+      throw sourceError(
+        entry,
+        statement,
+        'multiple bootstrap declarators; put each declaration on its own statement',
+      );
+    }
+
+    if (statement.type === 'ImportDeclaration' || moved.has(statement)) {
+      continue;
+    }
+
+    if (
+      [
+        call,
+        rootCall,
+        render,
+        ...(originalRoutes.file === entry ? [originalRoutes.node] : []),
+      ].some((node) => node.start! >= statement.start! && node.end! <= statement.end!)
+    ) {
+      continue;
+    }
+
+    throw sourceError(
+      entry,
+      statement,
+      'additional browser startup statement; move it to a shared wrapper or migrate manually',
+    );
+  }
+
+  // Follow the original import, including aliases/re-export modules and extension spelling.
+  const routeArgument = unwrap(call.arguments[0]);
+  const routeBinding =
+    routeArgument?.type === 'Identifier' ? sources.import(entry, routeArgument.name) : undefined;
+  const shouldKeepRouteImport = routeBinding && routeValue.node === originalRoutes.node;
+  const routeName =
+    shouldKeepRouteImport && routeArgument?.type === 'Identifier'
+      ? routeArgument.name
+      : routeExport === 'default'
+        ? 'routes'
+        : routeExport;
+  const routeImport = shouldKeepRouteImport
+    ? importText(routeBinding.declaration, new Set([routeName]), routeBinding.source, q, end)
+    : `import ${routeExport === 'default' ? routeName : `{ ${routeExport} }`} from ${q}${relativeImport(entry, routeModule).replace(/\.[cm]?[jt]sx?$/, '')}${q}${end}`;
+  const sideEffects = ast.program.body
+    .filter((node) => node.type === 'ImportDeclaration' && !node.specifiers.length)
+    .map((node) => code.slice(node.start!, node.end!));
+
+  add(
+    entry,
+    [
+      `import entryClient from ${q}${PLUGIN_NAME}/browser/entry${q}${end}`,
+      appImport,
+      routeImport,
+      ...sideEffects,
+      '',
+      ...(appDeclaration ? [appDeclaration] : []),
+      `void entryClient(${appName}, ${routeName})${end}`,
+      '',
+    ].join(nl),
+  );
+  add(
+    server,
+    [
+      `import entryServer from ${q}${PLUGIN_NAME}/adapters/express/entry${q}${end}`,
+      serverAppImport,
+      routeImport,
+      '',
+      ...(serverAppDeclaration ? [serverAppDeclaration] : []),
+      `export default entryServer(${appName}, ${routeName})${end}`,
+      '',
+    ].join(nl),
+  );
+
+  const edits: IEdit[] = [];
+  const pluginOptions = [
+    `clientFile: ${quote}${path.relative(config.viteRoot, entry).split(path.sep).join('/')}${quote}`,
+    `serverFile: ${quote}${path.relative(config.viteRoot, server).split(path.sep).join('/')}${quote}`,
+  ];
+
+  if (!fs.existsSync(path.join(root, 'tsconfig.json'))) {
+    pluginOptions.push('tsconfigAliases: false');
+  }
+
+  const pluginCall = `SsrBoost({ ${pluginOptions.join(', ')} })`;
+
+  if (config.plugin) {
+    throw sourceError(
+      config.file,
+      config.plugin,
+      'existing SsrBoost plugin with a SPA browser entry; finish configuration manually',
+    );
+  }
+
+  if (config.plugins?.type === 'ArrayExpression') {
+    edits.push({
+      start: config.plugins.start! + 1,
+      end: config.plugins.start! + 1,
+      text: `${pluginCall}${config.plugins.elements.length ? ', ' : ''}`,
+    });
+  } else if (!config.plugins) {
+    edits.push({
+      start: config.node.start! + 1,
+      end: config.node.start! + 1,
+      text: `${newline}  plugins: [${pluginCall}],`,
+    });
+  } else {
+    throw sourceError(config.file, config.plugins, 'Vite plugins; use an array literal');
+  }
+
+  if (namesIn(config.ast).has('SsrBoost')) {
+    throw sourceError(
+      config.file,
+      undefined,
+      'existing SsrBoost binding; rename it before automatic migration',
+    );
+  }
+
+  add(
+    config.file,
+    `import SsrBoost from ${quote}${PLUGIN_NAME}/plugin${quote}${semicolon}${newline}${editText(config.code, edits)}`,
+  );
+
+  if (!html.outlets) {
+    add(
+      indexFile,
+      editText(html.code, [
+        {
+          start: rootLocation.startTag!.endOffset,
+          end: rootLocation.startTag!.endOffset,
+          text: '<!--ssr-outlet-->',
+        },
+      ]),
+    );
+  }
+
+  const packageFile = path.join(root, 'package.json');
+  const packageCode = fs.readFileSync(packageFile, 'utf8');
+  const pkg = readPackage(packageFile);
+  const scripts: Record<string, string> = {
+    ...pkg.scripts,
+    [pkg.scripts && Object.hasOwn(pkg.scripts, 'dev') ? 'dev' : 'develop']: 'ssr-boost dev',
+    build: 'ssr-boost build',
+    'start:ssr': 'ssr-boost start',
+  };
+
+  if (pkg.scripts?.preview === 'vite preview') {
+    scripts.preview = 'ssr-boost preview';
+  }
+
+  const packageFormat = format(packageCode);
+  const version = libraryPackage().version!;
+  const dependencies = {
+    ...pkg.dependencies,
+    [PLUGIN_NAME]:
+      pkg.dependencies?.[PLUGIN_NAME] ?? pkg.devDependencies?.[PLUGIN_NAME] ?? `^${version}`,
+  };
+
+  // JSON keeps its indentation, line endings, key order, and unrelated fields.
+  add(
+    packageFile,
+    `${JSON.stringify({ ...pkg, scripts, dependencies }, null, packageFormat.indent).replace(/\n/g, packageFormat.newline)}${packageCode.endsWith('\n') ? packageFormat.newline : ''}`,
+  );
+
+  return changes.sort((left, right) => left.file.localeCompare(right.file));
+};
+
+/** CLI default is a complete unified diff, with no temporary files or installs. */
+const runInit = (options: IInitOptions = {}): void => {
+  try {
+    if (options.apply && options.dryRun) {
+      throw new Error('Choose either --dry-run or --apply.');
+    }
+
+    const changes = planInit(options);
+
+    if (!changes.length) {
+      console.info('No changes: SSR is already initialized. Run ssr-boost doctor.');
+
+      return;
+    }
+
+    for (const change of changes) {
+      console.info(
+        createTwoFilesPatch(
+          change.before ? `a/${change.file}` : '/dev/null',
+          `b/${change.file}`,
+          change.before,
+          change.after,
+        ),
+      );
+    }
+
+    if (options.apply) {
+      for (const change of changes) {
+        fs.writeFileSync(path.resolve(options.root ?? process.cwd(), change.file), change.after);
+      }
+    }
+
+    console.info(
+      options.apply
+        ? `Applied ${changes.length} file changes.`
+        : 'Dry run: no files written. Use --apply to write these changes.',
+    );
+    console.info('Next: npm install; then npx ssr-boost doctor.');
+  } catch (error) {
+    console.error(`${(error as Error).message}\nManual migration: ${MANUAL_GUIDE}`);
+    process.exitCode = 1;
+  }
+};
+
+export default runInit;

--- a/src/cli/project.ts
+++ b/src/cli/project.ts
@@ -1,0 +1,229 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Node, ObjectExpression } from '@babel/types';
+import JSON5 from 'json5';
+import { parse as parseHtml } from 'parse5';
+import type { DefaultTreeAdapterTypes } from 'parse5';
+import type { Alias } from 'vite';
+import PLUGIN_NAME from '@constants/plugin-name';
+import SourceFiles, { propertyName, sourceError, unwrap } from '@services/source-files';
+
+export const MANUAL_GUIDE =
+  'https://lomray-software.github.io/vite-ssr-boost/guide/migrate-existing-spa';
+
+export interface IPackage {
+  version?: string;
+  engines?: { node?: string };
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+export interface IEdit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/** Apply non-overlapping source edits, preserving everything around them. */
+export const editText = (code: string, edits: IEdit[]): string =>
+  [...edits]
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (result, edit) => result.slice(0, edit.start) + edit.text + result.slice(edit.end),
+      code,
+    );
+
+/** Infer the small formatting choices needed for inserted code. */
+export const format = (
+  code: string,
+): { newline: string; quote: string; semicolon: string; indent: string } => ({
+  newline: code.includes('\r\n') ? '\r\n' : '\n',
+  quote: /(?:from\s+|import\s*)"/.test(code) ? '"' : "'",
+  semicolon: /(?:from\s+['"][^'"]+['"]|\))\s*;/.test(code) ? ';' : '',
+  indent: code.match(/\n([\t ]+)\S/)?.[1] ?? '  ',
+});
+
+export const readPackage = (file: string): IPackage =>
+  JSON.parse(fs.readFileSync(file, 'utf8')) as IPackage;
+
+/** Works in the source checkout and in the published cli/ directory. */
+export const libraryPackage = (): IPackage => {
+  const published = new URL('../package.json', import.meta.url);
+
+  return readPackage(
+    fs.existsSync(published)
+      ? published.pathname
+      : new URL('../../package.json', import.meta.url).pathname,
+  );
+};
+
+export const objectProperty = (object: ObjectExpression, name: string): Node | undefined => {
+  const property = object.properties.find((item) => propertyName(item) === name);
+
+  return property?.type === 'ObjectProperty' ? unwrap(property.value) : undefined;
+};
+
+export const stringValue = (node?: Node): string | undefined =>
+  node?.type === 'StringLiteral' ? node.value : undefined;
+
+/** Read a conventional Vite config without evaluating plugins or env files. */
+export const readConfig = (root: string) => {
+  const candidates = ['ts', 'js', 'mts', 'mjs', 'cts', 'cjs']
+    .map((extension) => path.join(root, `vite.config.${extension}`))
+    .filter((file) => fs.existsSync(file));
+
+  if (candidates.length !== 1) {
+    throw sourceError(
+      path.join(root, 'vite.config.*'),
+      undefined,
+      `Vite configs (${candidates.length}); expected exactly one`,
+    );
+  }
+
+  const [file] = candidates;
+  const sources = new SourceFiles();
+  const { code, ast } = sources.read(file);
+  let { node } = sources.exported(file);
+
+  if (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    sources.import(file, node.callee.name)?.exported === 'defineConfig'
+  ) {
+    node = unwrap(node.arguments[0])!;
+  }
+
+  if (node?.type === 'ArrowFunctionExpression') {
+    node = unwrap(node.body)!;
+  }
+
+  if (node?.type !== 'ObjectExpression') {
+    throw sourceError(file, node, 'Vite configuration; use defineConfig({ ... })');
+  }
+
+  const rootNode = objectProperty(node, 'root');
+
+  if (rootNode && rootNode.type !== 'StringLiteral') {
+    throw sourceError(file, rootNode, 'Vite root; use a string literal');
+  }
+
+  const viteRoot = path.resolve(root, stringValue(rootNode) ?? '.');
+  const plugins = objectProperty(node, 'plugins');
+  const plugin =
+    plugins?.type === 'ArrayExpression'
+      ? plugins.elements.find((element) => {
+          if (element?.type !== 'CallExpression' || element.callee.type !== 'Identifier') {
+            return false;
+          }
+
+          return (
+            sources.import(file, element.callee.name)?.source.replace(/\.js$/, '') ===
+            `${PLUGIN_NAME}/plugin`
+          );
+        })
+      : undefined;
+  const options = plugin?.type === 'CallExpression' ? unwrap(plugin.arguments[0]) : undefined;
+
+  if (options && options.type !== 'ObjectExpression') {
+    throw sourceError(file, options, 'SsrBoost options; use an object literal');
+  }
+
+  const option = (name: string): Node | undefined =>
+    options?.type === 'ObjectExpression' ? objectProperty(options, name) : undefined;
+  const aliases: Alias[] = [];
+  const resolve = objectProperty(node, 'resolve');
+  const alias = resolve?.type === 'ObjectExpression' ? objectProperty(resolve, 'alias') : undefined;
+
+  if (alias?.type === 'ObjectExpression') {
+    for (const property of alias.properties) {
+      if (property.type !== 'ObjectProperty') {
+        continue;
+      }
+
+      const find = propertyName(property);
+      let replacement = stringValue(unwrap(property.value));
+      const value = unwrap(property.value);
+
+      // Stock Vite alias: fileURLToPath(new URL('./src', import.meta.url)).
+      const url = value?.type === 'CallExpression' ? value.arguments[0] : undefined;
+
+      if (
+        url?.type === 'NewExpression' &&
+        url.callee.type === 'Identifier' &&
+        url.callee.name === 'URL' &&
+        url.arguments[0]?.type === 'StringLiteral'
+      ) {
+        replacement = path.resolve(root, url.arguments[0].value);
+      }
+
+      if (find && replacement) {
+        aliases.push({ find, replacement });
+      }
+    }
+  }
+
+  const tsconfig = path.join(root, 'tsconfig.json');
+
+  if (
+    fs.existsSync(tsconfig) &&
+    !(
+      option('tsconfigAliases')?.type === 'BooleanLiteral' &&
+      Reflect.get(option('tsconfigAliases')!, 'value') === false
+    )
+  ) {
+    const ts = JSON5.parse<{
+      compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+    }>(fs.readFileSync(tsconfig, 'utf8'));
+    const base = path.resolve(root, ts.compilerOptions?.baseUrl ?? path.relative(root, viteRoot));
+
+    for (const [find, replacements] of Object.entries(ts.compilerOptions?.paths ?? {})) {
+      aliases.push({
+        find: find.replace(/\/\*$/, ''),
+        replacement: path.resolve(base, replacements[0].replace(/\/\*$/, '')),
+      });
+    }
+  }
+
+  return { file, code, ast, node, viteRoot, plugins, plugin, option, aliases, sources };
+};
+
+/** HTML locations come from an HTML parser, so comments and attribute order are harmless. */
+export const readHtml = (
+  file: string,
+): {
+  code: string;
+  entries: DefaultTreeAdapterTypes.Element[];
+  roots: DefaultTreeAdapterTypes.Element[];
+  outlets: number;
+  attribute: (node: DefaultTreeAdapterTypes.Element, name: string) => string | undefined;
+} => {
+  const code = fs.readFileSync(file, 'utf8');
+  const document = parseHtml(code, { sourceCodeLocationInfo: true });
+  const elements: DefaultTreeAdapterTypes.Element[] = [];
+  const outlets = code.split('<!--ssr-outlet-->').length - 1;
+
+  const visit = (node: DefaultTreeAdapterTypes.Node): void => {
+    if ('tagName' in node) {
+      elements.push(node);
+    }
+
+    if ('childNodes' in node) {
+      node.childNodes.forEach(visit);
+    }
+  };
+
+  visit(document);
+
+  const attribute = (node: DefaultTreeAdapterTypes.Element, name: string): string | undefined =>
+    node.attrs.find((attr) => attr.name === name)?.value;
+  const entries = elements.filter(
+    (node) => node.tagName === 'script' && attribute(node, 'type') === 'module',
+  );
+  const roots = elements.filter((node) => attribute(node, 'id') === 'root');
+
+  return { code, entries, roots, outlets, attribute };
+};
+
+export type TProjectConfig = ReturnType<typeof readConfig>;

--- a/src/core/compose-html.ts
+++ b/src/core/compose-html.ts
@@ -1,84 +1,147 @@
-/**
- * Stream the shell, React body and hydration footer under downstream backpressure.
- */
+import type DataStream from '@core/data-stream';
+import htmlBoundary from '@core/html-boundary';
+
+/** Stream shell, data frames, React bytes and footer only under downstream demand. */
 const composeHtml = (
   header: string,
   body: ReadableStream<Uint8Array>,
   footer: string,
   abort?: (reason?: unknown) => void,
   onComplete?: () => void,
+  data?: DataStream,
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder();
   const reader = body.getReader();
   let phase: 'body' | 'footer' | 'header' = 'header';
+  let isStopped = false;
+  let isReleased = false;
+  let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | undefined;
+  const observe = htmlBoundary();
+  let canInject = true;
+  let heldChunk: Uint8Array | undefined;
+
+  /** Release exactly once, including cancellation during an outstanding read. */
+  const release = (): void => {
+    if (!isReleased) {
+      isReleased = true;
+      reader.releaseLock();
+    }
+  };
 
   return new ReadableStream<Uint8Array>(
     {
-      /**
-       * Release the React reader when the response consumer cancels.
-       */
+      /** Cancel immediately; a disconnected consumer cannot receive abort scripts. */
       cancel: async (reason) => {
+        isStopped = true;
         abort?.(reason);
-
-        if (phase === 'footer') {
-          return;
-        }
+        data?.cancel();
 
         try {
-          await reader.cancel(reason);
+          if (!isReleased) {
+            await reader.cancel(reason);
+          }
         } finally {
-          reader.releaseLock();
+          release();
           onComplete?.();
         }
       },
 
-      /**
-       * Emit one available shell or React chunk per downstream pull.
-       */
+      /** Keep at most the one React read requested by the current downstream pull. */
       async pull(controller) {
-        if (phase === 'header') {
-          phase = 'body';
+        try {
+          if (phase === 'header') {
+            phase = 'body';
 
-          if (header) {
-            controller.enqueue(encoder.encode(header));
+            if (header) {
+              controller.enqueue(encoder.encode(header));
 
+              return;
+            }
+          }
+
+          while (!isStopped) {
+            const frames = canInject ? data?.take() : undefined;
+
+            if (isStopped) {
+              return;
+            }
+
+            if (frames) {
+              controller.enqueue(encoder.encode(frames));
+
+              return;
+            }
+
+            if (heldChunk) {
+              canInject = observe(heldChunk);
+              controller.enqueue(heldChunk);
+              heldChunk = undefined;
+
+              return;
+            }
+
+            if (phase === 'body') {
+              pendingRead ??= reader.read();
+              const chunk = await (data && !data.isDone && canInject
+                ? Promise.race([pendingRead, data.changed().then(() => undefined)])
+                : pendingRead);
+
+              if (isStopped) {
+                return;
+              }
+
+              if (!chunk) {
+                continue;
+              }
+
+              pendingRead = undefined;
+
+              if (!chunk.done) {
+                heldChunk = chunk.value;
+                // Settle data already resolved by this React boundary before its HTML.
+                continue;
+              }
+
+              phase = 'footer';
+              canInject = true;
+              release();
+              continue;
+            }
+
+            if (data && !data.isDone) {
+              await data.changed();
+              continue;
+            }
+
+            if (footer) {
+              controller.enqueue(encoder.encode(footer));
+            }
+
+            isStopped = true;
+            onComplete?.();
+            controller.close();
+          }
+        } catch (error) {
+          if (isStopped) {
             return;
           }
-        }
 
-        if (phase === 'body') {
-          let chunk: ReadableStreamReadResult<Uint8Array>;
+          isStopped = true;
+          abort?.(error);
+          data?.cancel();
+          controller.error(error);
 
           try {
-            chunk = await reader.read();
-          } catch (error) {
-            abort?.(error);
-            reader.releaseLock();
+            if (!isReleased) {
+              await reader.cancel(error).catch(() => undefined);
+            }
+          } finally {
+            release();
             onComplete?.();
-            controller.error(error);
-
-            return;
           }
-
-          if (!chunk.done) {
-            controller.enqueue(chunk.value);
-
-            return;
-          }
-
-          phase = 'footer';
-          reader.releaseLock();
-          onComplete?.();
         }
-
-        if (footer) {
-          controller.enqueue(encoder.encode(footer));
-        }
-
-        controller.close();
       },
     },
-    // Do not start reading React while a downstream wrapper is still delivering the header.
     { highWaterMark: 0 },
   );
 };

--- a/src/core/data-stream.ts
+++ b/src/core/data-stream.ts
@@ -1,0 +1,258 @@
+import { stringify } from 'devalue';
+import { isRouteErrorResponse } from 'react-router';
+import type { StaticHandlerContext } from 'react-router';
+import script, { streamScript } from '@core/script';
+import serializeErrors from '@helpers/serialize-errors';
+import type Diagnostics from '@services/diagnostics';
+
+interface IPending {
+  settled: boolean;
+}
+
+/** Preserve route response details without shipping arbitrary error properties. */
+const errorProperties = (reason: unknown, diagnostics: boolean): Record<string, unknown> => {
+  const value = reason as {
+    type?: string;
+    init?: ResponseInit;
+    message?: string;
+    name?: string;
+    stack?: string;
+    data?: unknown;
+  } | null;
+  const isResponse = isRouteErrorResponse(reason);
+  const isDataError = value?.type === 'DataWithResponseInit';
+  const status = isResponse ? reason.status : value?.init?.status;
+  const statusText = isResponse ? reason.statusText : value?.init?.statusText;
+  const properties: Record<string, unknown> = {
+    message:
+      value?.message ??
+      (isResponse || isDataError
+        ? statusText || `Route data error (${status ?? 500})`
+        : String(reason)),
+    name: value?.name ?? 'Error',
+  };
+
+  if (isResponse || isDataError) {
+    Object.assign(properties, {
+      status: status ?? 500,
+      statusText: statusText ?? '',
+      data: value?.data,
+      internal: false,
+    });
+  }
+
+  if (diagnostics && value?.stack) {
+    properties.stack = value.stack;
+  }
+
+  return properties;
+};
+
+/**
+ * Request-local promise identities and settlements. devalue encodes each frame's
+ * value; promise reducers keep settlement scheduling outside the value codec.
+ * No React bytes are read here. Nested settlements can introduce further placeholders.
+ */
+class DataStream {
+  public readonly initial: string;
+  public readonly done: Promise<void>;
+  protected resolveDone!: () => void;
+  protected notify?: () => void;
+  protected change?: Promise<void>;
+  protected readonly identities = new WeakMap<Promise<unknown>, number>();
+  protected readonly pending = new Map<number, IPending>();
+  protected readonly frames: string[] = [];
+  protected initialized = false;
+  protected stopped = false;
+  protected aborted = false;
+  protected nextId = 0;
+
+  public constructor(
+    context: StaticHandlerContext,
+    protected readonly diagnostics?: Diagnostics,
+    protected readonly nonce?: string,
+  ) {
+    diagnostics?.inspectRouterState(context);
+    this.done = new Promise((resolve) => {
+      this.resolveDone = resolve;
+    });
+    try {
+      this.initial = this.encodeValue({
+        loaderData: context.loaderData,
+        actionData: context.actionData,
+        errors: serializeErrors(context.errors),
+      });
+      this.initialized = true;
+      this.wake();
+    } catch (error) {
+      this.cancel();
+      throw error;
+    }
+  }
+
+  /** Use the codec's public plugin API, without depending on React Router internals. */
+  protected promiseId = (value: unknown): [number] | false => {
+    if (value instanceof Promise) {
+      let id = this.identities.get(value);
+
+      if (id === undefined) {
+        id = this.nextId++;
+        this.identities.set(value, id);
+        this.pending.set(id, { settled: false });
+        const promiseId = id;
+
+        void value.then(
+          (result: unknown) => this.settle(promiseId, result, false),
+          (error: unknown) => this.settle(promiseId, error, true),
+        );
+
+        if (this.aborted) {
+          this.settle(id, new Error('SSR loader/action promise aborted before it settled.'), true);
+        }
+      }
+
+      return [id];
+    }
+
+    return false;
+  };
+
+  /** Encode one complete value, preserving the codec's built-in value representations. */
+  protected encodeValue(value: unknown): string {
+    return stringify(value, {
+      SSRBPromise: this.promiseId,
+      SSRBError: (error: unknown) =>
+        (error instanceof Error || isRouteErrorResponse(error)) &&
+        Object.entries(errorProperties(error, Boolean(this.diagnostics))),
+      SSRBObject: (item: unknown) =>
+        Boolean(item && typeof item === 'object' && Object.hasOwn(item, '__proto__')) &&
+        Object.entries(item as object),
+      SSRBUndefined: (item: unknown) =>
+        typeof item === 'function' ||
+        typeof item === 'symbol' ||
+        Boolean(
+          item &&
+          typeof item === 'object' &&
+          !Array.isArray(item) &&
+          ![
+            Object.prototype,
+            null,
+            Date.prototype,
+            Map.prototype,
+            Set.prototype,
+            RegExp.prototype,
+            Promise.prototype,
+            Error.prototype,
+          ].includes(Object.getPrototypeOf(item) as object),
+        ),
+    });
+  }
+
+  /** Publish only once, and finish encoding before announcing a settlement. */
+  protected settle(id: number, value: unknown, rejected: boolean): void {
+    const pending = this.pending.get(id);
+
+    if (!pending || pending.settled || this.stopped) {
+      return;
+    }
+
+    pending.settled = true;
+
+    if (!rejected) {
+      this.diagnostics?.inspectStreamValue(value, id);
+    }
+
+    try {
+      const payload = this.encodeValue(
+        rejected
+          ? Object.assign(
+              new Error('Streamed loader/action rejection'),
+              errorProperties(value, Boolean(this.diagnostics)),
+            )
+          : value,
+      );
+
+      this.frames.push(streamScript([rejected ? 'reject' : 'resolve', id, payload], this.nonce));
+    } catch (error) {
+      const payload = this.encodeValue(
+        new Error(`Cannot serialize streamed value: ${String(error)}`),
+      );
+
+      this.frames.push(streamScript(['reject', id, payload], this.nonce));
+    } finally {
+      this.pending.delete(id);
+      this.wake();
+    }
+  }
+
+  /** Notify a waiting pull and settle completion only after nested values were visited. */
+  protected wake(): void {
+    this.notify?.();
+    this.notify = undefined;
+    this.change = undefined;
+
+    if (this.initialized && !this.pending.size) {
+      this.resolveDone();
+    }
+  }
+
+  public get isDone(): boolean {
+    return this.initialized && !this.pending.size;
+  }
+
+  /** Wait for data, without starting a read from the React stream. */
+  public changed(): Promise<void> {
+    if (this.frames.length || this.isDone) {
+      return Promise.resolve();
+    }
+
+    return (this.change ??= new Promise((resolve) => {
+      this.notify = resolve;
+    }));
+  }
+
+  /** Drain completed value frames before delivering a React boundary chunk. */
+  public take(): string {
+    return this.frames.splice(0).join('');
+  }
+
+  /** Publish initialization in the selected shell/footer block to unblock hydration. */
+  public state(isEarly: boolean): string {
+    const { initial } = this;
+    const assignment = 'window.__staticRouterHydrationData = {__ssrBoostStream: true};';
+
+    return (
+      script(assignment, this.nonce, true) + streamScript(['init', initial, isEarly], this.nonce)
+    );
+  }
+
+  /** Reject outstanding placeholders before a timeout closes the HTML response. */
+  public abort(): void {
+    this.aborted = true;
+    let count = 0;
+
+    for (const [id, value] of this.pending) {
+      if (!value.settled) {
+        count++;
+        this.settle(id, new Error('SSR loader/action promise aborted before it settled.'), true);
+      }
+    }
+
+    if (count) {
+      this.diagnostics?.streamAborted(count);
+    }
+  }
+
+  /** A disconnected client cannot receive scripts; detach request state from late work. */
+  public cancel(): void {
+    this.stopped = true;
+    this.initialized = true;
+    this.pending.clear();
+    this.frames.length = 0;
+    this.wake();
+  }
+}
+
+export { errorProperties };
+
+export default DataStream;

--- a/src/core/html-boundary.ts
+++ b/src/core/html-boundary.ts
@@ -1,0 +1,59 @@
+/**
+ * Track tag, comment and raw-text boundaries across arbitrary React byte chunks.
+ * Data scripts may be inserted only after a complete tag, never in a split token
+ * or script/style body. This observer neither buffers HTML nor reads ahead.
+ */
+const htmlBoundary = (): ((chunk: Uint8Array) => boolean) => {
+  let mode: 'text' | 'tag' | 'comment' | 'raw' = 'text';
+  let token = '';
+  let quote = '';
+  let raw = '';
+
+  return (chunk) => {
+    for (const byte of chunk) {
+      const char = String.fromCharCode(byte);
+
+      if (mode === 'raw') {
+        token = (token + char).slice(-32);
+
+        if (char === '>' && new RegExp(`</${raw}\\s*>$`, 'i').test(token)) {
+          mode = 'text';
+          token = '';
+          raw = '';
+        }
+      } else if (mode === 'comment') {
+        token = (token + char).slice(-3);
+
+        if (token === '-->') {
+          mode = 'text';
+          token = '';
+        }
+      } else if (mode === 'tag') {
+        if (token.length < 32) {
+          token += char;
+        }
+
+        if (token === '<!--') {
+          mode = 'comment';
+        } else if (quote) {
+          if (char === quote) {
+            quote = '';
+          }
+        } else if (char === '"' || char === "'") {
+          quote = char;
+        } else if (char === '>') {
+          raw = /^<(script|style|textarea|title)(?:\s|>)/i.exec(token)?.[1]?.toLowerCase() ?? '';
+          mode = raw ? 'raw' : 'text';
+          token = '';
+        }
+      } else if (char === '<') {
+        mode = 'tag';
+        token = '<';
+      }
+    }
+
+    return mode === 'text' && chunk[chunk.length - 1] === 62;
+  };
+};
+
+export default htmlBoundary;

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -6,12 +6,12 @@ import StreamError from '@constants/stream-error';
 import { ServerProvider } from '@context/server';
 import type { IServerContext } from '@context/server';
 import composeHtml from '@core/compose-html';
+import DataStream from '@core/data-stream';
 import headResponse from '@core/head-response';
 import { mergeResponseHeaders } from '@core/headers';
 import transformHtml from '@core/transform-html';
 import type { ISsrExecutionContext } from '@core/types';
 import buildCustomState from '@helpers/build-custom-state';
-import buildRouterState from '@helpers/build-router-state';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import obtainStreamError from '@helpers/obtain-stream-error';
 import type Diagnostics from '@services/diagnostics';
@@ -40,6 +40,8 @@ export interface ISsrRequestContext<TAppProps = Record<string, any>> {
 }
 
 export interface IRenderStreamOptions {
+  nonce?: string;
+  bootstrapScriptContent?: string;
   onError: (error: unknown) => void;
   signal: AbortSignal;
 }
@@ -79,6 +81,10 @@ export interface ICoreRenderParams<TAppProps = Record<string, any>> {
 }
 
 export interface ICoreRenderOptions<TAppProps = Record<string, any>> {
+  /** Hydrate the parsed shell while deferred boundaries are still pending. */
+  hydration?: 'early' | 'footer';
+  nonce?: string;
+  bootstrapScriptContent?: string;
   /**
    * React rendering deadline in milliseconds, starting after router preparation.
    */
@@ -157,7 +163,8 @@ const createShellErrorResponse = <TAppProps,>(
  */
 const prepareHtmlResponse = <TAppProps,>(
   context: ISsrRequestContext<TAppProps>,
-  { getState, onShellReady }: ICoreRenderOptions<TAppProps>,
+  { getState, onShellReady, hydration, nonce }: ICoreRenderOptions<TAppProps>,
+  dataStream: DataStream,
 ): IHtmlResponse => {
   const serverResponse = context.serverContext!.response;
 
@@ -169,15 +176,27 @@ const prepareHtmlResponse = <TAppProps,>(
   }
 
   const shell = onShellReady?.({ context }) ?? {};
-  const routerState = buildRouterState(context.routerContext!, context.diagnostics);
-  const customState = buildCustomState(getState?.({ context }), context.diagnostics);
-  const header = shell.header || context.html.header;
+  const isEarly = hydration === 'early' && context.isStream;
+  const customState = buildCustomState(
+    getState?.({ context }),
+    context.diagnostics,
+    nonce,
+    Boolean(isEarly),
+  );
+  let header = shell.header || context.html.header;
   const shellFooter = shell.footer || context.html.footer;
 
   context.diagnostics?.inspectShell({ header, footer: shellFooter });
 
   // Router state unblocks the browser entry, so custom state must already be available.
-  const footer = customState + routerState + shellFooter;
+  let footer = shellFooter;
+
+  if (isEarly) {
+    header += customState + dataStream.state(true);
+  } else {
+    footer = customState + dataStream.state(false) + dataStream.take() + footer;
+  }
+
   const headers = new Headers(context.response.headers);
 
   return { header, footer, headers, status: context.response.status };
@@ -192,6 +211,9 @@ const render = async <TAppProps,>(
   {
     abortDelay = 15_000,
     getState,
+    hydration = 'footer',
+    nonce,
+    bootstrapScriptContent,
     onError,
     onResponse,
     onRouterReady,
@@ -211,8 +233,14 @@ const render = async <TAppProps,>(
   }
 
   context.routerContext = queried;
+  const dataStream = new DataStream(queried, context.diagnostics, nonce);
 
-  await prepare?.({ context, executionContext });
+  try {
+    await prepare?.({ context, executionContext });
+  } catch (error) {
+    dataStream.cancel();
+    throw error;
+  }
 
   const { isStream = true } = (await onRouterReady?.({ context })) ?? {};
 
@@ -271,6 +299,7 @@ const render = async <TAppProps,>(
     abortReason = reason;
     cleanup();
     context.didError ??= StreamError.RenderCancel;
+    dataStream.abort();
     renderController.abort(reason);
     output?.abort(reason);
   };
@@ -291,6 +320,11 @@ const render = async <TAppProps,>(
 
   try {
     output = await renderToStream(node, {
+      nonce,
+      bootstrapScriptContent:
+        hydration === 'early' && isStream
+          ? `(window.__ssrBoostStream = window.__ssrBoostStream || []).push(["shell"]);${bootstrapScriptContent ?? ''};document.currentScript?.remove();`
+          : bootstrapScriptContent,
       /**
        * Classify expected cancellation separately from unexpected React errors.
        */
@@ -320,9 +354,9 @@ const render = async <TAppProps,>(
       output.abort(abortReason);
     }
 
-    void output.allReady.then(clearAbortTimer, clearAbortTimer);
+    void Promise.all([output.allReady, dataStream.done]).then(clearAbortTimer, clearAbortTimer);
 
-    await (isStream ? output.shellReady : output.allReady);
+    await (isStream ? output.shellReady : Promise.all([output.allReady, dataStream.done]));
   } catch (error) {
     abort(error);
     await output?.stream.cancel(error).catch(() => undefined);
@@ -343,10 +377,16 @@ const render = async <TAppProps,>(
       );
     }
 
-    const { header, footer, headers, status } = prepareHtmlResponse(context, {
-      getState,
-      onShellReady,
-    });
+    const { header, footer, headers, status } = prepareHtmlResponse(
+      context,
+      {
+        getState,
+        onShellReady,
+        hydration,
+        nonce,
+      },
+      dataStream,
+    );
 
     if (context.request.method === 'HEAD' || [204, 205, 304].includes(status)) {
       abort();
@@ -358,7 +398,7 @@ const render = async <TAppProps,>(
       });
     }
 
-    const body = composeHtml(header, output.stream, footer, abort, cleanup);
+    const body = composeHtml(header, output.stream, footer, abort, cleanup, dataStream);
     const transformed = transformHtml(
       body,
       onResponse ? (html, isEnd) => onResponse({ context, html, isEnd }) : undefined,

--- a/src/core/script.ts
+++ b/src/core/script.ts
@@ -1,0 +1,23 @@
+import htmlEscape from '@helpers/html-escape';
+
+/** Escape an attribute independently of the JavaScript string escaping rules. */
+const script = (content: string, nonce?: string, isTemporary = false): string => {
+  const attribute =
+    nonce === undefined
+      ? ''
+      : ` nonce="${nonce.replace(/[&<>"']/g, (char) => `&#${char.charCodeAt(0)};`)}"`;
+
+  return `<script async${attribute}>${content}${isTemporary ? 'document.currentScript?.remove();' : ''}</script>`;
+};
+
+/** Queue frames even when the async browser entry has not executed yet. */
+const streamScript = (frame: unknown, nonce?: string): string =>
+  script(
+    `(window.__ssrBoostStream = window.__ssrBoostStream || []).push(${htmlEscape(JSON.stringify(frame))});`,
+    nonce,
+    true,
+  );
+
+export { streamScript };
+
+export default script;

--- a/src/edge/render-to-stream.ts
+++ b/src/edge/render-to-stream.ts
@@ -11,7 +11,10 @@ const getRenderer = async (): Promise<typeof ReactDOMServer.renderToReadableStre
 /**
  * Adapt React Web streams and settle readiness even when initialization is aborted.
  */
-const renderToStream: TRenderToStream = async (node, { onError, signal }) => {
+const renderToStream: TRenderToStream = async (
+  node,
+  { onError, signal, nonce, bootstrapScriptContent },
+) => {
   const controller = new AbortController();
   let rejectPending!: (reason: Error) => void;
 
@@ -46,7 +49,12 @@ const renderToStream: TRenderToStream = async (node, { onError, signal }) => {
   try {
     stream = await Promise.race([
       getRenderer().then((renderToReadableStream) =>
-        renderToReadableStream(node, { onError, signal: controller.signal }),
+        renderToReadableStream(node, {
+          onError,
+          signal: controller.signal,
+          nonce,
+          bootstrapScriptContent,
+        }),
       ),
       pendingAbort,
     ]);

--- a/src/helpers/build-custom-state.ts
+++ b/src/helpers/build-custom-state.ts
@@ -1,3 +1,4 @@
+import script from '@core/script';
 import htmlEscape from '@helpers/html-escape';
 import type Diagnostics from '@services/diagnostics';
 
@@ -7,6 +8,8 @@ import type Diagnostics from '@services/diagnostics';
 function buildCustomState(
   initState?: Record<string, Record<string, any>> | void,
   diagnostics?: Diagnostics,
+  nonce?: string,
+  isTemporary = false,
 ): string {
   diagnostics?.inspectState(initState);
 
@@ -20,7 +23,7 @@ function buildCustomState(
       ? `.${key}`
       : `[${htmlEscape(JSON.stringify(key))}]`;
 
-    return `<script async>window${property} = JSON.parse(${json});</script>`;
+    return script(`window${property} = JSON.parse(${json});`, nonce, isTemporary);
   });
 
   return stateScripts.join('').trim();

--- a/src/helpers/build-router-state.ts
+++ b/src/helpers/build-router-state.ts
@@ -1,4 +1,5 @@
 import type { StaticHandlerContext } from 'react-router';
+import script from '@core/script';
 import htmlEscape from '@helpers/html-escape';
 import serializeErrors from '@helpers/serialize-errors';
 import type Diagnostics from '@services/diagnostics';
@@ -6,7 +7,11 @@ import type Diagnostics from '@services/diagnostics';
 /**
  * Build router state
  */
-function buildRouterState(context: StaticHandlerContext, diagnostics?: Diagnostics): string {
+function buildRouterState(
+  context: StaticHandlerContext,
+  diagnostics?: Diagnostics,
+  nonce?: string,
+): string {
   diagnostics?.inspectRouterState(context);
 
   const { loaderData, actionData, errors } = context;
@@ -17,7 +22,7 @@ function buildRouterState(context: StaticHandlerContext, diagnostics?: Diagnosti
   };
   const json = htmlEscape(JSON.stringify(JSON.stringify(routerState)));
 
-  return `<script async>window.__staticRouterHydrationData = JSON.parse(${json});</script>`;
+  return script(`window.__staticRouterHydrationData = JSON.parse(${json});`, nonce);
 }
 
 export default buildRouterState;

--- a/src/helpers/is-route-file.ts
+++ b/src/helpers/is-route-file.ts
@@ -2,7 +2,8 @@
  * Detect route file
  */
 const isRoutesFile = (code: string): boolean =>
-  /{.*path:.*(lazy:.+import|Component:|element:)|{.*(lazy:.+import|Component:|element:).*path:/s.test(
+  /(?:\blazy|['"]lazy['"]\s*\]?)\s*:\s*(?:async\s*)?(?:function|\([^)]*\)\s*=>)/s.test(code) ||
+  /{.*(?:path|index)\s*:.*(?:Component|element)\s*:|{.*(?:Component|element)\s*:.*(?:path|index)\s*:/s.test(
     code,
   );
 

--- a/src/node/render-to-stream.ts
+++ b/src/node/render-to-stream.ts
@@ -44,6 +44,8 @@ const renderToStream: TRenderToStream = (node, options) => {
   let hasShellSettled = false;
   let hasAborted = false;
   const rendered = renderToPipeableStream(node, {
+    nonce: options.nonce,
+    bootstrapScriptContent: options.bootstrapScriptContent,
     onAllReady: resolveAll,
     onError: options.onError,
 

--- a/src/plugins/normalize-route.ts
+++ b/src/plugins/normalize-route.ts
@@ -30,7 +30,7 @@ function ViteNormalizeRouterPlugin(options: IPluginOptions = {}): Plugin {
 
       if (
         id.includes('node_modules') ||
-        !['.js', '.mjs', '.ts', '.tsx'].includes(extName) ||
+        !['.js', '.jsx', '.mjs', '.ts', '.tsx', '.mts'].includes(extName) ||
         !isRoutesPath ||
         !isRoutesFile(code)
       ) {
@@ -42,6 +42,7 @@ function ViteNormalizeRouterPlugin(options: IPluginOptions = {}): Plugin {
           code,
           // always add pathId to routes for development
           isSSR && !isBuild,
+          id,
         ),
         map: { mappings: '' },
       };

--- a/src/services/build.ts
+++ b/src/services/build.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import chalk from 'chalk';
 import type { ResolvedConfig } from 'vite';
 import { resolveConfig } from 'vite';
+import DIAGNOSTIC_CODES from '@cli/diagnostic-codes';
 import viteResetCache from '@cli/helpers/vite-reset-cache';
 import createFocusOnly from '@helpers/create-focus-only';
 import { createDevMarker } from '@helpers/dev-marker';
@@ -110,6 +111,8 @@ class Build {
    */
   protected hasPreviewModeExitListener = false;
 
+  protected diagnosticCodes = new Set<string>();
+
   /**
    * @constructor
    */
@@ -194,6 +197,20 @@ class Build {
 
     command.stdout?.pipe(process.stdout);
     command.stderr?.pipe(process.stderr);
+
+    // Keep only known codes. Payloads can contain request state or source snippets.
+    for (const stream of [command.stdout, command.stderr]) {
+      let tail = '';
+
+      stream?.on('data', (chunk: Uint8Array) => {
+        const text = tail + Buffer.from(chunk).toString();
+
+        DIAGNOSTIC_CODES.filter((code) => text.includes(code)).forEach((code) =>
+          this.diagnosticCodes.add(code),
+        );
+        tail = text.slice(-80);
+      });
+    }
 
     return { promise, command };
   }
@@ -378,6 +395,7 @@ class Build {
     // this is required step - build with different env may cause problems
     await viteResetCache();
     this.clearBuildFolder();
+    this.diagnosticCodes.clear();
 
     const {
       clientOptions,
@@ -462,6 +480,15 @@ class Build {
     }
 
     createDevMarker(this.isProd, this.viteConfig);
+    fs.mkdirSync(this.buildDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(this.buildDir, 'ssr-boost-diagnostics.json'),
+      JSON.stringify(
+        { codes: [...this.diagnosticCodes].sort((a, b) => a.localeCompare(b)) },
+        null,
+        2,
+      ),
+    );
     onFinish?.();
   }
 }

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -3,6 +3,7 @@ import Logger from '@services/logger';
 
 type TDiagnosticCode =
   | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
+  | 'SSR_BOOST_STREAM_PROMISE_ABORTED'
   | 'SSR_BOOST_STATE_NOT_SERIALIZABLE'
   | 'SSR_BOOST_OUTLET_MISSING'
   | 'SSR_BOOST_HYDRATION_STATE_MISSING'
@@ -78,15 +79,27 @@ const valueType = (value: unknown): string => {
 };
 
 /**
- * Find values JSON cannot preserve, descending only into plain objects and arrays.
+ * Custom state uses JSON. Router state also supports promises, Date, RegExp, bigint,
+ * Map and Set through the stream codec; functions, symbols, classes and cycles warn.
  */
 const walkSerializable = (
   value: unknown,
   report: (issue: ISerializationIssue) => void,
   path = '$',
   ancestors = new Set<object>(),
+  streamed = false,
 ): void => {
   const type = typeof value;
+
+  if (
+    streamed &&
+    (value instanceof Promise ||
+      value instanceof Date ||
+      value instanceof RegExp ||
+      type === 'bigint')
+  ) {
+    return;
+  }
 
   if (type === 'function' || type === 'bigint' || type === 'symbol') {
     report({ path, reason: `${valueType(value)} is not JSON-serializable` });
@@ -102,6 +115,7 @@ const walkSerializable = (
   const prototype: unknown = Object.getPrototypeOf(object);
 
   if (
+    !(streamed && (object instanceof Map || object instanceof Set)) &&
     prototype !== Object.prototype &&
     prototype !== null &&
     !(Array.isArray(object) && prototype === Array.prototype)
@@ -124,7 +138,17 @@ const walkSerializable = (
 
   ancestors.add(object);
 
-  for (const [key, child] of Object.entries(object)) {
+  const entries =
+    streamed && object instanceof Map
+      ? [...(object as Map<unknown, unknown>)].flatMap(([key, child], index) => [
+          [`${index}.key`, key],
+          [`${index}.value`, child],
+        ])
+      : streamed && object instanceof Set
+        ? [...(object as Set<unknown>)].map((child, index) => [String(index), child])
+        : Object.entries(object);
+
+  for (const [key, child] of entries as [string, unknown][]) {
     const suffix =
       Array.isArray(object) && /^(0|[1-9]\d*)$/.test(key)
         ? `[${key}]`
@@ -132,7 +156,7 @@ const walkSerializable = (
           ? `.${key}`
           : `[${JSON.stringify(key)}]`;
 
-    walkSerializable(child, report, path + suffix, ancestors);
+    walkSerializable(child, report, path + suffix, ancestors, streamed);
   }
 
   ancestors.delete(object);
@@ -193,9 +217,34 @@ class Diagnostics {
               `Route ${JSON.stringify(route)} at ${path}: ${reason}.`,
             ),
           `${kind}[${JSON.stringify(route)}]`,
+          new Set(),
+          true,
         );
       }
     }
+  }
+
+  /** Report the request's pending loader/action promises at the render deadline. */
+  public streamAborted(count: number): void {
+    this.warn(
+      'SSR_BOOST_STREAM_PROMISE_ABORTED',
+      `Route ${JSON.stringify(this.route)} aborted with ${count} pending loader/action promise(s); the browser receives a rejection when connected.`,
+    );
+  }
+
+  /** Inspect streamed resolutions with the same supported value matrix as initial data. */
+  public inspectStreamValue(value: unknown, id: number): void {
+    walkSerializable(
+      value,
+      ({ path, reason }) =>
+        this.warn(
+          'SSR_BOOST_LOADER_NOT_SERIALIZABLE',
+          `Route ${JSON.stringify(this.route)} at ${path}: ${reason}.`,
+        ),
+      `promise[${id}]`,
+      new Set(),
+      true,
+    );
   }
 
   /**

--- a/src/services/parse-routes.ts
+++ b/src/services/parse-routes.ts
@@ -1,6 +1,4 @@
-import fs from 'fs';
-import { resolve } from 'node:path';
-import path from 'path';
+import path from 'node:path';
 import babelGenerate from '@babel/generator';
 import type * as GenerateTypes from '@babel/generator';
 import * as parser from '@babel/parser';
@@ -8,11 +6,9 @@ import type { ParseResult } from '@babel/parser';
 import babelTraverse from '@babel/traverse';
 import type * as TraverseTypes from '@babel/traverse';
 import type {
-  ImportExpression,
+  Expression,
   Node as BabelNode,
   File as BabelFile,
-  VariableDeclaration,
-  ExportDefaultDeclaration,
   ObjectExpression,
 } from '@babel/types';
 import {
@@ -30,420 +26,246 @@ import {
 } from '@babel/types';
 import type { Alias } from 'vite';
 import PLUGIN_NAME from '@constants/plugin-name';
-import PathNormalize from '@services/path-normalize';
 import type ServerConfig from '@services/server-config';
-//
+import SourceFiles, { unwrap, walk, propertyName, sourceError } from '@services/source-files';
+import type { ISourceValue } from '@services/source-files';
+
 // @ts-expect-error known import problem
 const generate = (babelGenerate.default ?? babelGenerate) as (typeof GenerateTypes)['default'];
 // @ts-expect-error known import problem
 const traverse = (babelTraverse.default ?? babelTraverse) as (typeof TraverseTypes)['default'];
 
-interface IPathImport {
-  routesPath: string | null;
-  exportName: string | null;
-}
-
 interface IMapImports {
-  [name: string]: {
-    path: string;
-    isDefault: boolean; // is default import?
-  };
+  [name: string]: { path: string; isDefault: boolean };
 }
 
 export type TRoutesTree = {
   index: number;
+  id?: string;
+  path?: string | null;
   import: string;
   children: TRoutesTree[];
 };
 
-/**
- * Parse react router routes array
- */
-class ParseRoutes {
-  /**
-   * Unwrap expression-only TypeScript syntax and parentheses.
-   */
-  private static unwrapExpression(
-    node: BabelNode | null | undefined,
-  ): BabelNode | null | undefined {
-    switch (node?.type) {
-      case 'TSSatisfiesExpression':
-      case 'TSAsExpression':
-      case 'TSTypeAssertion':
-      case 'TSNonNullExpression':
-      case 'ParenthesizedExpression':
-        return ParseRoutes.unwrapExpression(node.expression);
-      default:
-        return node;
-    }
+/** Get the one statically named module loaded by a lazy route. */
+export const lazyImport = ({ node, file }: ISourceValue): string => {
+  const value = unwrap(node)!;
+
+  if (value.type !== 'ArrowFunctionExpression' && value.type !== 'FunctionExpression') {
+    throw sourceError(file, value, 'lazy route; use a function importing one literal module');
   }
 
-  /**
-   * Path normalize service
-   */
-  protected readonly pathNormalize: PathNormalize;
+  let result = unwrap(value.body);
 
-  /**
-   * Server config
-   */
-  protected readonly config: ServerConfig;
-
-  /**
-   * @constructor
-   */
-  constructor(config: ServerConfig, viteAliases?: Alias[]) {
-    this.config = config;
-    this.pathNormalize = new PathNormalize(config, viteAliases);
-  }
-
-  /**
-   * Parse routes
-   */
-  public parse(): TRoutesTree[] {
-    const { clientFile, root } = this.config.getParams();
-
-    const clientEntrypoint = resolve(root, clientFile);
-    const routesEntrypoint = this.findRoutesEntrypoint(clientEntrypoint);
-
-    if (!routesEntrypoint?.routesPath) {
-      throw new Error(`Unable to find routes file import in ${clientFile}`);
-    }
-
-    const { routesPath, exportName } = routesEntrypoint;
-    const routeFilepath = this.resolveFilename(routesPath, clientEntrypoint);
-
-    return this.recursiveBuildRoutesTree(routeFilepath, exportName);
-  }
-
-  /**
-   * Parse file and return ast
-   */
-  private parseFile(filename: string): ParseResult<BabelFile> | null {
-    try {
-      const code = fs.readFileSync(filename, 'utf-8');
-
-      return parser.parse(code, {
-        sourceType: 'module',
-        createImportExpressions: true,
-        plugins: ['typescript', 'jsx'],
-      });
-    } catch {
-      return null;
-    }
-  }
-
-  /**
-   * Find route import filepath
-   */
-  private getImportPath(
-    ast: ParseResult<BabelFile>,
-    importName: string | null,
-  ): IPathImport | null {
-    let routesPath: string | null = null;
-    let exportName: string | null = null;
-
-    traverse(ast, {
-      ImportDeclaration(nodePath) {
-        const importNode = nodePath.node;
-
-        importNode.specifiers.forEach((specifier) => {
-          if (specifier.local.name === importName) {
-            exportName = specifier.type === 'ImportDefaultSpecifier' ? null : importName;
-            routesPath = importNode.source.value;
-          }
-        });
-      },
-    });
-
-    return {
-      routesPath,
-      exportName,
-    };
-  }
-
-  /**
-   * Find routes array inside code
-   */
-  private findRoutesDefinition(
-    ast: ParseResult<BabelFile>,
-    exportName: string | null,
-  ): null | VariableDeclaration | ExportDefaultDeclaration {
-    let exportNameResolved = exportName;
-    let defaultExportNode: ExportDefaultDeclaration | null = null;
-
-    // noinspection JSUnusedGlobalSymbols
-    traverse(ast, {
-      ExportNamedDeclaration({ node }) {
-        if (!node.declaration && node.specifiers.length > 0) {
-          node.specifiers.forEach((specifier) => {
-            // @ts-expect-error missing in types
-            const exportedName = specifier.exported.name as string;
-
-            if (exportName === null && specifier.type === 'ExportSpecifier') {
-              if (specifier.local.name === 'default') {
-                exportNameResolved = exportedName;
-              }
-            } else if (exportedName === exportName) {
-              // @ts-expect-error missing in types
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              exportNameResolved = specifier.local.name as string;
-            }
-          });
-        }
-      },
-      ExportDefaultDeclaration({ node }) {
-        if (exportName === null) {
-          defaultExportNode = node;
-
-          if (node.declaration.type === 'Identifier') {
-            exportNameResolved = node.declaration.name;
-            // @ts-expect-error missing in types
-          } else if (node.declaration.type === 'VariableDeclaration') {
-            // @ts-expect-error missing in types
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            exportNameResolved = node.declaration.declarations[0].id.name as string;
-          }
-        }
-      },
-    });
-
-    if (exportNameResolved) {
-      let variableNode: VariableDeclaration | null = null;
-
-      traverse(ast, {
-        VariableDeclaration({ node }) {
-          node.declarations.forEach((declaration) => {
-            // @ts-expect-error missing in types
-            if (declaration.id.name === exportNameResolved) {
-              variableNode = node;
-            }
-          });
-        },
-      });
-
-      return variableNode;
-    }
-
-    return defaultExportNode;
-  }
-
-  /**
-   * Entrypoint routes file
-   */
-  private findRoutesEntrypoint(clientEntrypoint: string): IPathImport | null {
-    const ast = this.parseFile(clientEntrypoint);
-
-    let routesVariable: string | null = null;
-
-    if (!ast) {
-      return routesVariable;
-    }
-
-    traverse(ast, {
-      CallExpression({ node }) {
-        if (
-          // @ts-expect-error missing in types
-          node.callee.name === 'entryClient' &&
-          node.arguments.length >= 2 &&
-          node.arguments[1].type === 'Identifier'
-        ) {
-          routesVariable = node.arguments[1].name;
-        }
-      },
-    });
-
-    return this.getImportPath(ast, routesVariable);
-  }
-
-  /**
-   * Resolve route filename import
-   */
-  private resolveFilename(filename: string, relativeFile?: string): string | null {
-    let resolvedFilename = filename;
-
-    if ((filename.startsWith('./') || filename.startsWith('../')) && relativeFile) {
-      resolvedFilename = path.resolve(path.dirname(relativeFile), filename);
-    }
-
-    const filepath = this.pathNormalize.getAppPath(resolvedFilename, true);
-
-    return this.pathNormalize.findAppFile(filepath!);
-  }
-
-  /**
-   * Parse ast array routes objects
-   */
-  private parseRoutesArray(
-    elements: BabelNode[],
-    importsMap: IMapImports,
-    relativeFile: string,
-  ): TRoutesTree[] {
-    const results: TRoutesTree[] = [];
-
-    elements.forEach((node, index) => {
-      if (node.type === 'ObjectExpression') {
-        const routeInfo: TRoutesTree = { index, import: '', children: [] };
-
-        node.properties.forEach((prop) => {
-          const objectProp = prop as {
-            key: { name: string };
-            value: { type: string; elements: BabelNode[] };
-          };
-
-          if (objectProp.key.name === 'children') {
-            const children = ParseRoutes.unwrapExpression(objectProp.value as BabelNode);
-
-            if (isArrayExpression(children)) {
-              routeInfo.children = this.parseRoutesArray(
-                children.elements as BabelNode[],
-                importsMap,
-                relativeFile,
-              );
-            }
-          }
-
-          // async routes
-          if (
-            objectProp.key.name === 'lazy' &&
-            objectProp.value.type === 'ArrowFunctionExpression'
-          ) {
-            // @ts-expect-error incorrect types
-            const importCall = objectProp.value.body as ImportExpression;
-
-            if (importCall.type === 'ImportExpression') {
-              const importArg = importCall.source;
-
-              if (importArg.type === 'StringLiteral') {
-                routeInfo.import = importArg.value;
-              }
-            }
-          }
-
-          // static routes: Component
-          if (objectProp.key.name === 'Component' && objectProp.value.type === 'Identifier') {
-            // @ts-expect-error incorrect types
-            const importName = objectProp.value.name as string;
-            const { path: importPath } = importsMap[importName] ?? {};
-
-            if (importPath) {
-              routeInfo.import = importPath;
-            }
-          }
-
-          // static routes: element
-          if (objectProp.key.name === 'element' && objectProp.value.type === 'JSXElement') {
-            // @ts-expect-error incorrect types
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            const importName = objectProp.value?.openingElement?.name?.name as string;
-            const { path: importPath } = importsMap[importName] ?? {};
-
-            if (importPath) {
-              routeInfo.import = importPath;
-            }
-          }
-
-          if (objectProp.key.name === 'children' && objectProp.value.type === 'Identifier') {
-            // @ts-expect-error incorrect types
-            const importName = objectProp.value.name as string;
-            const { path: importPath, isDefault } = importsMap[importName] ?? {};
-
-            if (importPath) {
-              const childrenFilePath = this.resolveFilename(importPath, relativeFile);
-
-              if (childrenFilePath) {
-                routeInfo.children = this.recursiveBuildRoutesTree(
-                  childrenFilePath,
-                  isDefault ? null : importName,
-                );
-              }
-            }
-          }
-        });
-
-        if (routeInfo.import || routeInfo.children.length > 0) {
-          results.push(routeInfo);
-        }
-      }
-    });
-
-    return results;
-  }
-
-  /**
-   * Parse imports map from ast
-   */
-  private static parseImportsMap(ast: ParseResult<BabelFile>): IMapImports {
-    const importsMap: IMapImports = {};
-
-    traverse(ast, {
-      ImportDeclaration(nodePath) {
-        const importNode = nodePath.node;
-
-        importNode.specifiers.forEach((specifier) => {
-          importsMap[specifier.local.name] = {
-            path: importNode.source.value,
-            isDefault: specifier.type === 'ImportDefaultSpecifier',
-          };
-        });
-      },
-    });
-
-    return importsMap;
-  }
-
-  /**
-   * Recursive build routes tree with dynamic imports
-   */
-  private recursiveBuildRoutesTree(
-    filename: string | null,
-    exportName: string | null = null,
-  ): TRoutesTree[] {
-    if (!filename) {
-      return [];
-    }
-
-    const ast = this.parseFile(filename);
-
-    if (!ast) {
-      return [];
-    }
-
-    const routesNode = this.findRoutesDefinition(ast, exportName);
-    const results: TRoutesTree[] = [];
-
-    if (!routesNode) {
-      return results;
-    }
-
-    const importsMap = ParseRoutes.parseImportsMap(ast);
-
-    const routesArray = ParseRoutes.unwrapExpression(
-      routesNode.type === 'VariableDeclaration'
-        ? routesNode.declarations[0].init
-        : routesNode.declaration,
-    );
-
-    if (!isArrayExpression(routesArray)) {
-      if (routesNode.type === 'ExportDefaultDeclaration') {
-        const Logger = this.config.getLogger();
-
-        Logger.warn(
-          `Routes manifest: default export of ${filename} is a ${routesArray?.type} and cannot be analyzed; lazy route assets will not be injected.`,
-        );
-
-        return results;
-      }
-
-      throw new Error(
-        `Expected routes array in ${filename}, received ${routesArray?.type ?? 'undefined'}.`,
+  if (result?.type === 'BlockStatement') {
+    if (result.body.length !== 1 || result.body[0].type !== 'ReturnStatement') {
+      throw sourceError(
+        file,
+        value,
+        'lazy function body; return one literal import (optionally with .then)',
       );
     }
 
-    results.push(
-      ...this.parseRoutesArray(routesArray.elements as BabelNode[], importsMap, filename),
+    result = unwrap(result.body[0].argument);
+  }
+
+  if (result?.type === 'AwaitExpression') {
+    result = unwrap(result.argument);
+  }
+
+  if (
+    result?.type === 'CallExpression' &&
+    result.callee.type === 'MemberExpression' &&
+    result.callee.property.type === 'Identifier' &&
+    result.callee.property.name === 'then'
+  ) {
+    result = unwrap(result.callee.object);
+  }
+
+  if (result?.type !== 'ImportExpression') {
+    throw sourceError(
+      file,
+      result,
+      'lazy route result; return one literal import (optionally with .then)',
     );
+  }
+
+  const imports: string[] = [];
+
+  walk(value, (child) => {
+    // Babel 7 and 8 both use ImportExpression with createImportExpressions enabled.
+    if (child.type === 'ImportExpression') {
+      if (child.source.type !== 'StringLiteral') {
+        throw sourceError(file, child, 'dynamic lazy import; use a string literal');
+      }
+
+      imports.push(child.source.value);
+    }
+  });
+
+  if (imports.length !== 1) {
+    throw sourceError(
+      file,
+      value,
+      `lazy route with ${imports.length} imports; use exactly one literal module`,
+    );
+  }
+
+  return imports[0];
+};
+
+/** Static React Router route analysis; never imports application code. */
+class ParseRoutes {
+  private static unwrapExpression = unwrap;
+
+  public constructor(
+    private readonly config: ServerConfig,
+    private readonly viteAliases?: Alias[],
+  ) {}
+
+  /** Locate the library entry by its import binding, not its local spelling. */
+  public parse(includeEmpty = false): TRoutesTree[] {
+    const { clientFile, root } = this.config.getParams();
+    const file = path.resolve(root, clientFile);
+    const sources = new SourceFiles(
+      this.viteAliases ?? this.config.getVite()?.config.resolve.alias,
+    );
+    const calls: ISourceValue[] = [];
+
+    walk(sources.read(file).ast, (node) => {
+      if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') {
+        return;
+      }
+
+      const imported = sources.import(file, node.callee.name);
+
+      if (
+        imported?.source.replace(/\.js$/, '') === `${PLUGIN_NAME}/browser/entry` &&
+        ['default', 'entry'].includes(imported.exported)
+      ) {
+        if (!node.arguments[1]) {
+          throw sourceError(file, node, 'browser entry routes argument');
+        }
+
+        calls.push({ node: node.arguments[1], file });
+      }
+    });
+
+    if (calls.length !== 1) {
+      throw sourceError(
+        file,
+        calls[1]?.node,
+        `browser entry calls (${calls.length}); expected one library browser/entry call`,
+      );
+    }
+
+    return this.parseValue(sources, calls[0], includeEmpty);
+  }
+
+  /** Also used to validate a proposed migration before any files are written. */
+  public parseValue(
+    sources: SourceFiles,
+    value: ISourceValue,
+    includeEmpty = false,
+    ancestors = new Set<BabelNode>(),
+  ): TRoutesTree[] {
+    const { node, file } = sources.resolve(value);
+
+    if (node.type !== 'ArrayExpression' || ancestors.has(node)) {
+      throw sourceError(file, node, 'routes array; use a static, non-circular array');
+    }
+
+    const next = new Set([...ancestors, node]);
+    const results: TRoutesTree[] = [];
+
+    node.elements.forEach((element, index) => {
+      if (!element) {
+        throw sourceError(file, node, 'empty route array entry; use route objects');
+      }
+
+      if (element.type === 'SpreadElement') {
+        throw sourceError(file, element, 'route array spread; declare array entries explicitly');
+      }
+
+      const properties = sources.properties({ node: element, file });
+      const route: TRoutesTree = { index, import: '', children: [] };
+      const id = properties.get('id');
+      const routePath = properties.get('path');
+      const children = properties.get('children');
+      const lazy = properties.get('lazy');
+
+      if (id) {
+        const resolved = sources.resolve(id);
+
+        if (resolved.node.type !== 'StringLiteral') {
+          throw sourceError(resolved.file, resolved.node, 'route id; use a static string');
+        }
+
+        route.id = resolved.node.value;
+      }
+
+      if (routePath) {
+        // Dynamic path helpers do not affect asset analysis. Do not execute them for bundles.
+        const literal = unwrap(routePath.node);
+
+        route.path = literal?.type === 'StringLiteral' ? literal.value : null;
+      }
+
+      if (children) {
+        route.children = this.parseValue(sources, children, includeEmpty, next);
+      }
+
+      if (lazy) {
+        const resolved = sources.resolve(lazy);
+
+        route.import = this.assetPath(lazyImport(resolved), resolved.file);
+      } else {
+        const component = properties.get('Component') ?? properties.get('element');
+        const componentNode = unwrap(component?.node);
+        const name =
+          componentNode?.type === 'Identifier'
+            ? componentNode.name
+            : componentNode?.type === 'JSXElement' &&
+                componentNode.openingElement.name.type === 'JSXIdentifier'
+              ? componentNode.openingElement.name.name
+              : undefined;
+        const imported = component && name ? sources.import(component.file, name) : undefined;
+
+        if (imported) {
+          route.import = this.assetPath(imported.source, component!.file);
+        } else if (component) {
+          // Inline components and elements still belong to this module's asset graph.
+          route.import = component.file;
+        }
+      }
+
+      if (includeEmpty || route.import || route.children.length) {
+        results.push(route);
+      }
+    });
 
     return results;
+  }
+
+  private assetPath(specifier: string, file: string): string {
+    return specifier.startsWith('.') ? path.resolve(path.dirname(file), specifier) : specifier;
+  }
+
+  private static parseImportsMap(ast: ParseResult<BabelFile>): IMapImports {
+    const imports: IMapImports = {};
+
+    for (const node of ast.program.body) {
+      if (node.type === 'ImportDeclaration') {
+        for (const specifier of node.specifiers) {
+          imports[specifier.local.name] = {
+            path: node.source.value,
+            isDefault: specifier.type === 'ImportDefaultSpecifier',
+          };
+        }
+      }
+    }
+
+    return imports;
   }
 
   /**
@@ -454,14 +276,19 @@ class ParseRoutes {
     importsMap: IMapImports,
     shouldAddPathId: boolean,
     addImportRouteWrapper: () => void,
+    filename: string,
+    wrapperName: string,
   ): void {
     nodePath.node.properties.forEach((property) => {
-      if (isObjectProperty(property) && isIdentifier(property.key)) {
+      if (isObjectProperty(property)) {
+        const key = propertyName(property);
+
         // async routes
-        if (property.key.name === 'lazy' && property.value.type === 'ArrowFunctionExpression') {
-          const importCall = property.value.body as ImportExpression;
+        if (key === 'lazy' && isFunction(unwrap(property.value))) {
+          const lazyValue = unwrap(property.value)!;
+          const importPath = lazyImport({ node: lazyValue, file: filename });
           const onlyClientProp = nodePath.node.properties.find(
-            (p) => isObjectProperty(p) && isIdentifier(p.key) && p.key.name === 'onlyClient',
+            (p) => isObjectProperty(p) && propertyName(p) === 'onlyClient',
           );
 
           /**
@@ -472,7 +299,7 @@ class ParseRoutes {
             type: 'CallExpression',
             callee: {
               type: 'Identifier',
-              name: 'n',
+              name: wrapperName,
             },
             arguments:
               isObjectProperty(onlyClientProp) &&
@@ -480,8 +307,8 @@ class ParseRoutes {
                 isJSXElement(onlyClientProp.value) ||
                 isFunction(onlyClientProp.value) ||
                 isIdentifier(onlyClientProp.value))
-                ? [property.value, onlyClientProp.value]
-                : [property.value],
+                ? [property.value as Expression, onlyClientProp.value]
+                : [property.value as Expression],
           };
 
           if (onlyClientProp) {
@@ -490,22 +317,20 @@ class ParseRoutes {
 
           addImportRouteWrapper();
 
-          if (importCall.type === 'ImportExpression') {
-            const importArg = importCall.source;
+          if (importPath) {
             // current object has part of array (inside array)
             const parent = nodePath.findParent?.((p) =>
               isArrayExpression(ParseRoutes.unwrapExpression(p.node)),
             );
 
-            if (
-              parent &&
-              importArg.type === 'StringLiteral' &&
-              importArg.value &&
-              shouldAddPathId
-            ) {
+            if (parent && importPath && shouldAddPathId) {
               const pathIdProperty = objectProperty(
                 identifier('pathId'),
-                stringLiteral(importArg.value),
+                stringLiteral(
+                  importPath.startsWith('.') && path.isAbsolute(filename)
+                    ? path.resolve(path.dirname(filename), importPath)
+                    : importPath,
+                ),
               );
 
               // Insert the pathId property right after the element property
@@ -518,7 +343,7 @@ class ParseRoutes {
           }
         }
 
-        if (property.key.name === 'element' || property.key.name === 'Component') {
+        if (key === 'element' || key === 'Component') {
           let componentName = '';
 
           if (isJSXElement(property.value) && isJSXIdentifier(property.value.openingElement.name)) {
@@ -534,7 +359,14 @@ class ParseRoutes {
           const importName = importsMap[componentName]?.path;
 
           if (parent && importName && shouldAddPathId) {
-            const pathIdProperty = objectProperty(identifier('pathId'), stringLiteral(importName));
+            const pathIdProperty = objectProperty(
+              identifier('pathId'),
+              stringLiteral(
+                importName.startsWith('.') && path.isAbsolute(filename)
+                  ? path.resolve(path.dirname(filename), importName)
+                  : importName,
+              ),
+            );
 
             // Insert the pathId property right after the element property
             nodePath.node.properties.splice(
@@ -547,7 +379,7 @@ class ParseRoutes {
 
         const children = ParseRoutes.unwrapExpression(property.value);
 
-        if (property.key.name === 'children' && isArrayExpression(children)) {
+        if (key === 'children' && isArrayExpression(children)) {
           // Process each object in the children array recursively
           children.elements.forEach((element) => {
             if (isObjectExpression(element)) {
@@ -556,6 +388,8 @@ class ParseRoutes {
                 importsMap,
                 shouldAddPathId,
                 addImportRouteWrapper,
+                filename,
+                wrapperName,
               );
             }
           });
@@ -568,7 +402,7 @@ class ParseRoutes {
    * Inject pathId to sync/async routes
    * Add async wrapper (see import-routes)
    */
-  public static handleRoutes(code: string, shouldAddPathId: boolean): string {
+  public static handleRoutes(code: string, shouldAddPathId: boolean, filename = 'routes'): string {
     if (!code) {
       return code;
     }
@@ -585,12 +419,28 @@ class ParseRoutes {
 
     const importsMap = ParseRoutes.parseImportsMap(ast);
     let shouldAddRoutesImport = false;
+    let wrapperName = 'n';
+
+    traverse(ast, {
+      Program(nodePath) {
+        if (nodePath.scope.hasBinding(wrapperName)) {
+          wrapperName = nodePath.scope.generateUidIdentifier('importRoute').name;
+        }
+      },
+    });
 
     traverse(ast, {
       ObjectExpression(nodePath): void {
-        ParseRoutes.processRouteFileCode(nodePath, importsMap, shouldAddPathId, () => {
-          shouldAddRoutesImport = true;
-        });
+        ParseRoutes.processRouteFileCode(
+          nodePath,
+          importsMap,
+          shouldAddPathId,
+          () => {
+            shouldAddRoutesImport = true;
+          },
+          filename,
+          wrapperName,
+        );
       },
     });
 
@@ -602,7 +452,7 @@ class ParseRoutes {
             type: 'ImportDefaultSpecifier',
             local: {
               type: 'Identifier',
-              name: 'n',
+              name: wrapperName,
             },
           },
         ],

--- a/src/services/path-normalize.ts
+++ b/src/services/path-normalize.ts
@@ -47,7 +47,9 @@ class PathNormalize {
    */
   public getImportPostfix(): string[] {
     return ['', '/index']
-      .map((prefix) => ['', '.js', '.ts', '.tsx'].map((ext) => `${prefix}${ext}`))
+      .map((prefix) =>
+        ['', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.mts'].map((ext) => `${prefix}${ext}`),
+      )
       .flat();
   }
 

--- a/src/services/source-files.ts
+++ b/src/services/source-files.ts
@@ -1,0 +1,311 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '@babel/parser';
+import type { File, Node, ObjectExpression, ImportDeclaration } from '@babel/types';
+import { VISITOR_KEYS } from '@babel/types';
+import type { Alias } from 'vite';
+
+export interface ISourceValue {
+  node: Node;
+  file: string;
+}
+
+export interface ISourceFile {
+  code: string;
+  ast: File;
+}
+
+/** Strip syntax that has no runtime effect. */
+export const unwrap = (node: Node | null | undefined): Node | undefined => {
+  switch (node?.type) {
+    case 'TSSatisfiesExpression':
+    case 'TSAsExpression':
+    case 'TSTypeAssertion':
+    case 'TSNonNullExpression':
+    case 'ParenthesizedExpression':
+      return unwrap(node.expression);
+    default:
+      return node ?? undefined;
+  }
+};
+
+/** Walk syntax without evaluating application code or following type metadata. */
+export const walk = (node: Node, visit: (child: Node) => void): void => {
+  visit(node);
+
+  for (const key of VISITOR_KEYS[node.type] ?? []) {
+    const value: unknown = Reflect.get(node, key);
+
+    for (const child of Array.isArray(value) ? value : [value]) {
+      if (child && typeof child === 'object' && 'type' in child) {
+        walk(child as Node, visit);
+      }
+    }
+  }
+};
+
+/** A single actionable error, including the original source location. */
+export const sourceError = (file: string, node: Node | undefined, construct: string): Error =>
+  new Error(
+    `${file}:${node?.loc?.start.line ?? 1}:${(node?.loc?.start.column ?? 0) + 1}: Unsupported ${construct} (${node?.type ?? 'undefined'}).`,
+  );
+
+/** Property names whose meaning is known without executing an expression. */
+export const propertyName = (node: ObjectExpression['properties'][number]): string | undefined => {
+  if (node.type === 'SpreadElement') {
+    return;
+  }
+
+  if (node.key.type === 'StringLiteral') {
+    return node.key.value;
+  }
+
+  return !node.computed && node.key.type === 'Identifier' ? node.key.name : undefined;
+};
+
+/** Static module bindings shared by migration and route analysis. */
+class SourceFiles {
+  private readonly files = new Map<string, ISourceFile>();
+
+  public constructor(private readonly aliases: Alias[] = []) {}
+
+  public read(file: string): ISourceFile {
+    const cached = this.files.get(file);
+
+    if (cached) {
+      return cached;
+    }
+
+    let code: string;
+
+    try {
+      code = fs.readFileSync(file, 'utf8');
+    } catch {
+      throw sourceError(file, undefined, 'missing source file');
+    }
+
+    try {
+      const result = {
+        code,
+        ast: parse(code, {
+          sourceType: 'module',
+          createImportExpressions: true,
+          plugins: ['typescript', 'jsx'],
+        }),
+      };
+
+      this.files.set(file, result);
+
+      return result;
+    } catch (error) {
+      // Babel includes the syntax location, but not the source filename.
+      throw new Error(`${file}: ${String((error as Error).message)}`);
+    }
+  }
+
+  public import(
+    file: string,
+    name: string,
+  ): { source: string; exported: string; declaration: ImportDeclaration } | undefined {
+    for (const node of this.read(file).ast.program.body) {
+      if (node.type !== 'ImportDeclaration' || node.importKind === 'type') {
+        continue;
+      }
+
+      const specifier = node.specifiers.find((item) => item.local.name === name);
+
+      if (specifier?.type === 'ImportDefaultSpecifier') {
+        return { source: node.source.value, exported: 'default', declaration: node };
+      }
+
+      if (specifier?.type === 'ImportSpecifier' && specifier.importKind !== 'type') {
+        return {
+          source: node.source.value,
+          exported:
+            specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value,
+          declaration: node,
+        };
+      }
+    }
+
+    return undefined;
+  }
+
+  public filename(specifier: string, importer: string, node?: Node): string {
+    let filename = specifier;
+
+    for (const { find, replacement } of this.aliases) {
+      if (
+        typeof find === 'string'
+          ? filename === find || filename.startsWith(`${find}/`)
+          : find.test(filename)
+      ) {
+        filename = filename.replace(find, replacement);
+        break;
+      }
+    }
+
+    if (!path.isAbsolute(filename)) {
+      if (!filename.startsWith('.')) {
+        throw sourceError(importer, node, `unresolvable import ${JSON.stringify(specifier)}`);
+      }
+
+      filename = path.resolve(path.dirname(importer), filename);
+    }
+
+    for (const suffix of [
+      '',
+      '.js',
+      '.ts',
+      '.tsx',
+      '.jsx',
+      '.mjs',
+      '.mts',
+      '.cjs',
+      '.cts',
+      '/index.js',
+      '/index.ts',
+      '/index.tsx',
+      '/index.jsx',
+    ]) {
+      const candidate = `${filename}${suffix}`;
+
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    }
+
+    throw sourceError(importer, node, `missing import ${JSON.stringify(specifier)}`);
+  }
+
+  public exported(file: string, name = 'default', seen = new Set<string>()): ISourceValue {
+    const key = `${file}#export:${name}`;
+
+    if (seen.has(key)) {
+      throw sourceError(file, undefined, `circular export ${name}`);
+    }
+
+    seen.add(key);
+
+    for (const node of this.read(file).ast.program.body) {
+      if (node.type === 'ExportDefaultDeclaration' && name === 'default') {
+        return this.resolve({ node: node.declaration, file }, seen);
+      }
+
+      if (node.type !== 'ExportNamedDeclaration') {
+        continue;
+      }
+
+      if (node.declaration?.type === 'VariableDeclaration') {
+        const declaration = node.declaration.declarations.find(
+          (item) => item.id.type === 'Identifier' && item.id.name === name,
+        );
+
+        if (declaration?.init) {
+          return this.resolve({ node: declaration.init, file }, seen);
+        }
+      }
+
+      for (const specifier of node.specifiers) {
+        const exported =
+          specifier.exported.type === 'Identifier'
+            ? specifier.exported.name
+            : specifier.exported.value;
+
+        if (exported === name && specifier.type === 'ExportSpecifier') {
+          return node.source
+            ? this.exported(
+                this.filename(node.source.value, file, node),
+                specifier.local.name,
+                seen,
+              )
+            : this.resolve({ node: specifier.local, file }, seen);
+        }
+      }
+    }
+
+    throw sourceError(file, undefined, `missing export ${JSON.stringify(name)}`);
+  }
+
+  public resolve(value: ISourceValue, seen = new Set<string>()): ISourceValue {
+    const { file } = value;
+    const node = unwrap(value.node)!;
+
+    if (node.type !== 'Identifier') {
+      return { node, file };
+    }
+
+    const key = `${file}#${node.name}`;
+
+    if (seen.has(key)) {
+      throw sourceError(file, node, `circular binding ${node.name}`);
+    }
+
+    seen.add(key);
+
+    const imported = this.import(file, node.name);
+
+    if (imported) {
+      return this.exported(this.filename(imported.source, file, node), imported.exported, seen);
+    }
+
+    for (const statement of this.read(file).ast.program.body) {
+      const declaration =
+        statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+
+      if (declaration?.type === 'VariableDeclaration') {
+        const binding = declaration.declarations.find(
+          (item) => item.id.type === 'Identifier' && item.id.name === node.name,
+        );
+
+        if (binding?.init) {
+          return this.resolve({ node: binding.init, file }, seen);
+        }
+      }
+
+      if (declaration?.type === 'FunctionDeclaration' && declaration.id?.name === node.name) {
+        return { node: declaration, file };
+      }
+    }
+
+    throw sourceError(file, node, `unresolved binding ${node.name}`);
+  }
+
+  public properties(value: ISourceValue, ancestors = new Set<Node>()): Map<string, ISourceValue> {
+    const { node, file } = this.resolve(value);
+
+    if (node.type !== 'ObjectExpression' || ancestors.has(node)) {
+      throw sourceError(file, node, 'route object / object spread; use a static object');
+    }
+
+    const next = new Set([...ancestors, node]);
+    const properties = new Map<string, ISourceValue>();
+
+    for (const property of node.properties) {
+      if (property.type === 'SpreadElement') {
+        for (const [name, entry] of this.properties({ node: property.argument, file }, next)) {
+          properties.set(name, entry);
+        }
+
+        continue;
+      }
+
+      const name = propertyName(property);
+
+      if (name === undefined) {
+        throw sourceError(file, property, 'computed route key; use a string literal');
+      }
+
+      properties.set(name, {
+        node: property.type === 'ObjectProperty' ? property.value : property,
+        file,
+      });
+    }
+
+    return properties;
+  }
+}
+
+export default SourceFiles;

--- a/src/services/ssr-manifest.ts
+++ b/src/services/ssr-manifest.ts
@@ -161,15 +161,16 @@ class SsrManifest extends RouteAssets {
   ): Record<string, string | undefined> {
     const result: Record<string, string | undefined> = {};
 
-    routes.forEach((route, routeIndex) => {
-      const routeId = [index, String(routeIndex)].filter(Boolean).join('-');
+    routes.forEach((route) => {
+      const position = [index, String(route.index)].filter(Boolean).join('-');
+      const routeId = route.id ?? position;
 
       if (route.import) {
         result[routeId] = this.pathNormalize.getAppPath(route.import);
       }
 
       if (route.children.length > 0) {
-        Object.assign(result, this.getRoutesTreeIds(route.children, routeId));
+        Object.assign(result, this.getRoutesTreeIds(route.children, position));
       }
     });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import MakeAliases from './src/plugins/make-aliases';
 
 export default defineConfig({
   test: {
-    include: ['__tests__/**/*'],
+    include: ['__tests__/**/*.{ts,tsx,js}'],
     setupFiles: ['__helpers__/setup.ts'],
     coverage: {
       include: ['src/**/*'],


### PR DESCRIPTION
## Goal

Promote `staging` to `prod`: streamed loader data, `ssr-boost init` and `doctor`, and the support/discovery documentation.

## Changes since 8.2.0

- feat: loader and action promises are streamed to the browser so `<Await>` and React 19 `use()` hydrate in Data mode; optional `hydration: 'early'`; `SSR_BOOST_STREAM_PROMISE_ABORTED`; Playwright job in CI.
- feat: `ssr-boost init` (dry-run/apply migration of an existing Vite + React Router app) and `ssr-boost doctor` (checks, JSON, support bundle); the route parser accepts aliased entry imports, spreads, explicit ids and imported children.
- docs/ci: support policy (`SUPPORT.md`, docs page), "Upgrade from 7 to 8", `llms.txt`/`llms-full.txt`, Context7 scope and refresh workflow, stale bot limited to `needs-reproduction`, npm provenance, migrate-first home page, npm keywords.

## Verification

Each change went through its own pull request with the full CI (React 18/19 × Router 7/8 × Vite 6/7/8, packed edge, no-optional core, Bun, Chromium hydration test, template acceptance, docs build) and the reviewer's local gates; the beta was published from `staging`.
