### PR TITLE
ci: redeploy the docs after a release so llms.txt reports the released version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,11 @@ on:
       - 'package.json'
       - 'package-lock.json'
   workflow_dispatch:
+  # Redeploy after a release so the generated llms.txt reports the released version (the tag exists only after semantic-release).
+  workflow_run:
+    workflows: [ Release ]
+    branches: [ prod ]
+    types: [ completed ]
 
 permissions:
   contents: read
@@ -26,6 +31,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The docs deploy currently runs on the same push that triggers the release, before semantic-release creates the tag, so the generated llms.txt reported 8.2.0 after the 8.3.0 release. This adds a workflow_run trigger on the Release workflow (prod, successful runs only) so the docs are rebuilt once the tag exists; docs-only pushes keep deploying immediately.