### PR TITLE
ci: pin acceptance to the current template, verify the deferred route and warn about req/res

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -91,15 +91,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: 71d859cb1a6faae030fa0a561681a7de4aead810
+          ref: d15557c1d03a16a97521d38432a22cd8fe2b95c3
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies
         working-directory: acceptance/vite-template
         run: npm ci --ignore-scripts
 
+      - name: Install Chromium for the template browser checks
+        run: npx playwright install --with-deps chromium
+
       - name: Test template in development and production
         run: node scripts/test-template.mjs acceptance/vite-template
+        env:
+          SSR_BOOST_TEMPLATE_BROWSER: '1'
 
       - name: Test template with current runtime dependencies
         run: node scripts/test-template.mjs acceptance/vite-template

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,15 +93,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: acceptance/vite-template
-          ref: 71d859cb1a6faae030fa0a561681a7de4aead810
+          ref: d15557c1d03a16a97521d38432a22cd8fe2b95c3
           repository: Lomray-Software/vite-template
 
       - name: Install template dependencies
         working-directory: acceptance/vite-template
         run: npm ci --ignore-scripts
 
+      - name: Install Chromium for the template browser checks
+        run: npx playwright install --with-deps chromium
+
       - name: Test template in development and production
         run: node scripts/test-template.mjs acceptance/vite-template
+        env:
+          SSR_BOOST_TEMPLATE_BROWSER: '1'
 
       - name: Test template with current runtime dependencies
         run: node scripts/test-template.mjs acceptance/vite-template

--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import type { PropsWithChildren } from 'react';
 import { createStaticHandler } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import StreamError from '@constants/stream-error';
 import render from '@adapters/express/render';
 import type { IRenderOptions, IRequestContext } from '@adapters/express/render';
@@ -48,6 +48,9 @@ describe('legacy Express render adapter', () => {
       off: vi.fn(),
       once: vi.fn(),
       redirect: vi.fn(),
+      removeHeader: vi.fn((name: string) => {
+        delete responseHeaders[name.toLowerCase()];
+      }),
       setHeader: vi.fn((name: string, value: string | string[]) => {
         responseHeaders[name.toLowerCase()] = value;
 
@@ -93,9 +96,111 @@ describe('legacy Express render adapter', () => {
     return { config, context, logger, res };
   };
 
+  beforeEach(() => {
+    const key = Symbol.for('@lomray/vite-ssr-boost/diagnostics');
+    (globalThis as Record<symbol, Set<string>>)[key]?.clear();
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it.each(['req', 'res'] as const)(
+    'emits SSR_BOOST_DEPRECATED_REQ_RES once per process when a hook reads context.%s',
+    async (field) => {
+      const warnings: unknown[] = [];
+      for (const route of ['/first', '/second']) {
+        const { config, context, logger } = createContext();
+        const original = context[field];
+        context.req.originalUrl = route;
+        coreRenderMock.mockImplementation(async (_, updated, options) => {
+          expect(logger.warn).not.toHaveBeenCalled();
+          await options.onRouterReady({ context: updated });
+          options.getState({ context: updated });
+          return new Response('rendered');
+        });
+        await render({ App, handler: {} as never }, config as never, context as never, {
+          onRouterReady: ({ context: hookContext }) => {
+            expect(hookContext[field]).toBe(original);
+            expect(Object.keys(hookContext)).toContain(field);
+            return {};
+          },
+          getState: ({ context: hookContext }) => {
+            expect(hookContext.req).toBe(context.req);
+            expect(hookContext.res).toBe(context.res);
+            return {};
+          },
+        });
+        warnings.push(...logger.warn.mock.calls.map(([message]) => message));
+      }
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('SSR_BOOST_DEPRECATED_REQ_RES');
+      expect(warnings[0]).toContain('context.request, context.response.headers/context.response.status');
+      expect(warnings[0]).toContain('9.0');
+      expect(warnings[0]).toContain('diagnostics#ssr_boost_deprecated_req_res');
+    },
+  );
+
+  it.each([
+    [true, '1'],
+    [false, '0'],
+  ] as const)('keeps plain req/res properties with isProd=%s and diagnostics=%s', async (isProd, override) => {
+    vi.stubEnv('SSR_BOOST_DIAGNOSTICS', override);
+    const { config, context, logger } = createContext();
+    config.isProd = isProd;
+    coreRenderMock.mockImplementation(async (_, updated, options) => {
+      await options.onRouterReady({ context: updated });
+      return new Response('rendered');
+    });
+    await render({ App, handler: {} as never }, config as never, context as never, {
+      onRouterReady: ({ context: hookContext }) => {
+        for (const name of ['req', 'res'] as const) {
+          expect(Object.getOwnPropertyDescriptor(hookContext, name)).toEqual({
+            configurable: true,
+            enumerable: true,
+            value: context[name],
+            writable: true,
+          });
+        }
+        return {};
+      },
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('supports Fetch request and response metadata without a deprecation warning', async () => {
+    const { config, context, logger, res } = createContext();
+    const { default: coreRender } =
+      await vi.importActual<typeof import('@core/render')>('@core/render');
+    const handler = createStaticHandler([{ path: '*', Component: () => 'BODY' }]);
+    coreRenderMock.mockImplementationOnce(coreRender);
+    writeFetchResponseMock.mockImplementationOnce(async (_, response: Response) => {
+      expect(response.status).toBe(202);
+      expect(response.headers.get('x-modern')).toBe('shell');
+      expect(response.headers.has('x-remove')).toBe(false);
+      expect(res.getHeaders()['set-cookie']).toEqual(['one=1; Path=/', 'two=2; Path=/']);
+      await response.text();
+    });
+    await render({ App, handler }, config as never, context as never, {
+      onRouterReady: ({ context: hookContext }) => {
+        expect(hookContext.request.headers.get('user-agent')).toBe('Googlebot');
+        hookContext.response.status = 201;
+        hookContext.response.headers.set('x-modern', 'router');
+        hookContext.response.headers.set('x-remove', 'router');
+        return {};
+      },
+      onShellReady: ({ context: hookContext }) => {
+        hookContext.response.status = 202;
+        hookContext.response.headers.set('x-modern', 'shell');
+        hookContext.response.headers.delete('x-remove');
+        hookContext.response.headers.append('set-cookie', 'one=1; Path=/');
+        hookContext.response.headers.append('set-cookie', 'two=2; Path=/');
+        return {};
+      },
+    });
+    expect(writeFetchResponseMock).toHaveBeenCalledOnce();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/browser-tests/template.spec.mjs
+++ b/browser-tests/template.spec.mjs
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test('pinned template deferred shell hydrates and both user lists settle without errors', async ({ page }) => {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  // Observe the actual init/resolve frames, even when hydration consumes them.
+  await page.addInitScript(() => {
+    const frames = [];
+    const queue = [];
+    const seen = new WeakSet();
+    let push = queue.push.bind(queue);
+    Object.defineProperty(queue, 'push', {
+      get: () => (...entries) => {
+        for (const frame of entries) {
+          if (!seen.has(frame)) frames.push(frame);
+          seen.add(frame);
+        }
+        return push(...entries);
+      },
+      // The stream receiver replaces push and replays the original queue.
+      set: (receive) => { push = receive; },
+    });
+    window.__ssrBoostStream = queue;
+    window.acceptanceFrames = frames;
+  });
+  await page.goto('./deferred', { waitUntil: 'commit' });
+  await expect(page).toHaveTitle('Deferred data');
+  await expect(page.getByText('Loading users with Await…', { exact: true })).toBeVisible();
+  await expect(page.getByText('Loading users with use()…', { exact: true })).toBeVisible();
+  const counter = page.getByRole('button', { name: 'Count: 0', exact: true });
+  // The shell is interactive once React has hydrated the button: clicks made before the
+  // client modules load are dropped, which happens in development where Vite serves them unbundled.
+  await counter.waitFor();
+  await page.waitForFunction(
+    (button) => Object.keys(button).some((key) => key.startsWith('__reactProps')),
+    await counter.elementHandle(),
+    { timeout: 20_000 },
+  );
+  await counter.click();
+  await expect(page.getByRole('button', { name: 'Count: 1', exact: true })).toBeVisible();
+  for (const section of ['Users with Await', 'Users with React use()']) {
+    const region = page.getByRole('region', { name: section, exact: true });
+    await expect(region.getByRole('listitem')).toHaveText([
+      'Ada Lovelace', 'Grace Hopper', 'Margaret Hamilton',
+    ]);
+    await expect(region.getByRole('list')).toHaveCount(1);
+  }
+  await expect(page.getByText(/^Loading users with/)).toHaveCount(0);
+  const frames = await page.evaluate(() => window.acceptanceFrames);
+  expect(frames[0][0]).toBe('init');
+  expect(frames[0][1]).toContain('SSRBPromise');
+  expect(frames.filter(([type]) => type === 'resolve')).toHaveLength(1);
+  await page.getByRole('button', { name: 'Count: 1', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Count: 2', exact: true })).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -69,7 +69,8 @@ See [Server Lifecycle](/guide/server-lifecycle) for the flow and intent of each 
 receive `{ context }`, with these fields:
 
 - `request`: the Fetch `Request` built from the Express request; use it for headers, URL and method so hooks stay portable to other adapters.
-- `req` / `res`: the live Express request and response.
+- `response`: mutable Fetch `headers` and optional `status`; update these before the shell is sent.
+- `req` / `res`: the live Express request and response, [deprecated in 8.x](/guide/upgrade-v8#deprecated-in-8-x) with removal planned for 9.0.
 - `appProps`: request-scoped props returned by `onRequest`.
 - `html`: the template `header` and `footer`.
 - `routerContext` / `serverContext`: router and SSR metadata, once available.

--- a/docs/guide/upgrade-v8.md
+++ b/docs/guide/upgrade-v8.md
@@ -74,7 +74,19 @@ See the [server entry API](/api/server-entry#onresponse) for the full signature.
 
 The Express adapter's render-hook context now includes `request`, the Fetch `Request` used by React Router and the core. Use its `url`, `headers` and `signal` for Fetch-based request handling and cancellation. When constructing typed render-hook contexts in application code or fixtures, include this field.
 
-Managed Express request/render hooks retain the live Express `req` and `res`; keep Express-specific cookies, middleware and response takeover on those objects. `context.request` is available in render hooks, after the adapter converts the request; it is not an Express request and is not added to the earlier managed `onRequest` parameters. Fetch-core hooks use Web-standard requests and responses and do not emulate Express objects.
+`context.request` is available in render hooks, after the adapter converts the request; it is not an Express request and is not added to the earlier managed `onRequest(req, res)` parameters. Fetch-core hooks use Web-standard requests and responses and do not emulate Express objects.
+
+## Deprecated in 8.x
+
+Managed Express `context.req` and `context.res` remain available in 8.x, with removal planned for
+**9.0** after the [support policy](/reference/support) notice periods. Reading either field in
+development emits [`SSR_BOOST_DEPRECATED_REQ_RES`](/reference/diagnostics#ssr_boost_deprecated_req_res)
+once per process. Production has no accessors or warning overhead.
+
+Use `context.request` for request data, `context.response.headers` and `context.response.status`
+for response metadata before shell readiness, and React Router HTTP helpers such as `redirect()`
+in loaders/actions. Keep Express-specific middleware or response takeover in middleware or the
+earlier `onRequest(req, res)` hook; its arguments are unaffected.
 
 ## Check the upgraded application
 

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -14,13 +14,23 @@ Run these before a release. The same checks run in PR and release CI.
 | `npm run test:template` | Template SSR in dev/production, cold styles, SSR module reload, streamed and crawler HTML, gzip, static JS/CSS, redirects, HEAD, 404, subpath deployment, standalone SPA, client gzip budget and baseline TTFB comparison |
 | `npm run docs:build` | Documentation build and links |
 
-CI pins `vite-template` to `71d859cb1a6faae030fa0a561681a7de4aead810`. Locally, install its dependencies
+CI pins `vite-template` to `d15557c1d03a16a97521d38432a22cd8fe2b95c3`. Locally, install its dependencies
 in `../vite-template`, or pass its path to `node scripts/test-template.mjs`. The script works on a
-copy; it changes only that copy's configuration for the subpath test.
+copy; route typing, HMR edits and subpath configuration changes stay in that copy.
+
+In development, production and production under a basename, `/deferred` must send its title and
+promise placeholder in the first HTML chunk's `__ssrBoostStream` init frame, then a resolve frame
+and the three rendered users in later chunks. A separate Googlebot request must contain the
+resolved lists with zero pending Suspense markers (`<!--$?-->`). The summary records the delay
+from first HTML to the resolve frame; the template's loader waits 1.5 seconds.
 
 Before shipping, also check the template in a browser: hydration and console errors, client navigation,
 Suspense, crawler mode, HMR and SPA deep links. HTTP acceptance checks do not replace browser checks.
 Use `SSR_BOOST_KEEP_TEMPLATE=1 npm run test:template` to retain the test copy for inspection.
+With Chromium installed (`npx playwright install chromium`), run
+`SSR_BOOST_TEMPLATE_BROWSER=1 npm run test:template` to also test the pinned template's deferred
+page in Chromium in all three SSR modes. This checks shell interactivity, both Await/use() lists,
+init/resolve frames and hydration/console errors. Browser failures fail this opt-in gate.
 
 PR and release CI run the full suite on React/React DOM 18.2.0 and 19.2.8. The release waits for
 both versions. Template TTFB comparisons are advisory; early-stream checks retry up to three times
@@ -60,7 +70,7 @@ All sizes below use gzip level 9 and **KB = 1024 bytes**. Comparisons use unroun
 | `helpers/import-route` | 1.937 | 2.50 |
 | `interfaces/fc-route` | 0.091 | 0.25 |
 | Combined | 3.307 (3386 bytes) | 4.307 (4410 bytes) |
-| Template client total | 146.563 | 154 |
+| Template client total | 141.770 | 154 |
 
 The template gate sums the gzip size of each `build/client/assets/*.js` file after the candidate's
 production SSR build, including lazy chunks and framework/application dependencies. It excludes
@@ -71,7 +81,7 @@ use the same 154 KB limit.
 The browser table is printed and appended to `GITHUB_STEP_SUMMARY` when set. Template acceptance
 also prints and appends its client size/budget, production server readiness (process start through
 the first successful HTTP response, including readiness polling), baseline/candidate median TTFB,
-and development/production/subpath chunk counts. Decoded gzip chunks count HTML payload rather
+and development/production/subpath chunk counts and deferred settle delays. Decoded gzip chunks count HTML payload rather
 than gzip headers. Available measurements are reported even if a later acceptance check fails;
 unreached timings are marked `not measured`. Readiness and TTFB remain advisory.
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -18,6 +18,23 @@ the response finishes, without delaying streamed chunks. When disabled, they nei
 accumulate HTML. Completed-output checks skip cancelled or failed streams, redirects, and bodyless
 responses; invalid file-backed shells always throw, even with diagnostics disabled.
 
+## SSR_BOOST_DEPRECATED_REQ_RES {#ssr_boost_deprecated_req_res}
+
+A managed Express hook or loader reads `context.req` or `context.res`. These fields still return
+the live Express objects, but are deprecated in 8.x with removal planned for **9.0**, subject to
+the [support policy](/reference/support) notice periods. One warning covers both fields across
+all requests, hooks and development module reloads in the process. Merely creating the context
+or reading `context.request` does not warn.
+
+Use `context.request` for the Fetch request's URL, headers, method and signal. Before the shell
+is sent, set `context.response.headers` and `context.response.status` for response metadata;
+use React Router's HTTP helpers such as `redirect()` in loaders/actions. The earlier managed
+`onRequest(req, res)` arguments and Express middleware are not deprecated by this diagnostic.
+
+Accessors are installed only in managed development with diagnostics enabled, using `loggerDev`.
+`SSR_BOOST_DIAGNOSTICS=0` disables them. Production keeps plain properties with no accessor or
+warning overhead, even when other diagnostics are enabled with `SSR_BOOST_DIAGNOSTICS=1`.
+
 ## SSR_BOOST_LOADER_NOT_SERIALIZABLE {#ssr_boost_loader_not_serializable}
 
 ### When it appears

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './browser-tests',
+  testIgnore: 'template.spec.mjs',
   workers: 1,
   timeout: 30_000,
   reporter: 'list',

--- a/playwright.template.config.mjs
+++ b/playwright.template.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './browser-tests',
+  testMatch: 'template.spec.mjs',
+  workers: 1,
+  timeout: 30_000,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.TEMPLATE_BROWSER_ORIGIN,
+    // Exercise the template's human streaming mode, without HeadlessChrome bot detection.
+    userAgent: 'Mozilla/5.0',
+  },
+});

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -13,6 +13,7 @@ import { parse } from '@babel/parser';
 // KB = 1024 bytes. For intentional growth, measure the pinned template again and
 // set this to Math.ceil(measured gzip KB * 1.05); document the reason and new size.
 const TEMPLATE_CLIENT_GZIP_BUDGET_KB = 154;
+const TEMPLATE_HOME_MARKER = 'SPA, SSR, Mobx, Consistent Suspense, Meta tags';
 
 const projectRoot = process.cwd();
 const source = resolve(process.argv[2] ?? join(projectRoot, '..', 'vite-template'));
@@ -25,6 +26,7 @@ const acceptance = {
   baselineTtfb: undefined,
   candidateTtfb: undefined,
   chunks: [],
+  deferred: [],
 };
 const cli = join(directory, 'node_modules', '@lomray', 'vite-ssr-boost', 'cli.js');
 const runtimePath = [
@@ -128,6 +130,7 @@ const inspectStream = (origin, pathname, headers = {}) =>
     const started = performance.now();
     const request = http.get(new URL(pathname, origin), { headers }, (response) => {
       const chunks = [];
+      const chunkTimes = [];
       let firstChunkMs;
       // Count HTML bytes, not the empty gzip header that can hide buffering regressions.
       const decoded =
@@ -136,10 +139,13 @@ const inspectStream = (origin, pathname, headers = {}) =>
       decoded.on('data', (chunk) => {
         firstChunkMs ??= performance.now() - started;
         chunks.push(chunk);
+        chunkTimes.push(performance.now() - started);
       });
       decoded.on('end', () => {
         resolveStream({
           chunks: chunks.length,
+          chunkHtml: chunks.map((chunk) => chunk.toString('utf8')),
+          chunkTimes,
           firstChunkMs,
           html: Buffer.concat(chunks).toString('utf8'),
           status: response.statusCode,
@@ -254,6 +260,52 @@ const verify = async (origin, mode, base = '') => {
     )}ms/${Math.round(streamed.totalMs)}ms); buffered=${buffered.chunks} chunks`,
   );
   acceptance.chunks.push({ mode, streamed: streamed.chunks, buffered: buffered.chunks, gzip: gzipChunks });
+  await verifyDeferred(origin, mode, base);
+  if (process.env.SSR_BOOST_TEMPLATE_BROWSER === '1') {
+    execFileSync(process.execPath, [
+      join(projectRoot, 'node_modules', '@playwright', 'test', 'cli.js'),
+      'test', '--config', 'playwright.template.config.mjs',
+    ], {
+      cwd: projectRoot,
+      env: { ...process.env, TEMPLATE_BROWSER_ORIGIN: `${origin}${base}/` },
+      stdio: 'inherit',
+    });
+  }
+};
+
+const verifyDeferred = async (origin, mode, base) => {
+  const browser = await inspectEarlyStream(origin, `${base}/deferred`, `${mode} deferred`, {
+    'User-Agent': 'Mozilla/5.0',
+  });
+  const first = browser.chunkHtml[0];
+  const later = browser.chunkHtml.slice(1).join('');
+  const init = /window\.__ssrBoostStream[^<]*\.push\(\["init",/;
+  const resolveFrame = /window\.__ssrBoostStream[^<]*\.push\(\["resolve",/;
+  const users = ['Ada Lovelace', 'Grace Hopper', 'Margaret Hamilton'];
+
+  assert.match(first, /<title>Deferred data<\/title>/, `${mode} deferred first-chunk title`);
+  assert.match(first, init, `${mode} deferred first-chunk init frame`);
+  assert.match(first, /SSRBPromise/, `${mode} deferred first-chunk promise placeholder`);
+  assert.doesNotMatch(first, resolveFrame, `${mode} deferred resolved before the shell`);
+  assert.match(later, resolveFrame, `${mode} deferred later resolve frame`);
+  for (const user of users) {
+    assert.ok(!first.includes(user), `${mode} deferred ${user} arrived in the first chunk`);
+    assert.ok(later.includes(`<li>${user}</li>`), `${mode} deferred missing rendered ${user}`);
+  }
+  const resolveIndex = browser.chunkHtml.findIndex((chunk) => resolveFrame.test(chunk));
+  assert.ok(resolveIndex > 0, `${mode} deferred resolve frame must arrive in a later chunk`);
+  const settleMs = browser.chunkTimes[resolveIndex] - browser.firstChunkMs;
+  assert.ok(settleMs > 100, `${mode} deferred resolve frame was buffered with the shell`);
+
+  const bot = await inspectStream(origin, `${base}/deferred`, { 'User-Agent': 'Googlebot' });
+  assert.equal(bot.status, 200, `${mode} deferred Googlebot status`);
+  assert.match(bot.html, /<title>Deferred data<\/title>/);
+  assert.doesNotMatch(bot.html, /<!--\$\?-->/, `${mode} deferred Googlebot pending boundaries`);
+  for (const user of users) {
+    assert.ok(bot.html.includes(`<li>${user}</li>`), `${mode} deferred Googlebot missing ${user}`);
+  }
+  acceptance.deferred.push({ mode, settleMs });
+  console.info(`${mode}: deferred title + init first; resolve + 3 users later; settle ${Math.round(settleMs)}ms; Googlebot resolved, 0 pending boundaries`);
 };
 
 const measureClientGzip = async () => {
@@ -282,6 +334,8 @@ const reportAcceptance = async () => {
     `| Candidate median TTFB | ${milliseconds(acceptance.candidateTtfb)} | advisory |`,
     ...acceptance.chunks.map(({ mode, streamed, buffered, gzip }) =>
       `| ${mode} chunks (streamed / buffered / decoded gzip) | ${streamed} / ${buffered} / ${gzip ?? 'n/a'} | — |`),
+    ...acceptance.deferred.map(({ mode, settleMs }) =>
+      `| ${mode} deferred settle delay (first HTML to resolve frame) | ${milliseconds(settleMs)} | > 100 ms |`),
     '',
   ].join('\n');
   console.info(markdown);
@@ -409,7 +463,8 @@ const verifySpa = async (origin) => {
     const html = await response.text();
     assert.equal(response.status, 200, `SPA ${pathname}`);
     assert.match(html, /id="root"/);
-    assert.doesNotMatch(html, /window\.__staticRouterHydrationData|Welcome to demo app/);
+    assert.doesNotMatch(html, /window\.__staticRouterHydrationData/);
+    assert.ok(!html.includes(TEMPLATE_HOME_MARKER), `SPA ${pathname} contains server-rendered content`);
     const entry = html.match(/<script[^>]+src="([^"]+)"/);
     assert.ok(entry, `SPA ${pathname} has no client entry`);
     const script = await fetch(new URL(entry[1], origin));
@@ -463,8 +518,8 @@ const configureBasename = async () => {
   await edit('vite.config.ts', "root: 'src',", "root: 'src', base: '/acceptance/',");
   await edit(
     'src/client.ts',
-    'init: async () => {',
-    "routerOptions: { basename: '/acceptance' }, init: async () => {",
+    'init: async ({ isSSRMode }) => {',
+    "routerOptions: { basename: '/acceptance' }, init: async ({ isSSRMode }) => {",
   );
   await edit(
     'src/server.ts',
@@ -491,7 +546,7 @@ const configureTypedRoutes = async () => {
 const verifyHmr = async (origin) => {
   const filename = join(directory, 'src', 'pages', 'home', 'index.tsx');
   const original = await readFile(filename, 'utf8');
-  const current = 'SPA, SSR, Mobx, Consistent Suspense, Meta tags';
+  const current = TEMPLATE_HOME_MARKER;
   const marker = 'SSR dev reload accepted';
 
   assert.ok(original.includes(current), 'Template HMR marker source changed.');

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -20,9 +20,12 @@ import type ServerConfig from '@services/server-config';
 import SsrManifest from '@services/ssr-manifest';
 
 export interface IRequestContext<TAppProps = Record<any, any>> {
+  /** @deprecated Use request; planned for removal in 9.0. */
   req: ExpressRequest;
+  /** @deprecated Use response.headers/status; planned for removal in 9.0. */
   res: ExpressResponse;
   request: Request;
+  response: ISsrRequestContext['response'];
   appProps: NonNullable<TAppProps>;
   html: { header: string; footer: string };
   routerContext?: StaticHandlerContext;
@@ -34,7 +37,7 @@ export interface IRequestContext<TAppProps = Record<any, any>> {
 
 export type TRender<TAppProps = Record<any, any>> = (
   config: ServerConfig,
-  context: Omit<IRequestContext<TAppProps>, 'request'>,
+  context: Omit<IRequestContext<TAppProps>, 'request' | 'response'>,
   options: IRenderOptions,
 ) => Promise<void>;
 
@@ -115,7 +118,38 @@ const prepareResponse = (context: ISsrRequestContext, res: ExpressResponse): voi
 /**
  * Copy legacy hook metadata back to the core; cookies remain on the live response.
  */
-const syncResponse = (context: ISsrRequestContext, res: ExpressResponse): void => {
+const syncResponse = (
+  context: ISsrRequestContext,
+  res: ExpressResponse,
+  previous: ISsrRequestContext['response'],
+): void => {
+  // Apply Fetch metadata edits before reading legacy metadata back. Unchanged
+  // Fetch values must not overwrite edits made through the live Express response.
+  if (!res.headersSent && !res.writableEnded) {
+    if (context.response.status !== previous.status) {
+      res.status(context.response.status ?? 200);
+    }
+
+    const names = new Set([...previous.headers.keys(), ...context.response.headers.keys()]);
+
+    for (const name of names) {
+      if (context.response.headers.get(name) === previous.headers.get(name)) {
+        continue;
+      }
+
+      if (!context.response.headers.has(name)) {
+        res.removeHeader(name);
+      } else {
+        res.setHeader(
+          name,
+          name === 'set-cookie'
+            ? getSetCookieHeaders(context.response.headers)
+            : context.response.headers.get(name)!,
+        );
+      }
+    }
+  }
+
   const headers = new Headers(context.response.headers);
 
   headers.delete('Set-Cookie');
@@ -168,7 +202,7 @@ const writeResponse = async (res: ExpressResponse, response: Response): Promise<
 async function render(
   { App, handler }: IRenderParams,
   config: ServerConfig,
-  initialContext: Omit<IRequestContext, 'request'>,
+  initialContext: Omit<IRequestContext, 'request' | 'response'>,
   {
     onRouterReady,
     onShellReady,
@@ -189,6 +223,7 @@ async function render(
   try {
     const context: IRequestContext = Object.assign(initialContext, {
       request: createRenderRequest(req, requestSignal.signal, getBody),
+      response: { headers: new Headers() },
     });
     const coreContext: ISsrRequestContext = {
       appProps,
@@ -197,16 +232,38 @@ async function render(
         : undefined,
       html: shellHtml,
       request: context.request,
-      response: {
-        headers: new Headers(),
-      },
+      response: context.response,
     };
+
+    // Keep plain data properties in production, even with diagnostics forced on.
+    // Adapter internals retain req/res locals so only consumer reads warn.
+    if (!config.isProd && coreContext.diagnostics) {
+      const { diagnostics } = coreContext;
+
+      for (const name of ['req', 'res'] as const) {
+        let value = context[name];
+
+        Object.defineProperty(context, name, {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            diagnostics.deprecatedReqRes();
+
+            return value;
+          },
+          set: (next: typeof value) => {
+            value = next;
+          },
+        });
+      }
+    }
 
     /**
      * Keep legacy hooks attached to their original mutable request context.
      */
     const syncContext = (updated: ISsrRequestContext): IRequestContext => {
       context.request = updated.request;
+      context.response = updated.response;
       context.didError = updated.didError;
       context.html = updated.html;
       context.isStream = updated.isStream;
@@ -296,9 +353,14 @@ async function render(
 
           prepareResponse(updated, res);
 
+          const previous = {
+            headers: new Headers(updated.response.headers),
+            status: updated.response.status,
+          };
+
           const shell = onShellReady?.({ context: legacyContext });
 
-          syncResponse(updated, res);
+          syncResponse(updated, res, previous);
 
           return shell ?? {};
         },

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -2,6 +2,7 @@ import type { StaticHandlerContext } from 'react-router';
 import Logger from '@services/logger';
 
 type TDiagnosticCode =
+  | 'SSR_BOOST_DEPRECATED_REQ_RES'
   | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
   | 'SSR_BOOST_STREAM_PROMISE_ABORTED'
   | 'SSR_BOOST_STATE_NOT_SERIALIZABLE'
@@ -184,6 +185,14 @@ class Diagnostics {
       warned.add(message);
       this.logger.warn(message, {});
     }
+  }
+
+  /** Warn once for either legacy Express field, regardless of route or hook. */
+  public deprecatedReqRes(): void {
+    this.warn(
+      'SSR_BOOST_DEPRECATED_REQ_RES',
+      'context.req and context.res are deprecated in 8.x and planned for removal in 9.0; use context.request, context.response.headers/context.response.status and React Router HTTP helpers such as redirect().',
+    );
   }
 
   /**


### PR DESCRIPTION
Acceptance now pins `vite-template` `prod` at `d15557c` (the 8.3.0 template with `hydration: 'early'` and the streamed `/deferred` route) in both CI workflows and the reference docs, and checks that route in development, production and under a basename: the title and the promise `init` frame arrive in the first HTML chunk, the `resolve` frame and the three users follow later (the settle delay is reported in the step summary), and a Googlebot request gets the resolved lists with zero pending Suspense markers. The pinned template is also loaded in headless Chromium in all three modes (`SSR_BOOST_TEMPLATE_BROWSER=1`, on in CI): the shell counter responds after hydration, both `Await`/`use()` lists settle, exactly one `resolve` frame is observed and there are no page or console errors.

Reading `context.req` or `context.res` in a managed Express hook now emits `SSR_BOOST_DEPRECATED_REQ_RES` once per process in development (accessors exist only there; production keeps plain properties). The context gains `response` (Fetch headers and status) as the replacement; edits made through it before the shell is sent are applied to the live Express response. The upgrade guide and diagnostics reference document the deprecation and the planned removal in 9.0.

Verified locally: lint, types, 687 unit tests, build, size budgets, `test:core:no-optional`, docs build, and the full template acceptance with the Chromium checks (development, production, basename), with zero diagnostics emitted by the pinned template.
