### PR TITLE
feat: add document header and cache policy helpers

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Typescript check
         run: npm run ts:check
 
+      - name: Install Nginx for the caching recipe test
+        run: sudo apt-get install -y --no-install-recommends nginx
+
       - name: Test
         run: npm run test -- --coverage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Run eslint
         run: npm run lint:check
 
+      - name: Install Nginx for the caching recipe test
+        run: sudo apt-get install -y --no-install-recommends nginx
+
       - name: Test
         run: npm run test -- --coverage
 

--- a/__fixtures__/browser-template/server.jsx
+++ b/__fixtures__/browser-template/server.jsx
@@ -1,6 +1,7 @@
 import { createStaticHandler } from 'react-router';
 import createHandler from '@lomray/vite-ssr-boost/core/handler';
 import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import { cacheControl } from '@lomray/vite-ssr-boost/http';
 import { App, routes } from './routes.jsx';
 import React from 'react';
 export const handler = (html) =>
@@ -15,5 +16,7 @@ export const handler = (html) =>
       diagnostics: false,
       getHtml: () => html,
       getState: () => ({ custom: { ready: true } }),
+      sessionCookie: 'session',
+      documentHeaders: [{ when: () => true, set: { 'Cache-Control': cacheControl({ public: true, maxAge: 0, sMaxAge: 30 }) } }],
     },
   );

--- a/__fixtures__/caching/app.tsx
+++ b/__fixtures__/caching/app.tsx
@@ -1,0 +1,53 @@
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import type { TRenderToStream } from '@lomray/vite-ssr-boost/core/render';
+import { copyLoaderHeaders } from '@lomray/vite-ssr-boost/http';
+import React from 'react';
+import { createStaticHandler, useLoaderData } from 'react-router';
+import { rules, sessionCookie } from './policy';
+
+const Page = () => <main>{useLoaderData<{ message: string }>().message}</main>;
+
+/** A complete server-rendered example; wire real authentication into the loader. */
+export const createPageHandler = (renderToStream: TRenderToStream) =>
+  createHandler(
+    {
+      createApp: (children) => children,
+      handler: createStaticHandler([
+        {
+          path: '*',
+          Component: Page,
+          loader: ({ request }) => {
+            const authenticated =
+              request.headers.has('Authorization') ||
+              /(?:^|;)\s*session\s*=/.test(request.headers.get('Cookie') ?? '');
+
+            return Response.json({ message: authenticated ? 'Account page' : 'Guest page' });
+          },
+        },
+      ]),
+      renderToStream,
+    },
+    {
+      getHtml: () => ({
+        header: '<!doctype html><html><body><div id="root">',
+        footer: '</div></body></html>',
+      }),
+      sessionCookie,
+      documentHeaders: rules,
+      onRouterReady: ({ context }) => {
+        const copied = copyLoaderHeaders(context.routerContext!, {
+          allow: ['Cache-Control', 'Set-Cookie'],
+        });
+
+        // Preserve existing hook metadata and independent cookies.
+        copied.forEach((value, name) => {
+          if (name !== 'set-cookie') context.response.headers.set(name, value);
+        });
+        copied
+          .getSetCookie()
+          .forEach((cookie) => context.response.headers.append('Set-Cookie', cookie));
+
+        return {};
+      },
+    },
+  );

--- a/__fixtures__/caching/buffered.ts
+++ b/__fixtures__/caching/buffered.ts
@@ -1,0 +1,26 @@
+import { cacheControl, conditionalRequest } from '@lomray/vite-ssr-boost/http';
+
+/** A public, existing representation whose version includes every output dependency. */
+export const bufferedPage = (request: Request): Response => {
+  const html = '<!doctype html><main>Published article revision 7</main>';
+  const validators = {
+    etag: 'W/"article-7-template-2"',
+    lastModified: 'Tue, 01 Sep 2026 12:00:00 GMT',
+  };
+  const headers = new Headers({
+    'Cache-Control': cacheControl({ public: true, maxAge: 30 }),
+    'Content-Type': 'text/html',
+    ETag: validators.etag,
+    'Last-Modified': validators.lastModified,
+  });
+  const unchanged = conditionalRequest(request, validators);
+
+  if (unchanged) {
+    // A 304 must retain the cache policy and any Vary/Content-Location of the 200.
+    unchanged.headers.set('Cache-Control', headers.get('Cache-Control')!);
+
+    return unchanged;
+  }
+
+  return new Response(request.method === 'HEAD' ? null : html, { headers });
+};

--- a/__fixtures__/caching/express-start.ts
+++ b/__fixtures__/caching/express-start.ts
@@ -1,0 +1,3 @@
+import { start } from './express';
+
+start();

--- a/__fixtures__/caching/express.ts
+++ b/__fixtures__/caching/express.ts
@@ -1,0 +1,12 @@
+import adapterExpress from '@lomray/vite-ssr-boost/adapters/express';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import express from 'express';
+import { createPageHandler } from './app';
+
+export const app = express();
+
+app.disable('etag');
+app.use(adapterExpress(createPageHandler(renderToStream)));
+
+// The launcher calls start(); tests bind an ephemeral port on app instead.
+export const start = () => app.listen(3000, '127.0.0.1');

--- a/__fixtures__/caching/guest-cache.ts
+++ b/__fixtures__/caching/guest-cache.ts
@@ -1,0 +1,92 @@
+import type { TSsrHandler } from '@lomray/vite-ssr-boost/core/types';
+import { freshSeconds, guestPolicy, staleSeconds } from './policy';
+
+interface IBackgroundContext {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+
+/** URL-only, bounded SWR cache for the /guest representation in app.tsx. */
+export const createGuestCache = (
+  origin: TSsrHandler,
+  cache: Pick<Cache, 'match' | 'put' | 'delete'>,
+  now: () => number = Date.now,
+) => {
+  const refreshing = new Map<string, Promise<void>>();
+  const storedAt = 'X-Guest-Cache-Stored-At';
+
+  return async (request: Request, context: IBackgroundContext): Promise<Response> => {
+    const url = new URL(request.url);
+    const cookie = request.headers.get('Cookie') ?? '';
+
+    if (
+      request.method !== 'GET' ||
+      url.pathname !== '/guest' ||
+      /(?:^|;)\s*session\s*=/.test(cookie) ||
+      [
+        'Authorization',
+        'Range',
+        'If-None-Match',
+        'If-Modified-Since',
+        'Cache-Control',
+        'Pragma',
+      ].some((name) => request.headers.has(name))
+    ) {
+      return origin(request);
+    }
+
+    // Query strings stay in the key. Guest output must depend only on this URL.
+    url.hash = '';
+    const key = new Request(url, { method: 'GET' });
+    const cached = await cache.match(key);
+    const timestamp = Number(cached?.headers.get(storedAt) ?? NaN);
+    const age = Math.max(0, Math.floor((now() - timestamp) / 1000));
+
+    const refresh = async (): Promise<Response> => {
+      // Drop unkeyed cookies and headers before rendering the shared representation.
+      const response = await origin(new Request(url, { headers: { Accept: 'text/html' } }));
+
+      if (
+        response.status === 200 &&
+        response.headers.get('Cache-Control') === guestPolicy &&
+        !response.headers.has('Set-Cookie') &&
+        !response.headers.has('Vary')
+      ) {
+        const stored = new Response(response.clone().body, response);
+
+        stored.headers.set(storedAt, String(now()));
+        // Cache API has no native SWR: retain the body for the entire bounded window.
+        stored.headers.set('Cache-Control', `public, max-age=${freshSeconds + staleSeconds}`);
+        await cache.put(key, stored);
+      } else {
+        await cache.delete(key);
+      }
+
+      return response;
+    };
+
+    if (cached && Number.isFinite(timestamp) && age < freshSeconds + staleSeconds) {
+      if (age >= freshSeconds && !refreshing.has(url.href)) {
+        const pending = refresh()
+          .then((response) => response.body?.cancel())
+          .catch(() => undefined)
+          .finally(() => refreshing.delete(url.href));
+
+        refreshing.set(url.href, pending);
+        context.waitUntil(pending);
+      }
+
+      const response = new Response(cached.body, cached);
+
+      response.headers.delete(storedAt);
+      response.headers.set('Cache-Control', guestPolicy);
+      response.headers.set('Age', String(age));
+
+      return response;
+    }
+
+    // A tee's cancellation can wait for the cache's retained branch; do not block refresh.
+    void cached?.body?.cancel().catch(() => undefined);
+
+    return refresh();
+  };
+};

--- a/__fixtures__/caching/managed.tsx
+++ b/__fixtures__/caching/managed.tsx
@@ -1,0 +1,9 @@
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import React from 'react';
+import { rules, sessionCookie } from './policy';
+
+export default entryServer(
+  ({ children }) => children,
+  [{ path: '/guest', Component: () => <main>Public guest content</main> }],
+  { init: () => ({ documentHeaders: rules, sessionCookie }) },
+);

--- a/__fixtures__/caching/manual.ts
+++ b/__fixtures__/caching/manual.ts
@@ -1,0 +1,13 @@
+import { documentHeaders } from '@lomray/vite-ssr-boost/http';
+import type { ICoreRenderOptions } from '@lomray/vite-ssr-boost/core/render';
+import { rules, sessionCookie } from './policy';
+
+const finalize = documentHeaders(rules, { sessionCookie });
+
+// Equivalent to the handler's documentHeaders option. Prefer onShellReady so that
+// cookies written by earlier hooks are visible when the privacy default runs.
+export const onShellReady: ICoreRenderOptions['onShellReady'] = ({ context }) => {
+  context.response.headers = finalize(context);
+
+  return {};
+};

--- a/__fixtures__/caching/nginx.conf
+++ b/__fixtures__/caching/nginx.conf
@@ -1,0 +1,41 @@
+worker_processes 1;
+pid nginx.pid;
+error_log stderr;
+events { worker_connections 128; }
+http {
+    access_log off;
+    proxy_temp_path proxy_temp;
+    proxy_cache_path cache levels=1:2 keys_zone=guest:10m max_size=1g inactive=5m;
+
+    # Empty and "0" session values still mean cookie presence.
+    map $http_cookie $session_present {
+        default 0;
+        "~(^|;)[[:space:]]*session[[:space:]]*=" 1;
+    }
+    map $http_authorization $authorization_present {
+        default 1;
+        "" 0;
+    }
+
+    server {
+        listen 8080;
+        server_name localhost;
+        location = /guest {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header Host $host;
+            proxy_cache guest;
+            proxy_cache_key "$scheme://$host$request_uri";
+            proxy_cache_bypass $cookie_session $session_present $authorization_present;
+            proxy_no_cache $cookie_session $session_present $authorization_present $upstream_http_set_cookie;
+            proxy_cache_lock on;
+            proxy_cache_background_update on;
+            # Origin max-age and stale-while-revalidate bound freshness and stale use.
+            # Keep Nginx's handling of Cache-Control, Set-Cookie and Vary enabled.
+            add_header X-Page-Cache $upstream_cache_status always;
+        }
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header Host $host;
+        }
+    }
+}

--- a/__fixtures__/caching/policy.ts
+++ b/__fixtures__/caching/policy.ts
@@ -1,0 +1,21 @@
+import { cacheControl } from '@lomray/vite-ssr-boost/http';
+import type { IDocumentHeaderRule } from '@lomray/vite-ssr-boost/http';
+
+export const sessionCookie = 'session';
+export const freshSeconds = 30;
+export const staleSeconds = 60;
+export const guestPolicy = cacheControl({
+  public: true,
+  maxAge: freshSeconds,
+  staleWhileRevalidate: staleSeconds,
+});
+// Use this alternative when shared-cache freshness differs and stale serving is unnecessary.
+export const sharedPolicy = cacheControl({ public: true, maxAge: 0, sMaxAge: 30 });
+export const rules: IDocumentHeaderRule[] = [
+  { when: () => true, set: { 'Cache-Control': cacheControl({ private: true, noStore: true }) } },
+  {
+    when: ({ request, url }) =>
+      ['GET', 'HEAD'].includes(request.method) && url.pathname === '/guest',
+    set: { 'Cache-Control': guestPolicy },
+  },
+];

--- a/__fixtures__/caching/worker.ts
+++ b/__fixtures__/caching/worker.ts
@@ -1,0 +1,18 @@
+import renderToStream from '@lomray/vite-ssr-boost/edge/render-to-stream';
+import { createPageHandler } from './app';
+import { createGuestCache } from './guest-cache';
+
+const origin = createPageHandler(renderToStream);
+let cached: ReturnType<typeof createGuestCache> | undefined;
+
+export default {
+  fetch(
+    request: Request,
+    _env: unknown,
+    context: { waitUntil: (promise: Promise<unknown>) => void },
+  ) {
+    cached ??= createGuestCache(origin, (caches as CacheStorage & { default: Cache }).default);
+
+    return cached(request, context);
+  },
+};

--- a/__helpers__/cache-policy.tsx
+++ b/__helpers__/cache-policy.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { createStaticHandler } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import createHandler from '@core/handler';
+import type { TRenderToStream } from '@core/render';
+import { cacheControl, copyLoaderHeaders } from '../src/http';
+import Diagnostics from '@services/diagnostics';
+
+/** Exercise the actual router, header hooks, renderer and final Fetch response. */
+const testCachePolicy = (runtime: string, renderToStream: TRenderToStream) => {
+  describe(`${runtime} document policy`, () => {
+    it.each([true, false])(
+      'protects guest/authenticated responses with streaming=%s',
+      async (isStream) => {
+        const handler = createHandler(
+          {
+            createApp: (children) => children,
+            handler: createStaticHandler([
+              {
+                path: '*',
+                Component: () => <main>Rendered page</main>,
+                loader: () =>
+                  Response.json(
+                    { ok: true },
+                    { headers: { 'Cache-Control': 'public, max-age=100' } },
+                  ),
+              },
+            ]),
+            renderToStream,
+          },
+          {
+            diagnostics: false,
+            getHtml: () => ({ header: '<!doctype html><div>', footer: '</div>' }),
+            sessionCookie: 'session',
+            getState: ({ context }) => {
+              if (new URL(context.request.url).pathname === '/state-cookie') {
+                context.response.headers.append('Set-Cookie', 'state=new');
+              }
+            },
+            documentHeaders: [
+              {
+                when: () => true,
+                set: { 'Cache-Control': cacheControl({ public: true, maxAge: 0, sMaxAge: 30 }) },
+              },
+            ],
+            onRouterReady: ({ context }) => {
+              context.response.headers = copyLoaderHeaders(context.routerContext!, {
+                allow: ['Cache-Control', 'Content-Type'],
+              });
+              return { isStream };
+            },
+            onShellReady: ({ context }) => {
+              if (new URL(context.request.url).pathname === '/cookie')
+                context.response.headers.append('Set-Cookie', 'session=new');
+              return {};
+            },
+          },
+        );
+        for (const [path, headers, expected] of [
+          ['/guest', {}, 'public, max-age=0, s-maxage=30'],
+          ['/guest', { Cookie: 'session=x' }, 'private, no-store'],
+          ['/guest', { Authorization: 'Bearer x' }, 'private, no-store'],
+          ['/cookie', {}, 'private, no-store'],
+          ['/state-cookie', {}, 'private, no-store'],
+        ] as const) {
+          const response = await handler(new Request(`https://example.test${path}`, { headers }));
+          expect(response.headers.get('Cache-Control')).toBe(expected);
+          expect(response.headers.get('Content-Type')).toBe('text/html');
+          expect(await response.text()).toContain('Rendered page');
+        }
+      },
+    );
+
+    it.each([true, false])(
+      'diagnoses a final public override only when enabled=%s',
+      async (diagnostics) => {
+        const inspect = vi.spyOn(Diagnostics.prototype, 'inspectCachePolicy');
+        try {
+          const handler = createHandler(
+            {
+              createApp: (children) => children,
+              handler: createStaticHandler([{ path: '*', Component: () => <p>Page</p> }]),
+              renderToStream,
+            },
+            {
+              getHtml: () => ({ header: '<div>', footer: '</div>' }),
+              diagnostics,
+              sessionCookie: 'session',
+              protectPrivate: false,
+              documentHeaders: [{ when: () => true, set: { 'Cache-Control': 'public' } }],
+            },
+          );
+          const response = await handler(
+            new Request(`https://example.test/leak-${runtime}`, {
+              headers: { Cookie: 'session=x' },
+            }),
+          );
+          await response.text();
+          expect(inspect).toHaveBeenCalledTimes(diagnostics ? 1 : 0);
+          if (diagnostics) expect(inspect.mock.calls[0][1]).toBe(true);
+        } finally {
+          inspect.mockRestore();
+        }
+      },
+    );
+  });
+};
+
+export default testCachePolicy;

--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -390,6 +390,37 @@ describe('legacy Express render adapter', () => {
     },
   );
 
+  it.each([false, true])(
+    'passes managed document rules through to real core rendering (session=%s)',
+    async (authenticated) => {
+      const { default: coreRender } =
+        await vi.importActual<typeof import('@core/render')>('@core/render');
+      const { config, context } = createContext();
+      context.req.headers.cookie = authenticated ? 'session=secret' : 'theme=dark';
+      let headers: Headers;
+      coreRenderMock.mockImplementationOnce(coreRender);
+      writeFetchResponseMock.mockImplementationOnce(async (_, response: Response) => {
+        headers = response.headers;
+        await response.text();
+      });
+      await render(
+        {
+          App: App as never,
+          handler: createStaticHandler([{ path: '*', Component: () => 'Page' }]),
+        },
+        config as never,
+        context as never,
+        {
+          sessionCookie: 'session',
+          documentHeaders: [{ when: () => true, set: { 'Cache-Control': 'public, s-maxage=30' } }],
+        },
+      );
+      expect(headers!.get('Cache-Control')).toBe(
+        authenticated ? 'private, no-store' : 'public, s-maxage=30',
+      );
+    },
+  );
+
   it('keeps Express redirect behavior for legacy consumers', async () => {
     const { config, context, res } = createContext();
 

--- a/__tests__/http.ts
+++ b/__tests__/http.ts
@@ -1,0 +1,245 @@
+// @vitest-environment node
+import { createStaticHandler } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { cacheControl, conditionalRequest, copyLoaderHeaders, documentHeaders } from '../src/http';
+import Diagnostics from '@services/diagnostics';
+
+const publicRules = [{ when: () => true, set: { 'Cache-Control': 'public, s-maxage=30' } }];
+const context = (requestHeaders: HeadersInit = {}, headers: HeadersInit = {}) => ({
+  request: new Request('https://example.test/guest', { headers: requestHeaders }),
+  response: { headers: new Headers(headers) },
+});
+
+describe('cacheControl', () => {
+  it.each([
+    [{}, ''],
+    [{ public: true, maxAge: 0, sMaxAge: 30 }, 'public, max-age=0, s-maxage=30'],
+    [{ private: true, noStore: true }, 'private, no-store'],
+    [
+      { maxAge: 30, staleWhileRevalidate: 60, staleIfError: 120 },
+      'max-age=30, stale-while-revalidate=60, stale-if-error=120',
+    ],
+    [{ noCache: true, mustRevalidate: true }, 'no-cache, must-revalidate'],
+    [{ immutable: true, maxAge: 100, public: false }, 'max-age=100, immutable'],
+    [{ maxAge: undefined, noStore: false }, ''],
+  ])('serializes %j', (policy, value) => expect(cacheControl(policy)).toBe(value));
+
+  it.each([
+    null,
+    [],
+    'public',
+    { typo: true },
+    { public: 'yes' },
+    { noStore: 1 },
+    { maxAge: -1 },
+    { sMaxAge: 1.5 },
+    { staleWhileRevalidate: NaN },
+    { staleIfError: Infinity },
+    { maxAge: Number.MAX_SAFE_INTEGER + 1 },
+    { maxAge: '30' },
+    { public: true, private: true },
+    { noStore: true, public: true },
+    { noStore: true, maxAge: 0 },
+    { noStore: true, immutable: true },
+    { private: true, sMaxAge: 30 },
+    { noCache: true, immutable: true },
+    { mustRevalidate: true, staleWhileRevalidate: 30 },
+    { noCache: true, staleIfError: 30 },
+  ])('rejects %j', (policy) => expect(() => cacheControl(policy as never)).toThrow(TypeError));
+});
+
+describe('documentHeaders', () => {
+  it.each([
+    [{}, {}, 'public, s-maxage=30'],
+    [{ Cookie: 'theme=dark; session=secret' }, {}, 'private, no-store'],
+    [{ Cookie: 'session=' }, {}, 'private, no-store'],
+    [{ Cookie: 'session=0' }, {}, 'private, no-store'],
+    [{ Authorization: '' }, {}, 'private, no-store'],
+    [{}, { 'Set-Cookie': 'session=new' }, 'private, no-store'],
+    [{ Cookie: 'other_session=x; Session=x; theme=session=x' }, {}, 'public, s-maxage=30'],
+  ])('protects request %j and response %j', (request, response, expected) => {
+    const input = context(request, response);
+    const result = documentHeaders(publicRules, { sessionCookie: 'session' })(input);
+    expect(result.get('Cache-Control')).toBe(expected);
+    expect(input.response.headers.has('Cache-Control')).toBe(false);
+  });
+
+  it('applies matching rules in order and appends every cookie before privacy protection', () => {
+    const check = vi.fn(({ url, isBot, hasCookie, request, routerContext }) => {
+      expect(url.pathname).toBe('/guest');
+      expect(isBot).toBe(true);
+      expect(hasCookie('session')).toBe(true);
+      expect(request).toBe(input.request);
+      expect(routerContext).toBeUndefined();
+      return true;
+    });
+    const input = context(
+      { Cookie: 'session=;', 'User-Agent': 'Googlebot' },
+      { 'X-Rule': 'initial' },
+    );
+    const rules: Parameters<typeof documentHeaders>[0] = [
+      { when: check, set: { 'X-Rule': 'first', 'Set-Cookie': 'a=1' } },
+      { when: () => false, set: { 'X-Rule': 'skipped' } },
+      {
+        when: () => true,
+        set: [
+          ['X-Rule', 'last'],
+          ['Set-Cookie', 'b=2'],
+          ['Set-Cookie', 'c=3'],
+        ] as [string, string][],
+      },
+    ];
+    const result = documentHeaders(rules)(input);
+    expect(result.get('X-Rule')).toBe('last');
+    expect(result.getSetCookie()).toEqual(['a=1', 'b=2', 'c=3']);
+    expect(result.get('Cache-Control')).toBe('private, no-store');
+  });
+
+  it.each(['Cookie', 'Accept-Encoding, cOoKiE', '* , Cookie'])(
+    'never emits Cookie in Vary (%s)',
+    (vary) => {
+      const result = documentHeaders([{ when: () => true, set: { Vary: vary } }])(context());
+      expect(result.get('Vary')).toBe(
+        vary === 'Cookie' ? null : vary.startsWith('*') ? '*' : 'Accept-Encoding',
+      );
+    },
+  );
+
+  it('supports explicit overrides and leaves guests without matching policy unchanged', () => {
+    expect(documentHeaders([], { sessionCookie: 'session' })(context()).has('Cache-Control')).toBe(
+      false,
+    );
+    expect(
+      documentHeaders(publicRules, { sessionCookie: 'session', protectPrivate: false })(
+        context({ Cookie: 'session=x' }),
+      ).get('Cache-Control'),
+    ).toBe('public, s-maxage=30');
+  });
+});
+
+describe('copyLoaderHeaders', () => {
+  it('uses route depth, loader before action, appends cookies and excludes Content-Type', async () => {
+    const router = await createStaticHandler([
+      { id: 'root', path: '/', children: [{ id: 'leaf', path: 'guest', loader: () => null }] },
+    ]).query(new Request('https://example.test/guest'));
+    if (router instanceof Response) throw new Error('Expected a router context');
+    router.loaderHeaders = {
+      leaf: new Headers({
+        'Cache-Control': 'public',
+        'X-Depth': 'leaf',
+        'Set-Cookie': 'leaf=1',
+        'Content-Type': 'application/json',
+      }),
+      root: new Headers({
+        'Cache-Control': 'private',
+        'Set-Cookie': 'root=1; Expires=Wed, 21 Oct 2037 07:28:00 GMT',
+      }),
+      unmatched: new Headers({ 'Set-Cookie': 'ignored=1' }),
+    };
+    router.actionHeaders = {
+      root: new Headers({
+        'Cache-Control': 'no-store',
+        'X-Depth': 'root-action',
+        'Set-Cookie': 'action=1',
+      }),
+    };
+    const headers = copyLoaderHeaders(router, {
+      allow: ['cache-control', 'SET-COOKIE', 'Content-Type', 'X-Depth'],
+    });
+    expect(headers.get('Cache-Control')).toBe('private');
+    expect(headers.get('X-Depth')).toBe('root-action');
+    expect(headers.get('Content-Type')).toBeNull();
+    expect(headers.getSetCookie()).toEqual([
+      'root=1; Expires=Wed, 21 Oct 2037 07:28:00 GMT',
+      'action=1',
+      'leaf=1',
+    ]);
+    expect([...copyLoaderHeaders(router, { allow: [] })]).toEqual([]);
+    expect(router.loaderHeaders.leaf.get('Cache-Control')).toBe('public');
+  });
+});
+
+describe('conditionalRequest', () => {
+  const validators = { etag: '"version,1"', lastModified: new Date('2026-09-01T12:00:00.900Z') };
+  it.each(['GET', 'HEAD'])('weakly matches ETag lists for %s without a body', async (method) => {
+    const response = conditionalRequest(
+      new Request('https://example.test/', {
+        method,
+        headers: { 'If-None-Match': '"other", W/"version,1"' },
+      }),
+      validators,
+    )!;
+    expect(response.status).toBe(304);
+    expect(response.headers.get('ETag')).toBe(validators.etag);
+    expect(response.headers.get('Last-Modified')).toBe('Tue, 01 Sep 2026 12:00:00 GMT');
+    expect(await response.text()).toBe('');
+  });
+  it.each([
+    [{ 'If-None-Match': '*' }, 304],
+    [{ 'If-None-Match': '"miss"' }, undefined],
+    [{ 'If-None-Match': 'bad "version,1"' }, undefined],
+    [
+      { 'If-None-Match': '"miss"', 'If-Modified-Since': 'Tue, 01 Sep 2026 12:00:00 GMT' },
+      undefined,
+    ],
+    [{ 'If-Modified-Since': 'Tue, 01 Sep 2026 12:00:00 GMT' }, 304],
+    [{ 'If-Modified-Since': 'Wed, 02 Sep 2026 12:00:00 GMT' }, 304],
+    [{ 'If-Modified-Since': 'Mon, 31 Aug 2026 12:00:00 GMT' }, undefined],
+    [{ 'If-Modified-Since': 'invalid' }, undefined],
+    [{ 'If-Modified-Since': '2099' }, undefined],
+    [{ 'If-Modified-Since': '2099-09-01T12:00:00Z' }, undefined],
+    [{}, undefined],
+  ])('evaluates %j', (headers, status) => {
+    expect(
+      conditionalRequest(new Request('https://example.test/', { headers }), validators)?.status,
+    ).toBe(status);
+  });
+  it('ignores unsafe methods and never falls back to dates when an ETag condition is present', () => {
+    expect(
+      conditionalRequest(
+        new Request('https://example.test/', { method: 'POST', headers: { 'If-None-Match': '*' } }),
+        validators,
+      ),
+    ).toBeUndefined();
+    expect(
+      conditionalRequest(
+        new Request('https://example.test/', {
+          headers: { 'If-None-Match': '"x"', 'If-Modified-Since': 'Tue, 01 Sep 2026 12:00:00 GMT' },
+        }),
+        { lastModified: validators.lastModified },
+      ),
+    ).toBeUndefined();
+  });
+  it.each([{ etag: 'unquoted' }, { etag: '"bad\n"' }, { lastModified: 'bad' }])(
+    'validates %j',
+    (value) => {
+      expect(() => conditionalRequest(new Request('https://example.test/'), value)).toThrow(
+        TypeError,
+      );
+    },
+  );
+});
+
+describe('cache private leak diagnostic', () => {
+  it('warns once without revealing cookie or authorization values', () => {
+    const logger = { warn: vi.fn() };
+    const diagnostics = new Diagnostics('/private-leak-test', logger);
+    const headers = new Headers({
+      'Cache-Control': 'PUBLIC, max-age=30',
+      'Set-Cookie': 'secret=do-not-log',
+    });
+    diagnostics.inspectCachePolicy(headers, false);
+    diagnostics.inspectCachePolicy(headers, true);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toContain('SSR_BOOST_CACHE_PRIVATE_LEAK');
+    expect(logger.warn.mock.calls[0][0]).not.toContain('do-not-log');
+    diagnostics.inspectCachePolicy(new Headers({ 'Cache-Control': 'private, no-store' }), true);
+    diagnostics.inspectCachePolicy(new Headers({ 'Cache-Control': 'public' }), false);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    new Diagnostics('/cookie-only-leak', logger).inspectCachePolicy(
+      new Headers({ 'Cache-Control': 'public' }),
+      true,
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/integration/cache-policy-edge.tsx
+++ b/__tests__/integration/cache-policy-edge.tsx
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import testCachePolicy from '@__helpers__/cache-policy';
+import renderToStream from '@edge/render-to-stream';
+
+testCachePolicy('edge', renderToStream);

--- a/__tests__/integration/cache-policy-node.tsx
+++ b/__tests__/integration/cache-policy-node.tsx
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import testCachePolicy from '@__helpers__/cache-policy';
+import renderToStream from '@node/render-to-stream';
+
+testCachePolicy('node', renderToStream);

--- a/__tests__/integration/caching-recipes.ts
+++ b/__tests__/integration/caching-recipes.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { app } from '../../__fixtures__/caching/express';
+import { bufferedPage } from '../../__fixtures__/caching/buffered';
+import { createGuestCache } from '../../__fixtures__/caching/guest-cache';
+import { onShellReady } from '../../__fixtures__/caching/manual';
+import { guestPolicy } from '../../__fixtures__/caching/policy';
+
+describe('compiled caching recipes', () => {
+  let server: http.Server;
+  let origin: string;
+  beforeAll(async () => {
+    server = http.createServer(app).listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+  afterAll(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('serves the Express guest and authenticated documents', async () => {
+    for (const [headers, policy, content] of [
+      [{}, guestPolicy, 'Guest page'],
+      [{ Cookie: 'session=' }, 'private, no-store', 'Account page'],
+      [{ Authorization: 'Bearer credential' }, 'private, no-store', 'Account page'],
+    ] as const) {
+      const response = await fetch(`${origin}/guest`, { headers });
+      expect(response.headers.get('Cache-Control')).toBe(policy);
+      expect(await response.text()).toContain(content);
+    }
+  });
+
+  it('executes the manual hook and buffered conditional response recipes', async () => {
+    const context = {
+      request: new Request('https://example.test/guest', { headers: { Cookie: 'session=x' } }),
+      response: { headers: new Headers() },
+    };
+    onShellReady!({ context: context as never });
+    expect(context.response.headers.get('Cache-Control')).toBe('private, no-store');
+    const page = bufferedPage(new Request('https://example.test/'));
+    expect(await page.text()).toContain('revision 7');
+    for (const method of ['GET', 'HEAD']) {
+      const unchanged = bufferedPage(
+        new Request('https://example.test/', {
+          method,
+          headers: { 'If-None-Match': page.headers.get('ETag')! },
+        }),
+      );
+      expect(unchanged.status).toBe(304);
+      expect(unchanged.headers.get('Cache-Control')).toBe(page.headers.get('Cache-Control'));
+      expect(await unchanged.text()).toBe('');
+    }
+    expect(
+      await bufferedPage(new Request('https://example.test/', { method: 'HEAD' })).text(),
+    ).toBe('');
+  });
+
+  const nginx = process.env.NGINX_BINARY ?? 'nginx';
+  it.skipIf(spawnSync(nginx, ['-v']).error)(
+    'runs the Nginx configuration against Express, including empty/zero session bypass',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'caching-nginx-'));
+      const probe = http.createServer().listen(0, '127.0.0.1');
+      await once(probe, 'listening');
+      const port = (probe.address() as AddressInfo).port;
+      await new Promise<void>((resolve) => probe.close(() => resolve()));
+      const config = (
+        await readFile(new URL('../../__fixtures__/caching/nginx.conf', import.meta.url), 'utf8')
+      )
+        .replace('listen 8080;', `listen 127.0.0.1:${port};`)
+        .replaceAll('http://127.0.0.1:3000', origin);
+      await writeFile(join(directory, 'nginx.conf'), config);
+      const args = ['-p', `${directory}/`, '-c', 'nginx.conf', '-e', 'stderr'];
+      const checked = spawnSync(nginx, [...args, '-t'], { encoding: 'utf8' });
+      expect(checked.status, checked.stderr).toBe(0);
+      const child = spawn(nginx, [...args, '-g', 'daemon off; master_process off;'], {
+        stdio: 'pipe',
+      });
+      const closed = once(child, 'exit');
+      try {
+        const url = `http://127.0.0.1:${port}/guest`;
+        await vi.waitFor(async () => {
+          await (await fetch(url)).text();
+        });
+        const guest = await fetch(url);
+        expect(guest.headers.get('X-Page-Cache')).toBe('HIT');
+        expect(await guest.text()).toContain('Guest page');
+        const credentialHeaders: HeadersInit[] = [
+          { Cookie: 'session=secret' },
+          { Cookie: 'session=' },
+          { Cookie: 'session=0' },
+          { Authorization: 'Bearer secret' },
+        ];
+        for (const headers of credentialHeaders) {
+          const account = await fetch(url, { headers });
+          expect(account.headers.get('X-Page-Cache'), JSON.stringify(headers)).toBe('BYPASS');
+          expect(account.headers.get('Cache-Control')).toBe('private, no-store');
+          expect(await account.text()).toContain('Account page');
+        }
+        const after = await fetch(url);
+        expect(after.headers.get('X-Page-Cache')).toBe('HIT');
+        expect(await after.text()).toContain('Guest page');
+      } finally {
+        child.kill('SIGTERM');
+        await closed;
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+describe('Worker Cache API recipe', () => {
+  const setup = () => {
+    const stored = new Map<string, Response>();
+    const cache = {
+      match: vi.fn(async (request: Request) => stored.get(request.url)?.clone()),
+      put: vi.fn(async (request: Request, response: Response) => {
+        stored.set(request.url, new Response(await response.arrayBuffer(), response));
+      }),
+      delete: vi.fn(async (request: Request) => stored.delete(request.url)),
+    };
+    let time = 1_000_000;
+    const origin = vi.fn(
+      async () =>
+        new Response(`revision ${origin.mock.calls.length}`, {
+          headers: { 'Cache-Control': guestPolicy },
+        }),
+    );
+    const background: Promise<unknown>[] = [];
+    const context = {
+      waitUntil: (promise: Promise<unknown>) => {
+        background.push(promise);
+      },
+    };
+    const handler = createGuestCache(origin, cache as never, () => time);
+    return {
+      cache,
+      origin,
+      background,
+      context,
+      handler,
+      advance: (seconds: number) => {
+        time += seconds * 1000;
+      },
+    };
+  };
+
+  it('caches by full URL, strips unkeyed inputs, refreshes stale content and expires the window', async () => {
+    const { handler, context, origin, background, advance } = setup();
+    const request = new Request('https://example.test/guest?language=en', {
+      headers: { Cookie: 'theme=dark', 'X-Unkeyed': 'value' },
+    });
+    expect(await (await handler(request, context)).text()).toBe('revision 1');
+    const forwarded = origin.mock.calls[0] as unknown as [Request];
+    expect(forwarded[0].headers.has('Cookie')).toBe(false);
+    expect(forwarded[0].headers.has('X-Unkeyed')).toBe(false);
+    advance(20);
+    const fresh = await handler(request, context);
+    expect(await fresh.text()).toBe('revision 1');
+    expect(fresh.headers.get('Age')).toBe('20');
+    expect(fresh.headers.has('X-Guest-Cache-Stored-At')).toBe(false);
+    expect(origin).toHaveBeenCalledTimes(1);
+    advance(15);
+    expect(await (await handler(request, context)).text()).toBe('revision 1');
+    await Promise.all(background);
+    expect(await (await handler(request, context)).text()).toBe('revision 2');
+    advance(91);
+    expect(await (await handler(request, context)).text()).toBe('revision 3');
+    expect(
+      await (await handler(new Request('https://example.test/guest?language=fr'), context)).text(),
+    ).toBe('revision 4');
+  });
+
+  it.each([
+    { headers: { Cookie: 'session=' } },
+    { headers: { Cookie: 'session=0' } },
+    { headers: { Authorization: '' } },
+    { headers: { Range: 'bytes=0-10' } },
+    { headers: { 'If-None-Match': '"v1"' } },
+    { headers: { 'Cache-Control': 'no-cache' } },
+    { method: 'HEAD' },
+    { method: 'POST' },
+  ])('bypasses both reads and writes for %j', async (init) => {
+    const { handler, context, cache, origin } = setup();
+    const request = new Request('https://example.test/guest', init as RequestInit);
+    await (await handler(request, context)).text();
+    expect(cache.match).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+    expect(origin).toHaveBeenCalledWith(request);
+  });
+
+  it.each([
+    { status: 500 },
+    { headers: { 'Cache-Control': 'private, no-store' } },
+    { headers: { 'Cache-Control': guestPolicy, 'Set-Cookie': 'session=x' } },
+    { headers: { 'Cache-Control': guestPolicy, Vary: 'Accept-Language' } },
+  ])('does not store unsafe origin responses %j', async (init) => {
+    const { handler, context, cache, origin } = setup();
+    origin.mockResolvedValueOnce(new Response('uncacheable', init as ResponseInit));
+    await (await handler(new Request('https://example.test/guest'), context)).text();
+    expect(cache.put).not.toHaveBeenCalled();
+    expect(cache.delete).toHaveBeenCalled();
+  });
+
+  it('keeps refresh failure within the stale window and then surfaces origin errors', async () => {
+    const { handler, context, origin, background, advance } = setup();
+    const request = new Request('https://example.test/guest');
+    await (await handler(request, context)).text();
+    advance(31);
+    origin.mockRejectedValue(new Error('origin unavailable'));
+    expect(await (await handler(request, context)).text()).toBe('revision 1');
+    await Promise.all(background);
+    advance(60);
+    await expect(handler(request, context)).rejects.toThrow('origin unavailable');
+  });
+});

--- a/__tests__/integration/miniflare.ts
+++ b/__tests__/integration/miniflare.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('Miniflare edge app', () => {
   let miniflare: Miniflare;
+  let caching: Miniflare;
 
   beforeAll(async () => {
     const useBuildOutput = process.env.SSR_BOOST_PACKED_EDGE === '1';
@@ -61,10 +62,67 @@ describe('Miniflare edge app', () => {
         },
       ],
     });
+
+    const cachingBundle = await build({
+      bundle: true,
+      conditions: ['workerd', 'worker', 'browser'],
+      define: { 'process.env.NODE_ENV': '"production"' },
+      entryPoints: [
+        fileURLToPath(new URL('../../__fixtures__/caching/worker.ts', import.meta.url)),
+      ],
+      format: 'esm',
+      platform: 'browser',
+      target: 'es2022',
+      write: false,
+      plugins: [
+        {
+          name: 'caching-recipe-package',
+          setup(builder) {
+            builder.onResolve({ filter: /^@lomray\/vite-ssr-boost\// }, ({ path }) => ({
+              path: fileURLToPath(
+                new URL(
+                  `../../${useBuildOutput ? 'lib' : 'src'}/${path.slice('@lomray/vite-ssr-boost/'.length)}.${useBuildOutput ? 'js' : 'ts'}`,
+                  import.meta.url,
+                ),
+              ),
+            }));
+          },
+        },
+      ],
+    });
+    caching = new Miniflare({
+      compatibilityDate: '2025-01-01',
+      modules: [
+        {
+          contents: cachingBundle.outputFiles[0].text,
+          path: 'caching-worker.mjs',
+          type: 'ESModule',
+        },
+      ],
+    });
   }, 30_000);
 
   afterAll(async () => {
-    await miniflare.dispose();
+    await Promise.all([miniflare?.dispose(), caching?.dispose()]);
+  });
+
+  it('runs the complete Worker Cache API recipe with guest hits and credential bypass', async () => {
+    const url = 'https://edge.example/guest';
+    const miss = await caching.dispatchFetch(url);
+    expect(miss.headers.get('Cache-Control')).toBe('public, max-age=30, stale-while-revalidate=60');
+    expect(await miss.text()).toContain('Guest page');
+    const hit = await caching.dispatchFetch(url);
+    expect(hit.headers.has('Age')).toBe(true);
+    expect(await hit.text()).toContain('Guest page');
+    for (const headers of [{ Cookie: 'session=' }, { Authorization: 'Bearer secret' }]) {
+      const account = await caching.dispatchFetch(url, { headers });
+      expect(account.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(account.headers.has('Age')).toBe(false);
+      expect(await account.text()).toContain('Account page');
+    }
+    const guest = await caching.dispatchFetch(url);
+    expect(guest.headers.has('Age')).toBe(true);
+    expect(await guest.text()).toContain('Guest page');
   });
 
   it('boots and streams a real SSR app inside workerd', async () => {

--- a/browser-tests/cache-policy.spec.mjs
+++ b/browser-tests/cache-policy.spec.mjs
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test('document navigation switches from guest caching to private after a session cookie', async ({ page, context }) => {
+  const guest = await page.goto('http://127.0.0.1:4179/');
+  expect(guest.headers()['cache-control']).toBe('public, max-age=0, s-maxage=30');
+  await context.addCookies([{ name: 'session', value: 'browser-session', url: 'http://127.0.0.1:4179' }]);
+  const account = await page.reload();
+  expect(account.headers()['cache-control']).toBe('private, no-store');
+  expect(account.headers().vary ?? '').not.toMatch(/cookie/i);
+  await context.clearCookies();
+  const loggedOut = await page.reload();
+  expect(loggedOut.headers()['cache-control']).toBe('public, max-age=0, s-maxage=30');
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
           { text: 'Server Lifecycle', link: '/guide/server-lifecycle' },
           { text: 'Runtime Adapters', link: '/guide/runtime-adapters' },
           { text: 'Deployment', link: '/guide/deployment' },
+          { text: 'Caching', link: '/guide/caching' },
         ],
       },
       {

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -1,0 +1,202 @@
+# Document headers and caching
+
+Cache guest HTML at the CDN with a short freshness lifetime and a bounded
+stale-while-revalidate window. Bypass **both cache reads and writes** whenever the
+session cookie or Authorization header is present. Authenticated documents use
+`private, no-store`; cache their underlying data with appropriate user or tenant keys
+instead of sharing rendered pages.
+
+Only opt URLs into a shared cache when their HTML, loader data and serialized custom
+state are public and independent of unkeyed inputs. Put locale or other public variants
+in the URL, or design a separate cache key. Login, account, cart and mutation routes
+should bypass the page cache. Purge guest entries when content must disappear sooner
+than their freshness plus stale window.
+
+`private` excludes shared caches; `no-store` also excludes browser storage. Setting
+Set-Cookie alone does not prohibit caching, so the document helper applies a privacy
+default explicitly. See [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html).
+Stale-while-revalidate permits a bounded stale response while refresh runs in the
+background; it does not extend freshness. See [RFC 5861](https://www.rfc-editor.org/rfc/rfc5861.html).
+
+## HTTP helpers
+
+Import the server-side `@lomray/vite-ssr-boost/http` entry. It uses Fetch primitives,
+has no Node-only imports, and works with either renderer. Keep it out of browser entries.
+All snippets on this page are compiled fixtures; the helper, Express, Worker and
+Nginx examples also have executable tests.
+
+### `cacheControl(policy)`
+
+The boolean fields are `public`, `private`, `noStore`, `noCache`, `mustRevalidate`,
+and `immutable`. The duration fields are `maxAge`, `sMaxAge`, `staleWhileRevalidate`,
+and `staleIfError`, in non-negative safe integer seconds. False and undefined fields
+are omitted; an empty object returns an empty string. Invalid types, unknown fields,
+public plus private, and contradictory storage/revalidation directives throw TypeError.
+
+These policies and ordered rules are shared by the following examples:
+
+<<< ../../__fixtures__/caching/policy.ts
+
+The SWR policy uses `max-age`, not `s-maxage`: RFC 9111 gives `s-maxage` the
+semantics of proxy-revalidate, which prevents shared caches from serving stale
+responses before validation. The `sharedPolicy` alternative gives browsers a zero
+freshness lifetime and shared caches 30 seconds when stale serving is unnecessary.
+The builder permits `sMaxAge` together with stale extensions, but does not change
+the cache's interpretation. Cloudflare documents this restriction in its
+[revalidation guide](https://developers.cloudflare.com/cache/concepts/revalidation/).
+
+### `documentHeaders(rules, options?)`
+
+The helper returns a function taking the Fetch render context and returning a fresh
+Headers object. Each rule has `when({ request, url, isBot, hasCookie, routerContext })`
+and `set: HeadersInit`. All matching rules run in array order. Later rules replace
+ordinary fields; every Set-Cookie value appends independently. Existing hook headers
+are the starting point. Guests without a matching policy keep those headers.
+
+`isBot` is a User-Agent heuristic matching bot, crawler, spider or crawling; it is
+not an authentication check. `hasCookie(name)` compares exact, case-sensitive cookie
+names and treats empty values as present, without decoding the values.
+
+Set `sessionCookie` to your application's cookie name. After the rules, Set-Cookie
+on the resulting document, Authorization on the request, or that session cookie
+forces `private, no-store`. Configure the same cookie name at the CDN. A deliberate
+`protectPrivate: false` override disables this final protection; public responses
+with Set-Cookie or the configured session cookie then trigger the development
+[SSR_BOOST_CACHE_PRIVATE_LEAK diagnostic](/reference/diagnostics#ssr_boost_cache_private_leak).
+
+The helper removes the Cookie token from Vary, preserving other tokens. **It never
+emits Vary: Cookie**: varying on entire cookie strings fragments a CDN cache by
+session IDs and unrelated tracking cookies. Use a session-presence bypass instead.
+Do not use these URL-only recipes for pages personalized by other cookies; bypass
+those pages too. Removing Vary does not make personalized content public.
+
+Use the handler's `documentHeaders` option to apply the rules automatically after
+`onShellReady` in `prepareHtmlResponse`, before document metadata is committed.
+It is opt-in, including an empty rule list to enable only the privacy defaults.
+Explicit loader/action and server redirects keep their existing `mergeResponseHeaders`
+precedence; short-circuit `onRequest` responses and fatal shell errors are not rule
+targets. Give those responses their own cache headers.
+
+For manual use in `onRouterReady` or `onShellReady`:
+
+<<< ../../__fixtures__/caching/manual.ts
+
+The shell stage sees cookies written by earlier hooks. If you use the router stage,
+recompute after any later header changes. Headers and statuses cannot change once
+the streamed shell has been sent.
+
+### `copyLoaderHeaders(routerContext, { allow })`
+
+Rendered loader/action headers remain separate from document headers until explicitly
+copied. This helper returns a new Headers object containing only the allowlist. It
+visits matched routes from root to leaf, loader before action at the same route.
+The first ordinary value wins, so the shallowest route controls Cache-Control and
+other allowed fields. All Set-Cookie values append in traversal order, including
+cookies with commas in Expires. Unmatched route headers are ignored. Content-Type
+is never copied, even when allowed: loader JSON is not the HTML document.
+
+The complete application factory below demonstrates copying without discarding
+existing hook headers. Document rules run afterwards and override copied ordinary
+fields. Supply the Node or edge renderer as shown in the recipes. This example renders
+server HTML only; an interactive application supplies its built browser script and
+static assets through its existing shell/asset pipeline. The cookie check is a
+demonstration of presence, not session validation.
+
+<<< ../../__fixtures__/caching/app.tsx
+
+The managed CLI entry passes the same policy options through its `init` result:
+
+<<< ../../__fixtures__/caching/managed.tsx
+
+## Cloudflare Worker
+
+This Worker caches `/guest` by the full URL, including the query string. Credentialed
+requests bypass lookup and storage. Guest renders receive only the URL and a fixed
+Accept header, so unkeyed cookies or headers cannot affect the shared representation.
+HEAD, mutations, ranges, validators and explicit request cache directives go to the origin.
+Only successful responses with the exact guest policy, no cookies and no Vary are stored.
+
+The [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) does not
+implement stale-while-revalidate. This wrapper stores the body for 90 seconds, returns
+the original 30-second policy and Age to clients, and refreshes during the next 60
+seconds with `waitUntil`. At expiry it waits for a fresh response. Refresh errors
+cannot extend the stale window. Concurrent refreshes are coalesced within one isolate.
+Cache API storage is local to a data center and does not use tiered caching.
+
+<<< ../../__fixtures__/caching/guest-cache.ts
+
+Worker entry (bundle with the `workerd` and `worker` resolution conditions):
+
+<<< ../../__fixtures__/caching/worker.ts
+
+### Equivalent Cache Rules for an origin server
+
+Use these settings instead of the Worker wrapper when Cloudflare fronts the Express
+origin directly. The origin must keep the same public representation contract.
+Create the guest eligibility rule first and the bypass rule last, since matching
+later rules override earlier settings. Scope both rules to your hostname.
+
+| Rule | Matching requests | Settings |
+| --- | --- | --- |
+| Guest page | GET or HEAD, path exactly `/guest` | Eligible for cache; respect origin Cache-Control and bypass if absent; browser TTL respects origin; full URL key including query; serve stale while revalidating enabled |
+| Credentials | Cookie string contains `session=` or Authorization header is present | Bypass cache |
+| Other requests | Other paths, methods, Range, conditional headers or explicit request cache directives | Bypass cache |
+
+The cookie substring match intentionally over-bypasses lookalike names; it does not
+miss an empty `session=` value. Use the rules editor's header-presence condition for
+Authorization, including empty values. Do not override origin private/no-store,
+strip Set-Cookie, or force an edge TTL on credentialed responses. The origin guest
+policy supplies max-age and stale-while-revalidate; using s-maxage disables stale
+serving on Cloudflare. See [Cache Rules settings](https://developers.cloudflare.com/cache/how-to/cache-rules/settings/)
+and [cookie bypass](https://developers.cloudflare.com/cache/how-to/cache-rules/examples/bypass-cache-on-cookie/).
+
+## Express behind Nginx
+
+Create the Express app with the Node renderer:
+
+<<< ../../__fixtures__/caching/express.ts
+
+Run this launcher with your server TypeScript build/runtime:
+
+<<< ../../__fixtures__/caching/express-start.ts
+
+Run Nginx with this configuration in a writable prefix directory. It listens on 8080
+and proxies to Express on localhost:3000; configure production TLS and hostnames for
+your deployment. Guest HTML is buffered into the proxy cache. The private path
+always reaches Express. Both bypass and no-cache directives matter: the former
+prevents reading a guest hit; the latter prevents storing a private response.
+
+<<< ../../__fixtures__/caching/nginx.conf{nginx}
+
+`$cookie_session` alone treats empty and `0` values as false, so the additional raw
+cookie presence map covers those values. Nginx honors origin Cache-Control,
+Set-Cookie and Vary by default. Background update uses the origin's bounded SWR
+window; avoid an unconditional `proxy_cache_use_stale updating` override that could
+outlive it. See the [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html).
+
+## Conditional requests and streaming
+
+`conditionalRequest(request, { etag?, lastModified? })` returns a bodyless 304 for a
+matching GET or HEAD, otherwise undefined. ETags must be quoted (optionally W/);
+Last-Modified accepts a Date or date string. It supports weak ETag comparison,
+comma-separated tags and `*` for an existing representation. If-None-Match takes
+precedence over If-Modified-Since, including when no ETag matches. Modification
+times compare at HTTP's whole-second precision. Invalid supplied validators throw;
+invalid request validators are ignored. Other methods never return 304.
+
+Call it only for an existing successful representation after selecting and authorizing
+that representation. It does not implement mutation preconditions such as If-Match.
+Retain the 200 response's Cache-Control, Vary and Content-Location when applicable.
+The following buffered response uses an application-supplied version covering both
+article and template revisions:
+
+<<< ../../__fixtures__/caching/buffered.ts
+
+A streamed body cannot be hashed before sending it. Setting `isStream: false` waits
+for React and loader promises, but the Fetch response still exposes a body stream;
+buffer/consume that body yourself before hashing it and constructing a conditional
+response. This helper never reads a stream. For streaming applications, use an
+application-supplied representation version known before rendering, and make the
+conditional decision in a buffered/non-streaming path before committing the shell.
+The version must cover every output dependency, including serialized state and
+personalization. A build ID alone is insufficient for changing page data.

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -291,6 +291,10 @@ that ran before the redirect. Redirect headers override matching hook headers; `
 from both are appended separately. For rendered routes,
 React Router exposes loader/action headers on `context.routerContext`; copy the headers your HTML
 document needs in `onRouterReady`. A JSON loader's `Content-Type` is not the document's content type.
+The server-side [HTTP helpers](/guide/caching) provide explicit `copyLoaderHeaders`
+allowlists and ordered `documentHeaders` policies. Both `createHandler` and the managed
+entry's `init` result accept `documentHeaders`, `sessionCookie` and `protectPrivate`.
+Document rules run after `onShellReady`; redirects retain the precedence above.
 
 ## Streaming and cancellation
 

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -108,6 +108,11 @@ Typical uses:
 - state container tags
 - request-specific metadata
 
+For final document policies, prefer the `documentHeaders` lifecycle option: it runs
+after this hook, including its cookie mutations. Configure `sessionCookie` to make
+authenticated documents private by default. Loader/action headers remain explicit;
+use `copyLoaderHeaders` with an allowlist. See [Document headers and caching](/guide/caching).
+
 ## `onResponse`
 
 Receives `{ context, html, isEnd }` for HTML chunks as they are written, with `isEnd: false`.

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -18,6 +18,15 @@ the response finishes, without delaying streamed chunks. When disabled, they nei
 accumulate HTML. Completed-output checks skip cancelled or failed streams, redirects, and bodyless
 responses; invalid file-backed shells always throw, even with diagnostics disabled.
 
+## SSR_BOOST_CACHE_PRIVATE_LEAK {#ssr_boost_cache_private_leak}
+
+A final response is explicitly public while carrying Set-Cookie or while the request
+contains the configured `sessionCookie`. Use `documentHeaders` with its default
+credential protection and bypass shared cache reads and writes for that cookie.
+The warning is deduplicated and never prints cookie values. Like other development
+checks, it is disabled in production unless diagnostics are explicitly enabled.
+See [Document headers and caching](/guide/caching) for the helpers and tested recipes.
+
 ## SSR_BOOST_DEPRECATED_REQ_RES {#ssr_boost_deprecated_req_res}
 
 A managed Express hook or loader reads `context.req` or `context.res`. These fields still return

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -33,6 +33,8 @@ const { exports: publicExports } = JSON.parse(await readFile(resolve(projectRoot
 // context/server and helpers/get-server-state ARE browser entries despite their names.
 // Everything else is covered automatically; a new entry needs an explicit budget.
 const excludedPaths = [
+  // The HTTP policy entry is server-side, even though it also supports edge runtimes.
+  /^http\.js$/,
   /^(?:server|core|edge|node|adapters?|cli|plugins?|services|workflow)(?:\/|\.js$)/,
   /^constants\/(?:cli-|plugin-|stream-error\.js$)/,
   /^helpers\/(?:build-(?:custom|router)-state|create-focus-only|dev-marker|html-escape|is-route-file|obtain-stream-error|plugin-config|print-server-(?:info|urls)|process-stop|resolve-server-urls|serialize-errors|vite-aliases)\.js$/,

--- a/scripts/test-core-no-optional.mjs
+++ b/scripts/test-core-no-optional.mjs
@@ -168,6 +168,13 @@ try {
     const { default: createHandler } = await import('@lomray/vite-ssr-boost/core/handler');
     const { default: adapterEdge } = await import('@lomray/vite-ssr-boost/adapters/edge');
     const { default: adapterNode } = await import('@lomray/vite-ssr-boost/adapters/node');
+    const http = await import('@lomray/vite-ssr-boost/http');
+    const httpJs = await import('@lomray/vite-ssr-boost/http.js');
+    for (const name of ['cacheControl', 'documentHeaders', 'copyLoaderHeaders', 'conditionalRequest']) {
+      assert.equal(typeof http[name], 'function', name);
+      assert.equal(http[name], httpJs[name], name);
+    }
+    assert.equal(http.cacheControl({ private: true, noStore: true }), 'private, no-store');
     const production = await import('@lomray/vite-ssr-boost/node/production');
     const productionJs = await import('@lomray/vite-ssr-boost/node/production.js');
     for (const name of ['loadHtmlShell', 'createRouteAssetPreparer']) {
@@ -210,6 +217,13 @@ try {
     import type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions } from '@lomray/vite-ssr-boost/node/production';
     import type { IHtmlShell as IHtmlShellJs } from '@lomray/vite-ssr-boost/node/production.js';
     import type { ICreateHandlerOptions } from '@lomray/vite-ssr-boost/core/handler';
+    import { cacheControl, documentHeaders, conditionalRequest } from '@lomray/vite-ssr-boost/http';
+    import type { IDocumentHeaderRule } from '@lomray/vite-ssr-boost/http.js';
+    const rules: IDocumentHeaderRule[] = [{ when: ({ hasCookie }) => !hasCookie('session'), set: { 'Cache-Control': cacheControl({ public: true, sMaxAge: 30 }) } }];
+    const headers: Headers = documentHeaders(rules, { sessionCookie: 'session' })({ request: new Request('https://example.com'), response: { headers: new Headers() } });
+    const conditional: Response | undefined = conditionalRequest(new Request('https://example.com'), { etag: '"v1"' });
+    // @ts-expect-error Cache durations are numeric seconds.
+    cacheControl({ maxAge: '30' });
 
     const shellOptions: ILoadHtmlShellOptions = { indexFile: '/app/build/client/index.html' };
     const assetOptions: IRouteAssetPreparerOptions = { buildDir: '/app/build', modulePreload: true };
@@ -263,7 +277,7 @@ try {
     }
   }
 
-  process.stdout.write('Packed exports (including node/production), NodeNext/Bundler declarations and optional-free core passed.\n');
+  process.stdout.write('Packed exports (including http and node/production), NodeNext/Bundler declarations and optional-free core passed.\n');
 } finally {
   await rm(directory, { force: true, recursive: true });
 }

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -518,8 +518,9 @@ const configureBasename = async () => {
   await edit('vite.config.ts', "root: 'src',", "root: 'src', base: '/acceptance/',");
   await edit(
     'src/client.ts',
-    'init: async ({ isSSRMode }) => {',
-    "routerOptions: { basename: '/acceptance' }, init: async ({ isSSRMode }) => {",
+    // Insert at the entry options, independently of the init callback's parameters.
+    'entryClient(App, routes, {',
+    "entryClient(App, routes, { routerOptions: { basename: '/acceptance' },",
   );
   await edit(
     'src/server.ts',

--- a/src/adapters/express/entry.tsx
+++ b/src/adapters/express/entry.tsx
@@ -31,6 +31,9 @@ export interface IEntrypointOptions<TAppProps = Record<string, any>> extends Pic
   | 'hydration'
   | 'nonce'
   | 'bootstrapScriptContent'
+  | 'documentHeaders'
+  | 'sessionCookie'
+  | 'protectPrivate'
 > {
   onServerCreated?: (app: Express, serverApi: ServerApi) => Promise<void> | void;
   onServerStarted?: (app: Express, serverApi: ServerApi, server: Server) => Promise<void> | void;

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -9,7 +9,7 @@ import type { IServerContext } from '@context/server';
 import emitEarlyHints from '@core/early-hints';
 import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
 import coreRender from '@core/render';
-import type { ISsrRequestContext } from '@core/render';
+import type { ICoreRenderOptions, ISsrRequestContext } from '@core/render';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import renderToStream from '@node/render-to-stream';
 import createRequestSignal from '@node/request-signal';
@@ -46,7 +46,10 @@ export interface IRenderParams<TAppProps = Record<string, any>> {
   handler: StaticHandler;
 }
 
-export interface IRenderOptions<TAppProps = Record<string, any>> {
+export interface IRenderOptions<TAppProps = Record<string, any>> extends Pick<
+  ICoreRenderOptions<TAppProps>,
+  'documentHeaders' | 'sessionCookie' | 'protectPrivate'
+> {
   hydration?: 'early' | 'footer';
   nonce?: string;
   bootstrapScriptContent?: string;
@@ -214,6 +217,9 @@ async function render(
     hydration,
     nonce,
     bootstrapScriptContent,
+    documentHeaders,
+    sessionCookie,
+    protectPrivate,
     abortDelay = 15000,
   }: IRenderOptions,
 ): Promise<void> {
@@ -289,6 +295,9 @@ async function render(
         hydration,
         nonce,
         bootstrapScriptContent,
+        documentHeaders,
+        sessionCookie,
+        protectPrivate,
 
         /**
          * Read custom state through the legacy request context.

--- a/src/core/cache-control.ts
+++ b/src/core/cache-control.ts
@@ -1,0 +1,82 @@
+export interface ICachePolicy {
+  public?: boolean;
+  private?: boolean;
+  maxAge?: number;
+  sMaxAge?: number;
+  staleWhileRevalidate?: number;
+  staleIfError?: number;
+  noStore?: boolean;
+  noCache?: boolean;
+  mustRevalidate?: boolean;
+  immutable?: boolean;
+}
+
+const directives = {
+  public: 'public',
+  private: 'private',
+  maxAge: 'max-age',
+  sMaxAge: 's-maxage',
+  staleWhileRevalidate: 'stale-while-revalidate',
+  staleIfError: 'stale-if-error',
+  noStore: 'no-store',
+  noCache: 'no-cache',
+  mustRevalidate: 'must-revalidate',
+  immutable: 'immutable',
+} as const;
+const seconds = new Set(['maxAge', 'sMaxAge', 'staleWhileRevalidate', 'staleIfError']);
+
+/** Build a deterministic Cache-Control field; durations are non-negative integer seconds. */
+const cacheControl = (policy: ICachePolicy): string => {
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+    throw new TypeError('Cache policy must be an object.');
+  }
+
+  for (const [name, value] of Object.entries(policy)) {
+    if (!Object.hasOwn(directives, name)) {
+      throw new TypeError(`Unknown cache directive: ${name}.`);
+    }
+
+    if (value === undefined) {
+      continue;
+    }
+
+    if (
+      seconds.has(name)
+        ? typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0
+        : typeof value !== 'boolean'
+    ) {
+      throw new TypeError(`Invalid cache directive: ${name}.`);
+    }
+  }
+
+  if (policy.public && policy.private) {
+    throw new TypeError('Cache policy cannot be both public and private.');
+  }
+
+  if (
+    (policy.noStore &&
+      (policy.public ||
+        policy.immutable ||
+        [...seconds].some((name) => policy[name as keyof ICachePolicy] !== undefined))) ||
+    (policy.private && policy.sMaxAge !== undefined) ||
+    (policy.immutable && (policy.noCache || policy.mustRevalidate)) ||
+    ((policy.noCache || policy.mustRevalidate) &&
+      (policy.staleWhileRevalidate !== undefined || policy.staleIfError !== undefined))
+  ) {
+    throw new TypeError('Cache policy contains conflicting directives.');
+  }
+
+  return Object.entries(directives)
+    .flatMap(([name, directive]) => {
+      const value = policy[name as keyof ICachePolicy];
+
+      if (value === undefined || value === false) {
+        return [];
+      }
+
+      return [seconds.has(name) ? `${directive}=${value}` : directive];
+    })
+    .join(', ');
+};
+
+export default cacheControl;

--- a/src/core/conditional-request.ts
+++ b/src/core/conditional-request.ts
@@ -1,0 +1,76 @@
+export interface IConditionalValidators {
+  /** Quoted entity tag, optionally prefixed with W/. Must identify the selected representation. */
+  etag?: string;
+  lastModified?: string | Date;
+}
+
+const entityTag = /^(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"$/;
+// HTTP-date includes the two obsolete wire formats; exclude Date.parse's ISO/year shortcuts.
+const httpDate =
+  /^(?:[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT|[A-Za-z]+, \d{2}-[A-Za-z]{3}-\d{2} \d{2}:\d{2}:\d{2} GMT|[A-Za-z]{3} [A-Za-z]{3} [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
+
+/**
+ * Evaluate GET/HEAD cache validators for an existing successful representation.
+ * If-None-Match takes precedence, uses weak comparison, and may contain a list.
+ * Call before sending a buffered response; this helper never reads or hashes a stream.
+ */
+const conditionalRequest = (
+  request: Request,
+  { etag, lastModified }: IConditionalValidators,
+): Response | undefined => {
+  if (etag !== undefined && !entityTag.test(etag)) {
+    throw new TypeError('ETag must be a quoted entity tag, optionally prefixed with W/.');
+  }
+
+  const modified = lastModified === undefined ? undefined : new Date(lastModified).getTime();
+
+  if (modified !== undefined && !Number.isFinite(modified)) {
+    throw new TypeError('Last-Modified must be a valid date.');
+  }
+
+  if (!['GET', 'HEAD'].includes(request.method)) {
+    return undefined;
+  }
+
+  const noneMatch = request.headers.get('If-None-Match');
+  let hasMatch = false;
+
+  if (noneMatch !== null) {
+    // Commas are legal inside an opaque tag, so splitting on commas is incorrect.
+    const list: string[] = noneMatch.match(/(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"|\*/g) ?? [];
+    const isValidList =
+      /^(?:\*|(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"(?:\s*,\s*(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*")*)$/.test(
+        noneMatch,
+      );
+
+    hasMatch =
+      isValidList &&
+      list.some(
+        (tag) => tag === '*' || (etag && tag.replace(/^W\//, '') === etag.replace(/^W\//, '')),
+      );
+  } else if (modified !== undefined) {
+    const since = request.headers.get('If-Modified-Since');
+    const timestamp = since !== null && httpDate.test(since) ? Date.parse(since) : NaN;
+
+    hasMatch =
+      Number.isFinite(timestamp) && Math.floor(modified / 1000) <= Math.floor(timestamp / 1000);
+  }
+
+  if (!hasMatch) {
+    return undefined;
+  }
+
+  const headers = new Headers();
+
+  if (etag !== undefined) {
+    headers.set('ETag', etag);
+  }
+
+  if (modified !== undefined) {
+    headers.set('Last-Modified', new Date(modified).toUTCString());
+  }
+
+  return new Response(null, { status: 304, headers });
+};
+
+export default conditionalRequest;

--- a/src/core/copy-loader-headers.ts
+++ b/src/core/copy-loader-headers.ts
@@ -1,0 +1,41 @@
+import type { StaticHandlerContext } from 'react-router';
+import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
+
+/**
+ * Copy only named fields, visiting matched routes root to leaf, loader before action.
+ * The first ordinary value wins (including Cache-Control); all cookies are appended.
+ */
+const copyLoaderHeaders = (
+  routerContext: Pick<StaticHandlerContext, 'matches' | 'loaderHeaders' | 'actionHeaders'>,
+  { allow }: { allow: readonly string[] },
+): Headers => {
+  const headers = new Headers();
+  const allowed = new Set(allow.map((name) => name.toLowerCase()));
+
+  allowed.delete('content-type');
+
+  for (const { route } of routerContext.matches) {
+    for (const source of [
+      routerContext.loaderHeaders[route.id],
+      routerContext.actionHeaders[route.id],
+    ]) {
+      if (!source) {
+        continue;
+      }
+
+      getHeaderEntries(source).forEach(([name, value]) => {
+        if (allowed.has(name.toLowerCase()) && !headers.has(name)) {
+          headers.set(name, value);
+        }
+      });
+
+      if (allowed.has('set-cookie')) {
+        getSetCookieHeaders(source).forEach((cookie) => headers.append('Set-Cookie', cookie));
+      }
+    }
+  }
+
+  return headers;
+};
+
+export default copyLoaderHeaders;

--- a/src/core/document-headers.ts
+++ b/src/core/document-headers.ts
@@ -1,0 +1,94 @@
+import type { StaticHandlerContext } from 'react-router';
+import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
+
+export interface IDocumentHeadersOptions {
+  /** Exact, case-sensitive cookie name. Empty values count as present. */
+  sessionCookie?: string;
+  /** Explicit escape hatch: let rules control credentialed responses too. Default: true. */
+  protectPrivate?: boolean;
+}
+
+export interface IDocumentHeaderContext {
+  request: Request;
+  routerContext?: StaticHandlerContext;
+  response: { headers: Headers };
+}
+
+export interface IDocumentRuleContext {
+  request: Request;
+  url: URL;
+  /** User-Agent heuristic for policy selection, never an authentication signal. */
+  isBot: boolean;
+  hasCookie: (name: string) => boolean;
+  routerContext?: StaticHandlerContext;
+}
+
+export interface IDocumentHeaderRule {
+  when: (context: IDocumentRuleContext) => boolean;
+  set: HeadersInit;
+}
+
+/** Test cookie presence without decoding, exposing, or comparing credential values. */
+export const hasCookie = (request: Request, name: string): boolean =>
+  (request.headers.get('Cookie') ?? '').split(';').some((cookie) => {
+    const separator = cookie.indexOf('=');
+
+    return separator !== -1 && cookie.slice(0, separator).trim() === name;
+  });
+
+/**
+ * Compute fresh document headers after hooks. Later rules replace ordinary fields;
+ * cookies append. Credential protection runs last unless explicitly disabled.
+ */
+const documentHeaders = (
+  rules: readonly IDocumentHeaderRule[],
+  { sessionCookie, protectPrivate = true }: IDocumentHeadersOptions = {},
+): ((context: IDocumentHeaderContext) => Headers) => {
+  return ({ request, routerContext, response }) => {
+    const headers = new Headers(response.headers);
+    const ruleContext: IDocumentRuleContext = {
+      request,
+      url: new URL(request.url),
+      isBot: /bot|crawler|spider|crawling/i.test(request.headers.get('User-Agent') ?? ''),
+      hasCookie: (name) => hasCookie(request, name),
+      routerContext,
+    };
+
+    for (const rule of rules) {
+      if (!rule.when(ruleContext)) {
+        continue;
+      }
+
+      const selected = new Headers(rule.set);
+
+      getHeaderEntries(selected).forEach(([name, value]) => headers.set(name, value));
+      getSetCookieHeaders(selected).forEach((cookie) => headers.append('Set-Cookie', cookie));
+    }
+
+    if (
+      protectPrivate &&
+      (headers.has('Set-Cookie') ||
+        request.headers.has('Authorization') ||
+        (sessionCookie && hasCookie(request, sessionCookie)))
+    ) {
+      headers.set('Cache-Control', 'private, no-store');
+    }
+
+    // Vary: Cookie fragments a shared cache by entire cookie strings. Bypass the
+    // cache on session presence instead; this helper never emits that Vary token.
+    const vary = (headers.get('Vary') ?? '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter((name) => name && name.toLowerCase() !== 'cookie');
+
+    if (vary.length) {
+      headers.set('Vary', vary.join(', '));
+    } else {
+      headers.delete('Vary');
+    }
+
+    return headers;
+  };
+};
+
+export default documentHeaders;

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -1,3 +1,4 @@
+import { hasCookie } from '@core/document-headers';
 import headResponse from '@core/head-response';
 import render from '@core/render';
 import type { ICoreRenderOptions, ICoreRenderParams, ISsrRequestContext } from '@core/render';
@@ -46,17 +47,23 @@ const createHandler = <TAppProps = Record<string, any>>(
    * Build fresh context for this request before invoking the renderer.
    */
   return async (request, executionContext) => {
+    const requestDiagnostics = isDiagnosticsEnabled(diagnostics)
+      ? new Diagnostics(new URL(request.url).pathname)
+      : undefined;
     const requestInit = await onRequest?.({ executionContext, request });
 
     if (requestInit instanceof Response) {
+      requestDiagnostics?.inspectCachePolicy(
+        requestInit.headers,
+        Boolean(options.sessionCookie && hasCookie(request, options.sessionCookie)),
+      );
+
       return headResponse(request, requestInit);
     }
 
     const context: ISsrRequestContext<TAppProps> = {
       appProps: (requestInit?.appProps ?? {}) as NonNullable<TAppProps>,
-      diagnostics: isDiagnosticsEnabled(diagnostics)
-        ? new Diagnostics(new URL(request.url).pathname)
-        : undefined,
+      diagnostics: requestDiagnostics,
       html: await getHtml(request),
       request,
       response: {

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -7,6 +7,8 @@ import { ServerProvider } from '@context/server';
 import type { IServerContext } from '@context/server';
 import composeHtml from '@core/compose-html';
 import DataStream from '@core/data-stream';
+import documentHeaders, { hasCookie } from '@core/document-headers';
+import type { IDocumentHeaderRule, IDocumentHeadersOptions } from '@core/document-headers';
 import headResponse from '@core/head-response';
 import { mergeResponseHeaders } from '@core/headers';
 import transformHtml from '@core/transform-html';
@@ -80,7 +82,11 @@ export interface ICoreRenderParams<TAppProps = Record<string, any>> {
   renderToStream: TRenderToStream;
 }
 
-export interface ICoreRenderOptions<TAppProps = Record<string, any>> {
+export interface ICoreRenderOptions<
+  TAppProps = Record<string, any>,
+> extends IDocumentHeadersOptions {
+  /** Opt in to document policies after onShellReady; redirects keep their header contract. */
+  documentHeaders?: readonly IDocumentHeaderRule[];
   /** Hydrate the parsed shell while deferred boundaries are still pending. */
   hydration?: 'early' | 'footer';
   nonce?: string;
@@ -163,7 +169,15 @@ const createShellErrorResponse = <TAppProps,>(
  */
 const prepareHtmlResponse = <TAppProps,>(
   context: ISsrRequestContext<TAppProps>,
-  { getState, onShellReady, hydration, nonce }: ICoreRenderOptions<TAppProps>,
+  {
+    getState,
+    onShellReady,
+    hydration,
+    nonce,
+    documentHeaders: rules,
+    sessionCookie,
+    protectPrivate,
+  }: ICoreRenderOptions<TAppProps>,
   dataStream: DataStream,
 ): IHtmlResponse => {
   const serverResponse = context.serverContext!.response;
@@ -176,6 +190,7 @@ const prepareHtmlResponse = <TAppProps,>(
   }
 
   const shell = onShellReady?.({ context }) ?? {};
+
   const isEarly = hydration === 'early' && context.isStream;
   const customState = buildCustomState(
     getState?.({ context }),
@@ -197,6 +212,10 @@ const prepareHtmlResponse = <TAppProps,>(
     footer = customState + dataStream.state(false) + dataStream.take() + footer;
   }
 
+  if (rules) {
+    context.response.headers = documentHeaders(rules, { sessionCookie, protectPrivate })(context);
+  }
+
   const headers = new Headers(context.response.headers);
 
   return { header, footer, headers, status: context.response.status };
@@ -205,7 +224,7 @@ const prepareHtmlResponse = <TAppProps,>(
 /**
  * Coordinate router queries, React rendering and the final Fetch response.
  */
-const render = async <TAppProps,>(
+const renderResponse = async <TAppProps,>(
   { createApp, handler, renderToStream }: ICoreRenderParams<TAppProps>,
   context: ISsrRequestContext<TAppProps>,
   {
@@ -221,6 +240,9 @@ const render = async <TAppProps,>(
     onShellReady,
     prepare,
     routerRequestContext,
+    documentHeaders: rules,
+    sessionCookie,
+    protectPrivate,
   }: ICoreRenderOptions<TAppProps>,
   executionContext?: ISsrExecutionContext,
 ): Promise<Response> => {
@@ -384,6 +406,9 @@ const render = async <TAppProps,>(
         onShellReady,
         hydration,
         nonce,
+        documentHeaders: rules,
+        sessionCookie,
+        protectPrivate,
       },
       dataStream,
     );
@@ -420,6 +445,23 @@ const render = async <TAppProps,>(
 
     throw error;
   }
+};
+
+/** Inspect the committed metadata, including redirect and shell-error responses. */
+const render = async <TAppProps,>(
+  params: ICoreRenderParams<TAppProps>,
+  context: ISsrRequestContext<TAppProps>,
+  options: ICoreRenderOptions<TAppProps>,
+  executionContext?: ISsrExecutionContext,
+): Promise<Response> => {
+  const response = await renderResponse(params, context, options, executionContext);
+
+  context.diagnostics?.inspectCachePolicy(
+    response.headers,
+    Boolean(options.sessionCookie && hasCookie(context.request, options.sessionCookie)),
+  );
+
+  return response;
 };
 
 export default render;

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,19 @@
+// Server-only HTTP helpers use Fetch primitives and can also run on the edge.
+export { default as cacheControl } from '@core/cache-control';
+
+export type { ICachePolicy } from '@core/cache-control';
+
+export { default as conditionalRequest } from '@core/conditional-request';
+
+export type { IConditionalValidators } from '@core/conditional-request';
+
+export { default as copyLoaderHeaders } from '@core/copy-loader-headers';
+
+export { default as documentHeaders } from '@core/document-headers';
+
+export type {
+  IDocumentHeaderContext,
+  IDocumentHeaderRule,
+  IDocumentHeadersOptions,
+  IDocumentRuleContext,
+} from '@core/document-headers';

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -2,6 +2,7 @@ import type { StaticHandlerContext } from 'react-router';
 import Logger from '@services/logger';
 
 type TDiagnosticCode =
+  | 'SSR_BOOST_CACHE_PRIVATE_LEAK'
   | 'SSR_BOOST_DEPRECATED_REQ_RES'
   | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
   | 'SSR_BOOST_STREAM_PROMISE_ABORTED'
@@ -208,6 +209,19 @@ class Diagnostics {
       this.warn(
         'SSR_BOOST_OUTLET_MISSING',
         `HTML shell for route ${JSON.stringify(this.route)} must supply both header and footer around exactly one ${OUTLET} outlet, with no outlet left in either half.`,
+      );
+    }
+  }
+
+  /** Warn about explicitly public documents carrying credentials without logging their values. */
+  public inspectCachePolicy(headers: Headers, hasSessionCookie: boolean): void {
+    if (
+      /(?:^|,)\s*public\s*(?:,|$)/i.test(headers.get('Cache-Control') ?? '') &&
+      (headers.has('Set-Cookie') || hasSessionCookie)
+    ) {
+      this.warn(
+        'SSR_BOOST_CACHE_PRIVATE_LEAK',
+        `Response for route ${JSON.stringify(this.route)} is public with Set-Cookie or a session cookie. Use private, no-store and bypass the shared cache for authenticated requests.`,
       );
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "useDefineForClassFields": true,
     "jsx": "react",
     "paths": {
+      "@lomray/vite-ssr-boost/*": ["./src/*"],
       "@__helpers__/*": ["./__helpers__/*"],
       "@__mocks__/*": ["./__mocks__/*"],
       "@adapters/*": ["./src/adapters/*"],
@@ -55,6 +56,7 @@
   "include": [
     "src",
     "__tests__",
+    "__fixtures__/caching",
     "__mocks__",
     "__helpers__",
     "types",


### PR DESCRIPTION
New server-side entry `@lomray/vite-ssr-boost/http` (Fetch primitives only, runs on Node and edge runtimes):

- `cacheControl(policy)` builds a validated `Cache-Control` value from typed fields and rejects contradictory directives.
- `documentHeaders(rules, { sessionCookie, protectPrivate })` computes the document headers from ordered `{ when, set }` rules with a `{ request, url, isBot, hasCookie, routerContext }` context; by default any response with `Set-Cookie`, an `Authorization` request header or the configured session cookie ends up `private, no-store`, and `Vary: Cookie` is never emitted. `createHandler` and the managed Express entry accept the same `documentHeaders`, `sessionCookie` and `protectPrivate` options and apply the rules after `onShellReady`.
- `copyLoaderHeaders(routerContext, { allow })` copies an allow-list of loader/action headers (shallowest route wins, cookies append, `Content-Type` never).
- `conditionalRequest(request, { etag, lastModified })` returns a bodyless 304 for matching GET/HEAD validators without touching a streamed body.
- Development diagnostic `SSR_BOOST_CACHE_PRIVATE_LEAK` for explicitly public responses that carry credentials.

The new guide `docs/guide/caching.md` covers guest CDN caching with a bounded stale-while-revalidate window and session bypass, the Cloudflare Worker Cache API wrapper and equivalent Cache Rules, Express behind Nginx, and conditional requests with streaming; every snippet is a compiled fixture with an executable test (the Nginx recipe runs live when an `nginx` binary is present, so CI now installs it).

Verified locally on Node 22.23.2: lint, types, 772 unit/integration tests (Node and workerd renderers, managed Express), build, size budgets (the `http` entry is server-only and excluded), `test:core:no-optional` with the packed `http` exports and declarations, docs build, the template acceptance with zero diagnostics, and the Playwright suite in Chromium including the new guest-to-private navigation test.
