### PR TITLE
feat: serve selected routes as the spa shell for incremental ssr rollout

### DIFF
--- a/__fixtures__/browser-template/client.jsx
+++ b/__fixtures__/browser-template/client.jsx
@@ -1,7 +1,7 @@
 import entry from '@lomray/vite-ssr-boost/browser/entry';
 import { App, routes } from './routes.jsx';
 void entry(App, routes, {
-  init: async () => {
-    if (!window.custom?.ready) throw new Error('Custom state missing before hydration');
+  init: async ({ isSSRMode }) => {
+    if (isSSRMode && !window.custom?.ready) throw new Error('Custom state missing before hydration');
   },
 });

--- a/__fixtures__/browser-template/routes.jsx
+++ b/__fixtures__/browser-template/routes.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from 'react';
-import { Await, Link, useLoaderData } from 'react-router';
+import { Await, Link, redirect, useLoaderData } from 'react-router';
 
 const Shell = ({ children }) => {
   const [count, setCount] = useState(0);
@@ -8,6 +8,8 @@ const Shell = ({ children }) => {
       <button onClick={() => setCount(count + 1)}>Count {count}</button>
       <Link to="/">Home</Link>
       <Link to="/deferred">Deferred</Link>
+      <Link to="/spa">SPA</Link>
+      <Link to="/public">Public</Link>
       {children}
     </main>
   );
@@ -31,6 +33,28 @@ const Deferred = () => {
   );
 };
 export const routes = [
+  {
+    path: '/spa',
+    loader: () => {
+      if (typeof window === 'undefined') throw new Error('SPA loader executed on server');
+      return 'Browser loader';
+    },
+    HydrateFallback: () => <p>Loading SPA</p>,
+    Component: () => <Shell><h1>SPA page</h1><p>{useLoaderData()}</p></Shell>,
+  },
+  {
+    path: '/spa-redirect',
+    loader: () => {
+      if (typeof window === 'undefined') throw new Error('SPA redirect executed on server');
+      return redirect('/public');
+    },
+    HydrateFallback: () => <p>Redirecting</p>,
+  },
+  {
+    path: '/public',
+    loader: ({ request }) => typeof document === 'undefined' ? request.headers.get('cookie') : document.cookie,
+    Component: () => <Shell><h1>Public page</h1><p data-cookie>{useLoaderData() || 'No cookie'}</p></Shell>,
+  },
   {
     path: '/',
     Component: () => (

--- a/__fixtures__/browser-template/server.jsx
+++ b/__fixtures__/browser-template/server.jsx
@@ -13,6 +13,7 @@ export const handler = (html) =>
     },
     {
       hydration: 'early',
+      ssr: { mode: 'exclude', routes: ['/spa', '/spa-redirect'] },
       diagnostics: false,
       getHtml: () => html,
       getState: () => ({ custom: { ready: true } }),

--- a/__tests__/browser/incremental-ssr.tsx
+++ b/__tests__/browser/incremental-ssr.tsx
@@ -1,0 +1,70 @@
+import { act, cleanup, waitFor } from '@testing-library/react';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import type { DataRouter } from 'react-router';
+import { redirect, useLoaderData } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import entry from '@browser/entry';
+
+let root: ReactDOM.Root | undefined;
+let router: DataRouter | undefined;
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  router?.dispose();
+  cleanup();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+  delete document.documentElement.dataset.forceSpa;
+  window.history.replaceState({}, '', '/');
+});
+
+describe('incremental SSR browser entry', () => {
+  it.each(['root', 'document'])(
+    'mounts the %s SPA marker, runs browser loaders and navigates both directions',
+    async (marker) => {
+      document.body.innerHTML = `<div id="app" ${marker === 'root' ? 'data-force-spa="1"' : ''}></div>`;
+      if (marker === 'document') document.documentElement.dataset.forceSpa = '1';
+      window.history.replaceState({}, '', '/spa');
+      Reflect.deleteProperty(window, '__staticRouterHydrationData');
+      const createRoot = vi.spyOn(ReactDOM, 'createRoot');
+      const hydrate = vi.spyOn(ReactDOM, 'hydrateRoot');
+      const loader = vi.fn(() => 'loaded in browser');
+      const redirectLoader = vi.fn(() => redirect('/public'));
+      const init = vi.fn(async (params) => {
+        router = params.router;
+      });
+      await act(async () => {
+        await entry(
+          ({ children }) => children,
+          [
+            {
+              path: '/spa',
+              loader,
+              HydrateFallback: () => null,
+              Component: () => <p>SPA: {useLoaderData() as string}</p>,
+            },
+            { path: '/public', Component: () => <p>Public page</p> },
+            { path: '/redirect', loader: redirectLoader, HydrateFallback: () => null },
+          ],
+          { rootId: 'app', init },
+        );
+      });
+      root = createRoot.mock.results[0].value;
+      expect(init.mock.calls[0][0].isSSRMode).toBe(false);
+      await waitFor(() => expect(document.body.textContent).toBe('SPA: loaded in browser'));
+      const documentRoot = document.getElementById('app');
+      await act(async () => router!.navigate('/public'));
+      expect(document.body.textContent).toBe('Public page');
+      await act(async () => router!.navigate('/spa'));
+      expect(document.body.textContent).toBe('SPA: loaded in browser');
+      expect(loader).toHaveBeenCalledTimes(2);
+      await act(async () => router!.navigate('/redirect'));
+      expect(router!.state.location.pathname).toBe('/public');
+      expect(redirectLoader).toHaveBeenCalledOnce();
+      expect(document.getElementById('app')).toBe(documentRoot);
+      expect(createRoot).toHaveBeenCalledOnce();
+      expect(hydrate).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/__tests__/core/spa-shell.ts
+++ b/__tests__/core/spa-shell.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import createSpaShell from '@core/spa-shell';
+import createSpaHtml from '@core/spa-html';
+
+describe('cached SPA shell', () => {
+  it('returns isolated shells and invalidates changed request-specific input', () => {
+    const getShell = createSpaShell();
+    const html = { header: '<html><head></head><body><div id="root">', footer: '</div></body></html>' };
+    const first = getShell(html);
+    first.header += 'request assets';
+    expect(getShell(html).header).not.toContain('request assets');
+    expect(html.header).not.toContain('data-force-spa');
+    expect(getShell({ ...html, header: html.header.replace('<head>', '<head><title>Changed</title>') }).header).toContain('Changed');
+    expect(getShell(html).header).not.toContain('Changed');
+  });
+
+  it('shares SPA index generation and handles quoted custom roots idempotently', () => {
+    const html = "<html><body><div data-id='root'></div><div id='app'></div></body></html>";
+    const marked = createSpaHtml(html, 'app');
+    expect(marked).toContain("id='app' data-force-spa=\"1\"");
+    expect(marked).toContain("<div data-id='root'></div>");
+    expect(createSpaHtml(marked, 'app')).toBe(marked);
+    const inferred = createSpaHtml(html);
+    expect(inferred).toContain('<html data-force-spa="1">');
+    expect(createSpaHtml(inferred)).toBe(inferred);
+  });
+});

--- a/__tests__/core/ssr-policy.ts
+++ b/__tests__/core/ssr-policy.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { createStaticHandler } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SsrPolicy, { ISsrPolicy } from '@core/ssr-policy';
+import Diagnostics from '@services/diagnostics';
+
+const human =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+const request = (path: string, agent = human) =>
+  new Request(`https://example.test${path}`, { headers: { 'User-Agent': agent } });
+const routes = createStaticHandler([
+  {
+    id: 'layout',
+    path: '/',
+    children: [
+      { id: 'home', index: true },
+      { id: 'public', path: 'public/:slug' },
+      { id: 'private', path: 'private' },
+      { id: 'fallback', path: '*' },
+    ],
+  },
+]).dataRoutes;
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('SSR policy patterns', () => {
+  it.each<[ISsrPolicy, string, string]>([
+    [{}, '/private', 'ssr'],
+    [{ mode: 'all', routes: ['/private'] }, '/elsewhere', 'ssr'],
+    [{ mode: 'include' }, '/', 'spa'],
+    [{ mode: 'exclude' }, '/', 'ssr'],
+    [{ mode: 'include', routes: ['/public/:slug'] }, '/public/hello?preview=1', 'ssr'],
+    [{ mode: 'include', routes: ['/public/:slug'] }, '/public/hello/extra', 'spa'],
+    [{ mode: 'include', routes: ['/public/:slug'] }, '/public/hello/', 'ssr'],
+    [{ mode: 'include', routes: ['/public/:slug'] }, '/public/%E0%A4%A', 'ssr'],
+    [{ mode: 'include', routes: ['/public{/:slug}'] }, '/public', 'ssr'],
+    [{ mode: 'include', routes: ['/public/*parts'] }, '/public/a/b', 'ssr'],
+    [{ mode: 'include', routes: [/^\/public\//] }, '/public/hello', 'ssr'],
+    [{ mode: 'exclude', routes: ['/private'] }, '/private?x=1', 'spa'],
+    [{ mode: 'exclude', routes: ['/private'] }, '/', 'ssr'],
+    [{ mode: 'exclude', routes: [/^\/private$/] }, '/private', 'spa'],
+    [{ mode: 'include', routes: ['/'] }, '/private', 'spa'],
+  ])('%j at %s selects %s', (config, path, expected) => {
+    expect(new SsrPolicy(config, routes).select(request(path))).toBe(expected);
+  });
+
+  it('resets cloned global and sticky regex state on every request', () => {
+    const pattern = /^\/private/gy;
+    pattern.lastIndex = 20;
+    const policy = new SsrPolicy({ mode: 'exclude', routes: [pattern] }, routes);
+    expect(policy.select(request('/private'))).toBe('spa');
+    expect(policy.select(request('/private'))).toBe('spa');
+    expect(pattern.lastIndex).toBe(20);
+  });
+
+  it('passes the same Request, parsed URL and bot flag to decide', () => {
+    const decide = vi.fn(({ url }) => (url.searchParams.has('spa') ? ('spa' as const) : undefined));
+    const policy = new SsrPolicy({ decide, bots: 'policy' }, routes);
+    const input = request('/private?spa=1', 'Googlebot');
+    expect(policy.select(input)).toBe('spa');
+    expect(decide).toHaveBeenCalledWith({ request: input, url: new URL(input.url), isBot: true });
+    expect(policy.select(request('/private'))).toBe('ssr');
+  });
+
+  it('keeps bots on SSR ahead of decide unless bots follows policy', () => {
+    const decide = vi.fn(() => 'spa' as const);
+    expect(new SsrPolicy({ decide }).select(request('/private', 'Googlebot'))).toBe('ssr');
+    expect(decide).not.toHaveBeenCalled();
+    expect(new SsrPolicy({ decide, bots: 'policy' }).select(request('/private', 'Googlebot'))).toBe(
+      'spa',
+    );
+  });
+
+  it('rejects malformed patterns at construction, before accepting requests', () => {
+    expect(() => new SsrPolicy({ mode: 'include', routes: ['/bad/:'] })).toThrow();
+  });
+});
+
+describe('SSR_BOOST_SSR_ROUTES startup override', () => {
+  it.each([
+    ['/', '/', 'ssr'],
+    ['/', '/private', 'spa'],
+    ['!/private', '/private', 'spa'],
+    ['!/private', '/', 'ssr'],
+    [' /public/:slug , !/public/draft, ', '/public/hello', 'ssr'],
+    ['/public/:slug,!/public/draft', '/public/draft', 'spa'],
+    ['/public/:slug,!/public/draft', '/', 'spa'],
+    ['', '/private', 'ssr'],
+  ])('%s at %s selects %s', (env, path, expected) => {
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', env);
+    const decide = vi.fn(() => 'spa' as const);
+    const policy = new SsrPolicy({ mode: 'include', routes: ['/ignored'], decide }, routes);
+    expect(policy.select(request(path))).toBe(expected);
+    expect(decide).not.toHaveBeenCalled();
+  });
+
+  it('snapshots overrides and retains bot protection across later env changes', () => {
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', '!/private');
+    const policy = new SsrPolicy({}, routes);
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', '/private');
+    expect(policy.select(request('/private'))).toBe('spa');
+    expect(policy.select(request('/private', 'Googlebot'))).toBe('ssr');
+    expect(new SsrPolicy({}, routes).select(request('/private'))).toBe('ssr');
+  });
+
+  it('rejects a bare exclusion marker', () => {
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', '!');
+    expect(() => new SsrPolicy()).toThrow();
+  });
+
+  it('works without Node globals in Fetch runtimes', () => {
+    const processDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'process')!;
+    try {
+      Reflect.deleteProperty(globalThis, 'process');
+      expect(new SsrPolicy({ mode: 'include' }).select(request('/'))).toBe('spa');
+    } finally {
+      Object.defineProperty(globalThis, 'process', processDescriptor);
+    }
+  });
+});
+
+describe('policy diagnostics', () => {
+  it('logs decisions once per pattern, with no concrete URL or query values', () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const policy = new SsrPolicy({ mode: 'include', routes: ['/public/:slug'] }, routes);
+    for (const path of ['/public/first?secret=one', '/public/second?secret=two']) {
+      policy.select(request(path), new Diagnostics(path, logger));
+    }
+    expect(logger.info).toHaveBeenCalledOnce();
+    expect(logger.info.mock.calls[0][0]).toContain(
+      'SSR_BOOST_SSR_POLICY: Pattern "/public/:slug" selects ssr via config include',
+    );
+    expect(logger.info.mock.calls[0][0]).not.toMatch(/secret|first|second/);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns once about a typo even when the router has a 404 catch-all', () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const policy = new SsrPolicy({ mode: 'exclude', routes: ['/privtae'] }, routes);
+    for (let count = 0; count < 2; count += 1) {
+      policy.select(request('/'), new Diagnostics('/', logger));
+    }
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn.mock.calls[0][0]).toContain(
+      'SSR_BOOST_SSR_POLICY_UNMATCHED: Pattern "/privtae" matches no known route id',
+    );
+  });
+
+  it('handles basenames and concrete dynamic URLs without typo warnings', () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const policy = new SsrPolicy(
+      { mode: 'include', routes: ['/app/public/hello', /^\/app\/private$/] },
+      routes,
+      '/app',
+    );
+    policy.select(request('/app/public/hello'), new Diagnostics('/', logger));
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('leaves default all mode silent', () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    new SsrPolicy().select(request('/'), new Diagnostics('/', logger));
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/integration/incremental-ssr.tsx
+++ b/__tests__/integration/incremental-ssr.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment node
+import { once } from 'node:events';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import React from 'react';
+import { createStaticHandler, redirect, useLoaderData } from 'react-router';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import entry from '@adapters/express/entry';
+import PrepareServer from '@adapters/express/prepare-server';
+import createServer from '@adapters/express/server';
+import createHandler from '@core/handler';
+import type { ISsrPolicy } from '@core/ssr-policy';
+import createSpaHtml from '@core/spa-html';
+import { createRouteAssetPreparer, loadHtmlShell } from '@node/production';
+import renderToStream from '@node/render-to-stream';
+import ServerConfig from '@services/server-config';
+
+const human =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+const html =
+  '<!doctype html><html><head><title>App shell</title></head><body><div id="root"><!--ssr-outlet--></div><script type="module" src="/entry.js"></script></body></html>';
+const App = ({ children }: React.PropsWithChildren) => <main>{children}</main>;
+let directory: string;
+const servers: Server[] = [];
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'ssr-boost-policy-'));
+  await mkdir(join(directory, 'client'));
+  await mkdir(join(directory, 'server'));
+  await writeFile(join(directory, 'client/index.html'), html);
+  await writeFile(
+    join(directory, 'server/assets-manifest.json'),
+    JSON.stringify({
+      private: [
+        { type: 'script', url: '/assets/private.js', weight: 2, isPreload: true, isNested: false },
+        { type: 'style', url: '/assets/private.css', weight: 1, isPreload: false, isNested: false },
+      ],
+      public: [
+        { type: 'style', url: '/assets/public.css', weight: 1, isPreload: false, isNested: false },
+      ],
+    }),
+  );
+});
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+afterAll(async () => rm(directory, { force: true, recursive: true }));
+
+const fixture = async (runtime: 'Fetch' | 'Express', ssr: ISsrPolicy, basename = '/') => {
+  const loader = vi.fn(
+    ({ request }: { request: Request }) => request.headers.get('cookie') ?? 'no cookie',
+  );
+  const privateLoader = vi.fn(() => redirect('/public'));
+  const lazy = vi.fn(async () => ({
+    Component: () => <p>Private rendered</p>,
+    loader: privateLoader,
+  }));
+  const onRouterReady = vi.fn(() => ({ isStream: false }));
+  const getState = vi.fn(() => ({ privateState: { secret: 'not in SPA' } }));
+  const onShellReady = vi.fn(() => ({}));
+  const onResponse = vi.fn(() => undefined);
+  const hooks = { onRouterReady, getState, onShellReady, onResponse };
+  const routes = [
+    { id: 'home', path: '/', Component: () => <p>Home SSR</p> },
+    {
+      id: 'public',
+      path: '/public',
+      loader,
+      Component: () => <p>Public: {useLoaderData() as string}</p>,
+    },
+    { id: 'private', path: '/private', lazy },
+    { id: 'auth', path: '/auth', loader: privateLoader },
+  ];
+  const getHtml = await loadHtmlShell({ indexFile: join(directory, 'client/index.html') });
+  let origin = 'http://example.test';
+  let send: (request: Request) => Promise<Response>;
+  const onRequest = vi.fn();
+
+  if (runtime === 'Fetch') {
+    send = createHandler(
+      {
+        handler: createStaticHandler(routes, { basename }),
+        createApp: (children) => <App>{children}</App>,
+        renderToStream,
+      },
+      {
+        ssr,
+        basename,
+        getHtml,
+        ...hooks,
+        diagnostics: true,
+        prepare: createRouteAssetPreparer({ buildDir: directory }),
+        onRequest: ({ request }) => {
+          onRequest(request);
+          if (new URL(request.url).pathname.endsWith('/auth')) {
+            return redirect('/login', 302);
+          }
+          return { headers: { 'X-Request-Hook': 'ran', 'Set-Cookie': 'checked=1; Path=/' } };
+        },
+      },
+    );
+  } else {
+    const config = ServerConfig.init({ isProd: true }, { root: directory, port: 0 });
+    const prepared = entry<Record<string, never>>(App, routes, {
+      ssr,
+      routerOptions: { basename },
+      middlewares: { compression: false, expressStatic: false },
+      init: () => ({
+        ...hooks,
+        onRequest: (req, res) => {
+          onRequest(req);
+          if (req.originalUrl.endsWith('/auth')) {
+            res.redirect(302, '/login');
+            return {};
+          }
+          res.setHeader('X-Request-Hook', 'ran');
+          res.setHeader('Set-Cookie', 'checked=1; Path=/');
+          return {};
+        },
+      }),
+    });
+    // Only replace module loading; run the real managed middleware, HTML cache,
+    // request bridge, route manifest, React renderer and HTTP response writer.
+    const initialized = await prepared.init!({ config });
+    vi.spyOn(PrepareServer.prototype, 'loadEntrypoint').mockResolvedValue({
+      ...prepared,
+      ...initialized,
+    });
+    const { run } = await createServer(config);
+    const server = run({ isPrintInfo: false }) as Server;
+    servers.push(server);
+    if (!server.listening) await once(server, 'listening');
+    origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    send = (request) => fetch(request, { redirect: 'manual' });
+  }
+
+  return {
+    loader,
+    privateLoader,
+    lazy,
+    onRequest,
+    hooks,
+    request: (path: string, init: RequestInit = {}) =>
+      send(
+        new Request(`${origin}${path}`, {
+          ...init,
+          headers: { 'User-Agent': human, ...init.headers },
+        }),
+      ),
+  };
+};
+
+describe.each(['Fetch', 'Express'] as const)('%s incremental SSR', (runtime) => {
+  it.each<ISsrPolicy>([
+    { mode: 'include', routes: ['/', '/public'] },
+    { mode: 'exclude', routes: ['/private'] },
+    { decide: ({ url }) => (url.pathname === '/private' ? 'spa' : 'ssr') },
+  ])('serves the SPA shell and route assets before loaders for %j', async (ssr) => {
+    const app = await fixture(runtime, ssr);
+    const spa = await app.request('/private?initial=1');
+    const body = await spa.text();
+    expect(spa.status).toBe(200);
+    expect(spa.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(spa.headers.get('Cache-Control')).toBe('no-store');
+    expect(spa.headers.get('X-Request-Hook')).toBe('ran');
+    expect(spa.headers.get('Set-Cookie')).toContain('checked=1');
+    expect(body).toContain('id="root" data-force-spa="1"');
+    expect(body).toContain('<link rel="stylesheet" href="/assets/private.css">');
+    expect(body).toContain(
+      '<link rel="modulepreload" as="script" crossorigin href="/assets/private.js">',
+    );
+    expect(body).toContain('src="/entry.js"');
+    expect(body).not.toMatch(/__staticRouterHydrationData|privateState|Private rendered|<main>/);
+    expect(app.lazy).not.toHaveBeenCalled();
+    expect(app.privateLoader).not.toHaveBeenCalled();
+    expect(app.onRequest).toHaveBeenCalledOnce();
+    for (const hook of Object.values(app.hooks)) expect(hook).not.toHaveBeenCalled();
+    const withoutAssets = body.replace(/<link\b[^>]*>/g, '').replace(/\n/g, '');
+    expect(withoutAssets).toBe(createSpaHtml(html).replace('<!--ssr-outlet-->', ''));
+
+    const ssrResponse = await app.request('/public', { headers: { Cookie: 'session=known' } });
+    const rendered = await ssrResponse.text();
+    expect(ssrResponse.status).toBe(200);
+    expect(rendered).toContain('session=known');
+    expect(rendered).toContain('window.__staticRouterHydrationData');
+    expect(rendered).not.toContain('data-force-spa');
+    expect(rendered).not.toContain('/assets/private');
+    expect(app.loader).toHaveBeenCalledOnce();
+
+    const reload = await (await app.request('/private')).text();
+    expect(reload).toBe(body);
+    expect(reload.match(/\/assets\/private.css/g)).toHaveLength(1);
+  });
+
+  it('forces Googlebot to SSR even when decide requests SPA', async () => {
+    const app = await fixture(runtime, { mode: 'include', routes: ['/'], decide: () => 'spa' });
+    const response = await app.request('/public', { headers: { 'User-Agent': 'Googlebot' } });
+    expect(await response.text()).toContain('window.__staticRouterHydrationData');
+    expect(app.loader).toHaveBeenCalledOnce();
+  });
+
+  it('allows bots to follow policy explicitly', async () => {
+    const app = await fixture(runtime, { mode: 'include', bots: 'policy' });
+    const response = await app.request('/public', { headers: { 'User-Agent': 'Googlebot' } });
+    expect(await response.text()).not.toContain('__staticRouterHydrationData');
+    expect(app.loader).not.toHaveBeenCalled();
+  });
+
+  it.each(['GET', 'HEAD'])(
+    'preserves onRequest auth redirects on SPA routes for %s',
+    async (method) => {
+      const app = await fixture(runtime, { mode: 'include', routes: ['/'] });
+      const response = await app.request('/auth', { method });
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/login');
+      if (method === 'HEAD') expect(await response.text()).toBe('');
+      else await response.text();
+      expect(app.privateLoader).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns bodyless HEAD with SPA metadata and no loaders', async () => {
+    const app = await fixture(runtime, { mode: 'exclude', routes: ['/private'] });
+    const response = await app.request('/private', { method: 'HEAD' });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(await response.text()).toBe('');
+    expect(app.lazy).not.toHaveBeenCalled();
+  });
+
+  it('matches URL paths with the router basename for SPA assets', async () => {
+    const app = await fixture(runtime, { mode: 'exclude', routes: ['/app/private'] }, '/app');
+    const response = await app.request('/app/private');
+    expect(await response.text()).toContain('/assets/private.js');
+    expect(app.lazy).not.toHaveBeenCalled();
+  });
+
+  it('snapshots environment rollback rules without rebuilding or invoking decide', async () => {
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', '!/public');
+    const decide = vi.fn(() => 'ssr' as const);
+    const app = await fixture(runtime, { decide });
+    vi.stubEnv('SSR_BOOST_SSR_ROUTES', '/public');
+    expect(await (await app.request('/public')).text()).not.toContain(
+      '__staticRouterHydrationData',
+    );
+    expect(await (await app.request('/')).text()).toContain('__staticRouterHydrationData');
+    expect(
+      await (await app.request('/public', { headers: { 'User-Agent': 'Googlebot' } })).text(),
+    ).toContain('__staticRouterHydrationData');
+    expect(decide).not.toHaveBeenCalled();
+  });
+
+  it('keeps the production shell in memory across repeated requests', async () => {
+    const app = await fixture(runtime, { mode: 'exclude', routes: ['/private'] });
+    const body = await (await app.request('/private')).text();
+    const index = join(directory, 'client/index.html');
+    const original = await readFile(index, 'utf8');
+    try {
+      await writeFile(index, 'not a usable shell');
+      expect(await (await app.request('/private')).text()).toBe(body);
+    } finally {
+      await writeFile(index, original);
+    }
+  });
+});
+
+describe('SPA shells and document header rules', () => {
+  it('applies documentHeaders rules to the SPA shell, with the privacy default for sessions', async () => {
+    const getHtml = await loadHtmlShell({ indexFile: join(directory, 'client/index.html') });
+    const send = createHandler(
+      {
+        handler: createStaticHandler([{ id: 'private', path: '/private', Component: () => <p>SPA</p> }]),
+        createApp: (children) => <App>{children}</App>,
+        renderToStream,
+      },
+      {
+        ssr: { mode: 'exclude', routes: ['/private'] },
+        getHtml,
+        sessionCookie: 'session',
+        documentHeaders: [{ when: () => true, set: { 'Cache-Control': 'public, max-age=30' } }],
+      },
+    );
+    const guest = await send(new Request('http://example.test/private', { headers: { 'user-agent': human } }));
+    const member = await send(
+      new Request('http://example.test/private', {
+        headers: { 'user-agent': human, cookie: 'session=abc' },
+      }),
+    );
+
+    expect(await guest.text()).toContain('data-force-spa="1"');
+    expect(guest.headers.get('Cache-Control')).toBe('public, max-age=30');
+    expect(member.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+});

--- a/browser-tests/incremental-ssr.spec.mjs
+++ b/browser-tests/incremental-ssr.spec.mjs
@@ -1,0 +1,65 @@
+import { test, expect, chromium } from '@playwright/test';
+
+test('SPA and SSR routes share navigation, reloads, cookies and browser loader redirects', async () => {
+  let browser;
+  try {
+    browser = await chromium.launch({ timeout: 10_000 });
+  } catch (error) {
+    const reason = error.message.split('\n').find((line) => line.includes('Permission denied')) || error.message.split('\n')[0];
+    console.info(`SKIP Chromium: ${reason}`);
+    test.skip(true, `Chromium cannot launch in this environment: ${reason}`);
+    return;
+  }
+  try {
+    // Headless Chromium reports HeadlessChrome, which isbot classifies as a crawler and the
+    // fixture's bots: 'ssr' default would then render /spa on the server.
+    const context = await browser.newContext({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' });
+    await context.addCookies([{ name: 'session', value: 'known', url: 'http://127.0.0.1:4179' }]);
+    const page = await context.newPage();
+    const errors = [];
+    let documents = 0;
+    page.on('request', (request) => {
+      if (request.isNavigationRequest() && request.frame() === page.mainFrame()) documents += 1;
+    });
+    page.on('pageerror', (error) => errors.push(error.message));
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+
+    const spa = await page.goto('http://127.0.0.1:4179/spa');
+    expect(await spa.text()).not.toContain('__staticRouterHydrationData');
+    await expect(page.getByRole('heading', { name: 'SPA page' })).toBeVisible();
+    await expect(page.getByText('Browser loader')).toBeVisible();
+    await page.evaluate(() => { window.documentIdentity = 'same document'; });
+    await page.getByRole('link', { name: 'Public', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Public page' })).toBeVisible();
+    await page.getByRole('link', { name: 'SPA', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'SPA page' })).toBeVisible();
+    expect(documents).toBe(1);
+    expect(await page.evaluate(() => window.documentIdentity)).toBe('same document');
+
+    await page.reload();
+    await expect(page.getByText('Browser loader')).toBeVisible();
+    const publicResponse = await page.goto('http://127.0.0.1:4179/public');
+    const publicHtml = await publicResponse.text();
+    expect(publicHtml).toContain('__staticRouterHydrationData');
+    expect(publicHtml).toContain('session=known');
+    await expect(page.locator('[data-cookie]')).toContainText('session=known');
+    const initialDocuments = documents;
+    await page.getByRole('link', { name: 'SPA', exact: true }).click();
+    await expect(page.getByText('Browser loader')).toBeVisible();
+    await page.getByRole('link', { name: 'Public', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Public page' })).toBeVisible();
+    expect(documents).toBe(initialDocuments);
+
+    const redirectShell = await page.goto('http://127.0.0.1:4179/spa-redirect', { waitUntil: 'commit' });
+    expect(redirectShell.status()).toBe(200);
+    expect(await redirectShell.text()).toContain('data-force-spa="1"');
+    await expect(page).toHaveURL('http://127.0.0.1:4179/public');
+    await expect(page.getByRole('heading', { name: 'Public page' })).toBeVisible();
+    expect(documents).toBe(initialDocuments + 1);
+    expect(errors).toEqual([]);
+  } finally {
+    await browser.close();
+  }
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: 'Introduction', link: '/' },
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Migrate an Existing SPA', link: '/guide/migrate-existing-spa' },
+          { text: 'Incremental SSR', link: '/guide/incremental-ssr' },
           { text: 'Upgrade from 7 to 8', link: '/guide/upgrade-v8' },
           { text: 'Choosing an SSR Approach', link: '/guide/choosing' },
           { text: 'Rendering Modes', link: '/guide/rendering-modes' },

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -6,6 +6,8 @@ Use this page as a grounding reference for tools working with the package.
 
 `@lomray/vite-ssr-boost` adds SSR to React Router apps in Data mode, without moving to Framework mode and without rewriting the app. Keep the Vite configuration, route objects and components; use the same application for SSR or SPA output.
 
+For [incremental SSR](/guide/incremental-ssr), managed Express entries and Fetch `createHandler` accept an `ssr` policy with include/exclude patterns and per-request decisions, default crawler SSR, and a restart-only `SSR_BOOST_SSR_ROUTES` rollback override.
+
 Data mode, not Framework mode. The server uses `createStaticHandler` and `StaticRouterProvider`, and the browser uses route objects with `createBrowserRouter`; see React Router's [mode definitions](https://reactrouter.com/start/modes).
 
 The package declares `engines.node: ">=22.12.0"` and peers for Vite `>=5`, React and React DOM `>=18.2.0`, and React Router `>=7.0.1`. The template tooling uses Node 22.23.2. Check the selected React Router and build tool versions for further engine requirements.

--- a/docs/api/browser-entry.md
+++ b/docs/api/browser-entry.md
@@ -54,6 +54,8 @@ void entryClient(App, routes, {
 
 Those values are passed to `App` as `client`.
 
+`isSSRMode` reflects the current document: it is `false` for an [incremental SSR](/guide/incremental-ssr) SPA shell even when the shared browser bundle was built for SSR.
+
 ## `createRouter`
 
 The default is `createBrowserRouter`.

--- a/docs/api/server-entry.md
+++ b/docs/api/server-entry.md
@@ -16,6 +16,7 @@ Options:
 
 ```ts
 interface IEntryServerOptions<TAppProps> {
+  ssr?: ISsrPolicy;
   abortDelay?: number;
   init?: (params: { config: ServerConfig }) =>
     IEntrypointOptions<TAppProps> | Promise<IEntrypointOptions<TAppProps>>;
@@ -39,6 +40,30 @@ The entry returns a render definition consumed by the runtime server. It include
 - `abortDelay`
 - optional loggers
 - optional middleware config
+
+## `ssr`
+
+Select SSR or the SPA shell per incoming URL, before route loaders run:
+
+```ts
+interface ISsrPolicy {
+  mode?: 'all' | 'include' | 'exclude';
+  routes?: (string | RegExp)[];
+  bots?: 'ssr' | 'policy';
+  decide?: (params: { request: Request; url: URL; isBot: boolean }) =>
+    'ssr' | 'spa' | undefined;
+}
+
+entryServer(App, routes, {
+  ssr: { mode: 'include', routes: ['/', '/articles/:slug'] },
+});
+```
+
+`all` is the default. `include` uses SSR only for matching URL pathnames; `exclude` serves matches as SPA. Strings use path-to-regexp 8 syntax, including named wildcards and brace optional groups; RegExp patterns use their own flags. Include the router basename in patterns. `decide` overrides the configured mode per request, with `undefined` falling back to the route policy. `bots: 'ssr'` defaults to forcing detected crawlers to SSR ahead of all other decisions; use `'policy'` to opt out.
+
+At entry creation, `SSR_BOOST_SSR_ROUTES` overrides `mode`, `routes` and `decide`, preserving `bots`. Comma-separated positive patterns form an include list; `!` patterns exclude URLs and win over includes. With only exclusions, other URLs stay SSR. An empty value selects SSR everywhere. Restart after changes; no rebuild is needed.
+
+SPA responses retain `onRequest` and route asset preparation, use status 200 and the `data-force-spa` mount marker, and omit router/custom state and SSR render hooks. Active policies default documents to `Cache-Control: no-store` unless `onRequest` supplies a cache policy. The same `ssr` option is available on Fetch `createHandler`. See [Incremental SSR](/guide/incremental-ssr) for the full reference, lifecycle trade-offs and rollback recipe.
 
 ## Request lifecycle hooks
 

--- a/docs/guide/incremental-ssr.md
+++ b/docs/guide/incremental-ssr.md
@@ -1,0 +1,125 @@
+# Incremental SSR
+
+Choose SSR or the SPA shell for each incoming URL in one application. Both modes use the same browser bundle and React Router route tree, so client navigation between them stays in the current document.
+
+## Roll out public pages first
+
+After [migrating your SPA](/guide/migrate-existing-spa), start with `include` and the public pages that need search indexing or link previews:
+
+```ts
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import App from './app';
+import routes from './routes';
+
+export default entryServer(App, routes, {
+  ssr: {
+    mode: 'include',
+    routes: ['/', '/about', '/articles/:slug'],
+    bots: 'ssr',
+  },
+  init: () => ({
+    onRequest: (req, res) => {
+      if (req.originalUrl.startsWith('/account') && !req.headers.cookie) {
+        res.redirect('/login');
+        return { shouldCancel: true };
+      }
+      return {};
+    },
+  }),
+});
+```
+
+The cookie check above only illustrates where an auth redirect belongs; use your application's session validation. `onRequest` runs before the policy, including for crawlers. Add public URL patterns as you verify their HTML, metadata, data loading and browser behavior. Later, use `exclude` for the remaining SPA pages or remove the option to SSR every URL.
+
+Keep the default `bots: 'ssr'` so detected crawlers receive SSR even on URLs served as SPA to people. Those routes must still support server execution and enforce authentication. Existing `onlyClient` components keep their browser-only behavior; this option does not make them server-renderable. Bot detection uses the `isbot` user-agent matcher. To wait for all suspended HTML, keep your existing bot-aware `onRouterReady` streaming decision.
+
+## Roll back without rebuilding
+
+Restart the same server build with a changed environment variable:
+
+```bash
+SSR_BOOST_SSR_ROUTES='!/details' npm run start:ssr
+```
+
+This serves `/details` as SPA to people while keeping other URLs on SSR. Googlebot still receives SSR for `/details`. No rebuild or separate browser bundle is needed. Apply the variable to every server process and restart them; changing `process.env` after creating the entry/handler does not change its policy. Set the variable in the process environment before startup, rather than in a client-side `VITE_*` variable.
+
+`SSR_BOOST_SSR_ROUTES` replaces the configured `mode`, `routes` **and `decide`**, preserving `bots`. It accepts comma-separated path patterns, trims whitespace and ignores empty items:
+
+| Value | Result for people |
+| --- | --- |
+| `/,/articles/:slug` | SSR only for the listed URLs |
+| `!/details,!/account{/*rest}` | SPA for these patterns; SSR elsewhere |
+| `/,/articles/:slug,!/articles/draft` | Include the public URLs, with exclusions winning |
+| Empty string | SSR for all URLs; disable the configured `decide` |
+
+Unset the variable and restart to restore the application configuration. Environment values use string patterns, not JavaScript regular expression literals. Malformed patterns fail during entry/handler creation instead of silently changing the rollout.
+
+To keep an existing include rollout while rolling back one URL, repeat its include list and add the exclusion, for example `SSR_BOOST_SSR_ROUTES='/,/articles/:slug,!/articles/draft'`. This keeps unlisted URLs on SPA. A value containing only exclusions selects SSR for every other URL.
+
+Active policies default document responses to `Cache-Control: no-store`, so cached SSR/SPA documents do not obscure a rollback. If `onRequest` supplies a cache policy, it takes precedence: configure your CDN's cache keys and invalidation to account for bot and request-specific decisions before enabling document caching. Static asset caching is unchanged. [Document header rules](/guide/caching#documentheaders-rules-options) apply to SPA shells as well as SSR documents, including the private default for requests carrying the session cookie.
+
+## Configuration reference
+
+Pass `ssr` in the third argument of the [managed Express entry](/api/server-entry#ssr), or in the options argument of Fetch [`createHandler`](/guide/runtime-adapters#create-a-fetch-handler):
+
+```ts
+interface ISsrPolicy {
+  mode?: 'all' | 'include' | 'exclude';
+  routes?: (string | RegExp)[];
+  bots?: 'ssr' | 'policy';
+  decide?: (params: {
+    request: Request;
+    url: URL;
+    isBot: boolean;
+  }) => 'ssr' | 'spa' | undefined;
+}
+```
+
+| Option | Default | Behavior |
+| --- | --- | --- |
+| `mode` | `'all'` | `all` renders every URL; `include` renders only matching URLs; `exclude` serves matching URLs as SPA. |
+| `routes` | `[]` | String or RegExp patterns matched against `url.pathname`, including any router basename. An empty include list makes every URL SPA; an empty exclude list makes every URL SSR. `all` ignores the list. |
+| `bots` | `'ssr'` | Detected crawlers always receive SSR, ahead of `decide` and the environment override. `'policy'` makes them follow the same decisions as other requests. |
+| `decide` | — | Synchronously override the configured mode for one request; return `undefined` to use the route policy. Receives the original Fetch Request, parsed URL and detected bot flag. |
+
+String patterns use path-to-regexp 8 syntax: `/articles/:slug` for one segment, `/account/*rest` for one or more segments, and `/account{/*rest}` for the account root and all descendants. Optional parts use braces, such as `/articles{/:slug}`. String matching covers the entire pathname, is case-insensitive and permits a trailing slash. Query strings are ignored by patterns and remain available to `decide`. Use a RegExp when you need different matching rules, for example `/^\/internal(?:\/|$)/`; repeated requests do not share its mutable `lastIndex`.
+
+For a request-dependent switch:
+
+```ts
+ssr: {
+  mode: 'include',
+  routes: ['/', '/articles/:slug'],
+  decide: ({ url }) => url.searchParams.get('render') === 'spa' ? 'spa' : undefined,
+},
+```
+
+Fetch handlers use the same option:
+
+```ts
+const handle = createHandler(
+  { handler: createStaticHandler(routes), createApp, renderToStream },
+  {
+    getHtml,
+    prepare: createRouteAssetPreparer({ buildDir: './build' }),
+    ssr: { mode: 'exclude', routes: ['/details'] },
+    onRequest: ({ request }) => initializeRequest(request),
+  },
+);
+```
+
+`getHtml` supplies the existing document shell. On Node, [`loadHtmlShell`](/api/node-production) reads it once; on edge runtimes, supply an in-memory shell and your normal asset `prepare` hook. For a router mounted at `/app`, pass `basename: '/app'` to both `createStaticHandler` and `createHandler`, and write policy patterns such as `/app/details`. Managed Express takes the basename from `routerOptions`.
+
+## What happens on SPA URLs
+
+The server runs `onRequest`, selects the policy, matches route structure without importing lazy server modules or running loaders/actions, and injects the matched route's CSS and module preloads. Fetch `prepare` hooks receive `context.matches` and `context.isSpa`; `routerContext` is absent on SPA responses. The managed server prepares Vite assets automatically.
+
+The response is the empty application shell with status 200, `Content-Type: text/html; charset=utf-8`, and `data-force-spa="1"`. It uses the same shell generation as `spaIndex`; enabling an extra `index-spa.html` build artifact is optional. Production file contents and generated shells are cached in memory per process. Each request gets a fresh mutable shell for asset injection; development template changes invalidate generation. Fetch `getHtml` still runs per request, so request-specific shells are not reused for a different request.
+
+SPA documents contain no router hydration data or `getState` snapshots. SSR render hooks (`onRouterReady`, `onShellReady`, `onResponse`, `getState`, and render error hooks) do not run for them. Keep authentication and HTTP redirects in `onRequest`. An Express hook can send a response and return `shouldCancel`; a Fetch hook can return a Response. HEAD returns the same metadata without a body.
+
+The browser entry mounts with `createRoot` and reports `isSSRMode: false` to its `init` hook. Loaders and loader redirects execute in the browser, as they already do during client navigation. Keep those loaders browser-compatible and use APIs for server-only work. A loader redirect on an initial SPA URL changes the client route after the 200 shell; it is not an HTTP redirect. Unknown SPA URLs also return the 200 shell and let the browser router render its fallback. Direct non-JavaScript form submissions to SPA-selected URLs do not run server actions.
+
+Links and router navigation between SSR and SPA routes use the shared browser router without reloading the document. Reloading a SPA URL mounts again; a direct link to an SSR URL still passes cookies through the Fetch request to its loaders.
+
+SPA routes render no application content server-side. Crawlers see only the shell when they follow the SPA policy, including with `bots: 'policy'`; the default bot override keeps detected crawlers on SSR. Check [policy diagnostics](/reference/diagnostics#ssr_boost_ssr_policy) during development for the chosen policy and misspelled patterns.

--- a/docs/guide/migrate-existing-spa.md
+++ b/docs/guide/migrate-existing-spa.md
@@ -192,6 +192,10 @@ Read public values through `import.meta.env` and keep secrets out of `VITE_*` va
 
 Compare the server HTML with the initial browser render, including data, dates, randomness and browser-dependent branches. [React's hydration troubleshooting](https://react.dev/reference/react-dom/client/hydrateRoot#troubleshooting) requires those outputs to match; correct their inputs before hiding a warning.
 
+## Roll out SSR one URL at a time
+
+Use [incremental SSR](/guide/incremental-ssr) to start with `ssr: { mode: 'include', routes: ['/', '/articles/:slug'] }` in your managed server entry, widen the public pages over time, and keep the remaining URLs on the SPA shell in the same build. Crawlers stay on SSR by default. Restart with `SSR_BOOST_SSR_ROUTES='!/details'` to roll a URL back to SPA without rebuilding; keep authentication redirects in `onRequest` because SPA route loaders execute in the browser.
+
 ## Going back to SPA
 
 Run `npm run build:spa`, then `npm run start:spa`; both scripts select `--focus-only client`. The app keeps the same route objects and browser entry, and the build omits the SSR server. Run `npm run build` again before returning to `npm run start:ssr`.

--- a/docs/guide/rendering-modes.md
+++ b/docs/guide/rendering-modes.md
@@ -26,6 +26,8 @@ The package uses `data-force-spa="1"` on the generated SPA index to tell the bro
 
 ## Switching between SSR and SPA
 
+For per-request selection inside one build, use the [incremental SSR policy](/guide/incremental-ssr): include public URLs, keep other pages on the SPA shell, and roll URLs back with a process environment override.
+
 This is one of the practical strengths of the package.
 
 - During normal SSR, `entryClient` hydrates.

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -9,11 +9,13 @@ At runtime the package:
 1. creates or reuses server config
 2. loads your server entry
 3. calls `onRequest`
-4. queries React Router static handler
+4. applies the [SSR policy](/guide/incremental-ssr), serving the SPA shell when selected or querying the React Router static handler for SSR
 5. decides whether to stream or wait
 6. writes HTML, state and response mutations
 
 That is where the customization hooks fit.
+
+Policy-selected SPA responses run `onRequest` and asset preparation, then return the shell without loaders or SSR render hooks. Fetch asset preparation can use `context.matches` in both modes; `context.isSpa` identifies a SPA response and `routerContext` exists only after an SSR query.
 
 Render hooks receive a [context](/api/server-entry#hook-context) with the shared Fetch `request` and live Express `req` / `res`; `onRequest` receives `(req, res)` before that context is created.
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -44,6 +44,18 @@ Accessors are installed only in managed development with diagnostics enabled, us
 `SSR_BOOST_DIAGNOSTICS=0` disables them. Production keeps plain properties with no accessor or
 warning overhead, even when other diagnostics are enabled with `SSR_BOOST_DIAGNOSTICS=1`.
 
+## SSR_BOOST_SSR_POLICY {#ssr_boost_ssr_policy}
+
+An info message explains whether a URL pattern selected `ssr` or `spa`, and whether the decision came from the configured include/exclude policy, `decide`, `SSR_BOOST_SSR_ROUTES`, or `bots: 'ssr'`. It appears for active [incremental SSR policies](/guide/incremental-ssr), once per pattern and distinct decision per process, using the development logger and diagnostics settings above. Plain default `all` mode stays silent; an `all` policy with `decide` is active.
+
+The message identifies patterns rather than concrete dynamic parameters, cookies or query values. Check it when a URL uses an unexpected mode. The environment override replaces the configured route policy and `decide`; bot protection has highest priority. This is informational and does not count as a warning. SPA shells intentionally have no hydration state and do not trigger `SSR_BOOST_HYDRATION_STATE_MISSING`.
+
+## SSR_BOOST_SSR_POLICY_UNMATCHED {#ssr_boost_ssr_policy_unmatched}
+
+An include/exclude pattern has no match among known route ids' declared URL paths. The warning checks nested paths and router basenames without importing lazy route modules or running loaders. A global 404 catch-all does not hide typos. Each distinct unmatched pattern warns once per process under the diagnostics settings above.
+
+Check spelling, include the URL basename, and use path patterns rather than component filenames or generated numeric route ids. The check is advisory and compares declared paths, so a RegExp restricted to particular dynamic parameter values may need manual verification. Invalid path-to-regexp string syntax instead throws during entry/handler creation, even with diagnostics disabled.
+
 ## SSR_BOOST_LOADER_NOT_SERIALIZABLE {#ssr_boost_loader_not_serializable}
 
 ### When it appears

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "devalue": "^5.9.2",
         "diff": "^9.0.0",
         "hoist-non-react-statics": "^3.3.2",
+        "isbot": "^5.2.2",
         "json5": "^2.2.3",
         "parse5": "^8.0.1",
+        "path-to-regexp": "^8.4.2",
         "semver": "^7.8.5"
       },
       "bin": {
@@ -10304,6 +10306,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isbot": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.2.2.tgz",
+      "integrity": "sha512-iQcBXcd+Rv/pkubRyGh2utW2j1oPG5hZY6TUhVPpqK4G+o3IbxpJNx04hgksjc/N7GK5pEorUxDeg31cFgEk/w==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -14066,7 +14077,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"

--- a/package.json
+++ b/package.json
@@ -78,8 +78,10 @@
     "devalue": "^5.9.2",
     "diff": "^9.0.0",
     "hoist-non-react-statics": "^3.3.2",
+    "isbot": "^5.2.2",
     "json5": "^2.2.3",
     "parse5": "^8.0.1",
+    "path-to-regexp": "^8.4.2",
     "semver": "^7.8.5"
   },
   "optionalDependencies": {

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -27,6 +27,8 @@ const acceptance = {
   candidateTtfb: undefined,
   chunks: [],
   deferred: [],
+  policyInfo: 0,
+  diagnosticsWarnings: 0,
 };
 const cli = join(directory, 'node_modules', '@lomray', 'vite-ssr-boost', 'cli.js');
 const runtimePath = [
@@ -55,30 +57,42 @@ const getPort = async () => {
   return address.port;
 };
 
-const run = async (args) => {
+const recordDiagnostics = (output) => {
+  for (const [, code] of stripVTControlCharacters(output).matchAll(/\b(SSR_BOOST_[A-Z_]+)(?=:|\])/g)) {
+    if (code === 'SSR_BOOST_SSR_POLICY') acceptance.policyInfo += 1;
+    else acceptance.diagnosticsWarnings += 1;
+  }
+};
+
+const start = (args, env = {}) => {
   const child = spawn(process.execPath, [cli, ...args], {
     cwd: directory,
-    env: { ...process.env, PATH: runtimePath },
-    stdio: 'inherit',
+    env: { ...process.env, PATH: runtimePath, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
-  const [code] = await once(child, 'exit');
+  let output = '';
+  child.stdout.on('data', (chunk) => { output += chunk; process.stdout.write(chunk); });
+  child.stderr.on('data', (chunk) => { output += chunk; process.stderr.write(chunk); });
+  child.closed = once(child, 'close').then((result) => {
+    recordDiagnostics(output);
+    return result;
+  });
+  return child;
+};
+
+const run = async (args) => {
+  const [code] = await start(args).closed;
 
   if (code !== 0) {
     throw new Error(`ssr-boost ${args[0]} exited with code ${code}.`);
   }
 };
 
-const start = (args) =>
-  spawn(process.execPath, [cli, ...args], {
-    cwd: directory,
-    env: { ...process.env, PATH: runtimePath },
-    stdio: 'inherit',
-  });
-
 const hasExited = (child) => child.exitCode !== null || child.signalCode !== null;
 
 const stop = async (child) => {
   if (hasExited(child)) {
+    await child.closed;
     return;
   }
 
@@ -99,6 +113,7 @@ const stop = async (child) => {
     child.kill('SIGKILL');
     await killed;
   }
+  await child.closed;
 };
 
 const waitUntilReady = async (origin, child) => {
@@ -336,6 +351,8 @@ const reportAcceptance = async () => {
       `| ${mode} chunks (streamed / buffered / decoded gzip) | ${streamed} / ${buffered} / ${gzip ?? 'n/a'} | — |`),
     ...acceptance.deferred.map(({ mode, settleMs }) =>
       `| ${mode} deferred settle delay (first HTML to resolve frame) | ${milliseconds(settleMs)} | > 100 ms |`),
+    `| SSR_BOOST_SSR_POLICY info lines | ${acceptance.policyInfo} | informational |`,
+    `| Other SSR_BOOST_ diagnostics | ${acceptance.diagnosticsWarnings} | 0 |`,
     '',
   ].join('\n');
   console.info(markdown);
@@ -447,6 +464,7 @@ const verifyColdStart = async () => {
     await closed;
     output = stripVTControlCharacters(output);
     console.info(output);
+    recordDiagnostics(output);
   }
 
   assert.doesNotMatch(
@@ -473,6 +491,52 @@ const verifySpa = async (origin) => {
     await script.arrayBuffer();
   }
   console.info('SPA: root, deep links, fallback and client assets passed');
+};
+
+const verifyIncremental = async (origin, mode) => {
+  const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+  const details = await fetch(`${origin}/details`, { headers: { 'User-Agent': userAgent } });
+  const shell = await details.text();
+  assert.equal(details.status, 200, `${mode} SPA /details`);
+  assert.match(details.headers.get('content-type'), /text\/html/);
+  assert.equal(details.headers.get('cache-control'), 'no-store');
+  assert.match(shell, /data-force-spa="1"/);
+  assert.doesNotMatch(shell, /__staticRouterHydrationData|Welcome to demo app/);
+  assert.match(shell, /rel="modulepreload"/, `${mode} SPA route chunk preload`);
+  assert.match(shell, /<style\b|rel="stylesheet"/, `${mode} SPA styles`);
+  for (const [, asset] of shell.matchAll(/(?:src|href)="([^"]+\.(?:js|css|tsx?))"/g)) {
+    const response = await fetch(new URL(asset, origin));
+    assert.equal(response.status, 200, `${mode} SPA asset ${asset}`);
+    await response.arrayBuffer();
+  }
+  const home = await fetch(origin, { headers: { 'User-Agent': userAgent } });
+  assert.equal(home.status, 200);
+  assert.match(await home.text(), /window\.__staticRouterHydrationData/);
+  const bot = await fetch(`${origin}/details`, { headers: { 'User-Agent': 'Googlebot' } });
+  assert.equal(bot.status, 200);
+  const botHtml = await bot.text();
+  assert.match(botHtml, /window\.__staticRouterHydrationData/);
+  assert.doesNotMatch(botHtml, /data-force-spa="1"/);
+  const head = await fetch(`${origin}/details`, { method: 'HEAD', headers: { 'User-Agent': userAgent } });
+  assert.equal(head.status, 200);
+  assert.equal(await head.text(), '');
+  console.info(`${mode} incremental SSR: /details SPA shell + assets, / SSR, Googlebot /details SSR, HEAD passed`);
+};
+
+const verifyIncrementalServer = async (command) => {
+  const port = await getPort();
+  if (command === 'dev') await writeFile(join(directory, '.env.development.local'), `VITE_PORT=${port}\n`);
+  const server = start([command, '--port', String(port)], {
+    SSR_BOOST_SSR_ROUTES: '!/details',
+    SSR_BOOST_DIAGNOSTICS: '1',
+  });
+  try {
+    const origin = `http://127.0.0.1:${port}`;
+    await waitUntilReady(origin, server);
+    await verifyIncremental(origin, command === 'dev' ? 'development' : 'production');
+  } finally {
+    await stop(server);
+  }
 };
 
 // Install the publishable package with its dependencies after measuring the original baseline.
@@ -626,6 +690,7 @@ try {
   }
 
   await verifyColdStart();
+  await verifyIncrementalServer('dev');
 
   await run(['build']);
   await measureClientGzip();
@@ -654,6 +719,8 @@ try {
   } finally {
     await stop(prod);
   }
+
+  await verifyIncrementalServer('start');
 
   if (keepTemplate) {
     await cp(join(directory, 'build'), join(directory, 'build-ssr'), { recursive: true });
@@ -689,6 +756,8 @@ try {
   } finally {
     await stop(spa);
   }
+  assert.ok(acceptance.policyInfo > 0, 'Incremental SSR must emit policy information with diagnostics enabled.');
+  assert.equal(acceptance.diagnosticsWarnings, 0, 'Template emitted unexpected SSR_BOOST_ diagnostics.');
 } finally {
   if (keepTemplate) {
     console.info(`Template retained for browser checks: ${directory}`);

--- a/src/adapters/express/entry.tsx
+++ b/src/adapters/express/entry.tsx
@@ -8,6 +8,9 @@ import type { ServeStaticOptions } from 'serve-static';
 import type { Logger } from 'vite';
 import type { IRenderOptions, TRender } from '@adapters/express/render';
 import render from '@adapters/express/render';
+import createSpaShell from '@core/spa-shell';
+import SsrPolicy from '@core/ssr-policy';
+import type { ISsrPolicy } from '@core/ssr-policy';
 import type { TRouteObject } from '@interfaces/route-object';
 import type ServerApi from '@services/server-api';
 import type ServerConfig from '@services/server-config';
@@ -70,6 +73,7 @@ export interface IEntryServerOptions<TAppProps = Record<string, any>> extends Pi
   IPrepareRenderOut,
   'loggerProd' | 'loggerDev' | 'middlewares'
 > {
+  ssr?: ISsrPolicy;
   abortDelay?: number;
   init?: (params: {
     config: ServerConfig;
@@ -83,12 +87,14 @@ export interface IEntryServerOptions<TAppProps = Record<string, any>> extends Pi
 function entry<TAppProps>(
   App: TApp<TAppProps>,
   routes: TRouteObject[],
-  { init, routerOptions, ...rest }: IEntryServerOptions<TAppProps> = {},
+  { init, routerOptions, ssr, ...rest }: IEntryServerOptions<TAppProps> = {},
 ): IPrepareRenderOut<TAppProps> {
   const handler = createStaticHandler(routes as RouteObject[], routerOptions);
+  const policy = new SsrPolicy(ssr, handler.dataRoutes, routerOptions?.basename);
+  const spaShell = createSpaShell();
 
   return {
-    render: render.bind(null, { handler, App }) as TRender,
+    render: render.bind(null, { handler, App, policy, spaShell }) as TRender,
     init,
     routes,
     ...rest,
@@ -96,3 +102,5 @@ function entry<TAppProps>(
 }
 
 export default entry;
+
+export type { ISsrPolicy };

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import React from 'react';
-import type { StaticHandlerContext, StaticHandler } from 'react-router';
+import type { RouterState, StaticHandlerContext, StaticHandler } from 'react-router';
 import createFetchRequest from '@adapters/express/create-request';
 import type { TApp } from '@adapters/express/entry';
 import StreamError from '@constants/stream-error';
@@ -10,6 +10,8 @@ import emitEarlyHints from '@core/early-hints';
 import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
 import coreRender from '@core/render';
 import type { ICoreRenderOptions, ISsrRequestContext } from '@core/render';
+import type createSpaShell from '@core/spa-shell';
+import type SsrPolicy from '@core/ssr-policy';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import renderToStream from '@node/render-to-stream';
 import createRequestSignal from '@node/request-signal';
@@ -31,6 +33,8 @@ export interface IRequestContext<TAppProps = Record<any, any>> {
   routerContext?: StaticHandlerContext;
   serverContext?: IServerContext;
   isStream?: boolean;
+  isSpa?: boolean;
+  matches?: RouterState['matches'];
   hasEarlyHints?: boolean;
   didError?: StreamError;
 }
@@ -44,6 +48,8 @@ export type TRender<TAppProps = Record<any, any>> = (
 export interface IRenderParams<TAppProps = Record<string, any>> {
   App: TApp<TAppProps>;
   handler: StaticHandler;
+  policy?: SsrPolicy;
+  spaShell?: ReturnType<typeof createSpaShell>;
 }
 
 export interface IRenderOptions<TAppProps = Record<string, any>> extends Pick<
@@ -203,7 +209,7 @@ const writeResponse = async (res: ExpressResponse, response: Response): Promise<
  * Render application
  */
 async function render(
-  { App, handler }: IRenderParams,
+  { App, handler, policy, spaShell }: IRenderParams,
   config: ServerConfig,
   initialContext: Omit<IRequestContext, 'request' | 'response'>,
   {
@@ -264,6 +270,15 @@ async function render(
       }
     }
 
+    syncResponse(coreContext, res, {
+      headers: new Headers(coreContext.response.headers),
+      status: coreContext.response.status,
+    });
+
+    if (coreContext.response.status === 200) {
+      coreContext.response.status = undefined;
+    }
+
     /**
      * Keep legacy hooks attached to their original mutable request context.
      */
@@ -273,6 +288,8 @@ async function render(
       context.didError = updated.didError;
       context.html = updated.html;
       context.isStream = updated.isStream;
+      context.isSpa = updated.isSpa;
+      context.matches = updated.matches;
       context.routerContext = updated.routerContext;
       context.serverContext = updated.serverContext;
 
@@ -287,6 +304,8 @@ async function render(
           <App server={{ ...updated.appProps, req }}>{children}</App>
         ),
         handler,
+        policy,
+        spaShell,
         renderToStream,
       },
       coreContext,
@@ -381,7 +400,7 @@ async function render(
           const legacyContext = syncContext(updated);
           const manifest = SsrManifest.get(config);
 
-          await manifest.prepareDevAssets(updated.routerContext?.matches);
+          await manifest.prepareDevAssets(updated.matches, updated.isSpa);
 
           const hints = manifest.injectAssets(legacyContext);
 

--- a/src/adapters/express/server.ts
+++ b/src/adapters/express/server.ts
@@ -119,7 +119,7 @@ async function createServer(config: ServerConfig): Promise<ICreateServerOut> {
             (await onRequest?.(req, res)) ?? {};
           const [header, footer] = clientHtml;
 
-          if (shouldCancel) {
+          if (shouldCancel || res.writableEnded || res.headersSent) {
             return;
           }
 

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -121,7 +121,11 @@ async function entry<TAppProps>(
 
   const router = createRouter(routes as RouteObject[], routerOptions);
   const root = document.getElementById(rootId) as HTMLElement;
-  const appProps = (await init?.({ isSSRMode: IS_SSR_MODE, router })) as TAppProps;
+  const isSSRMode =
+    IS_SSR_MODE &&
+    root.dataset['forceSpa'] !== '1' &&
+    document.documentElement.dataset['forceSpa'] !== '1';
+  const appProps = (await init?.({ isSSRMode, router })) as TAppProps;
 
   const AppComponent: FC = () => (
     <App client={appProps}>
@@ -129,7 +133,7 @@ async function entry<TAppProps>(
     </App>
   );
 
-  if (!IS_SSR_MODE || root.dataset['forceSpa'] === '1') {
+  if (!isSSRMode) {
     return ReactDOM.createRoot(root).render(<AppComponent />);
   }
 

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -2,6 +2,9 @@ import { hasCookie } from '@core/document-headers';
 import headResponse from '@core/head-response';
 import render from '@core/render';
 import type { ICoreRenderOptions, ICoreRenderParams, ISsrRequestContext } from '@core/render';
+import createSpaShell from '@core/spa-shell';
+import SsrPolicy from '@core/ssr-policy';
+import type { ISsrPolicy } from '@core/ssr-policy';
 import type { ISsrExecutionContext, TSsrHandler } from '@core/types';
 import Diagnostics, { isDiagnosticsEnabled } from '@services/diagnostics';
 
@@ -17,6 +20,12 @@ interface IRequestInit<TAppProps> {
 }
 
 interface ICreateHandlerOptions<TAppProps> extends ICoreRenderOptions<TAppProps> {
+  /** Select SSR or the SPA shell before running route loaders. */
+  ssr?: ISsrPolicy;
+
+  /** Must match the basename passed to createStaticHandler. */
+  basename?: string;
+
   /**
    * Development checks; defaults to NODE_ENV !== 'production', overridden by SSR_BOOST_DIAGNOSTICS.
    */
@@ -41,8 +50,11 @@ interface ICreateHandlerOptions<TAppProps> extends ICoreRenderOptions<TAppProps>
  */
 const createHandler = <TAppProps = Record<string, any>>(
   params: ICoreRenderParams<TAppProps>,
-  { diagnostics, getHtml, onRequest, ...options }: ICreateHandlerOptions<TAppProps>,
+  { diagnostics, getHtml, onRequest, ssr, basename, ...options }: ICreateHandlerOptions<TAppProps>,
 ): TSsrHandler => {
+  const policy = new SsrPolicy(ssr, params.handler.dataRoutes, basename);
+  const spaShell = createSpaShell();
+
   /**
    * Build fresh context for this request before invoking the renderer.
    */
@@ -72,10 +84,10 @@ const createHandler = <TAppProps = Record<string, any>>(
       },
     };
 
-    return render(params, context, options, executionContext);
+    return render({ ...params, policy, spaShell }, context, options, executionContext);
   };
 };
 
-export type { ICreateHandlerOptions, IHtmlShell, IRequestInit };
+export type { ICreateHandlerOptions, IHtmlShell, IRequestInit, ISsrPolicy };
 
 export default createHandler;

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import React from 'react';
-import type { StaticHandler, StaticHandlerContext } from 'react-router';
-import { createStaticRouter, StaticRouterProvider } from 'react-router';
+import type { RouterState, StaticHandler, StaticHandlerContext } from 'react-router';
+import { createStaticRouter, matchRoutes, StaticRouterProvider } from 'react-router';
 import StreamError from '@constants/stream-error';
 import { ServerProvider } from '@context/server';
 import type { IServerContext } from '@context/server';
@@ -11,6 +11,8 @@ import documentHeaders, { hasCookie } from '@core/document-headers';
 import type { IDocumentHeaderRule, IDocumentHeadersOptions } from '@core/document-headers';
 import headResponse from '@core/head-response';
 import { mergeResponseHeaders } from '@core/headers';
+import type createSpaShell from '@core/spa-shell';
+import type SsrPolicy from '@core/ssr-policy';
 import transformHtml from '@core/transform-html';
 import type { ISsrExecutionContext } from '@core/types';
 import buildCustomState from '@helpers/build-custom-state';
@@ -28,6 +30,9 @@ export interface ISsrRequestContext<TAppProps = Record<string, any>> {
   didError?: StreamError;
   html: { footer: string; header: string };
   isStream?: boolean;
+  isSpa?: boolean;
+  /** Structural route matches are available to prepare even when loaders are skipped. */
+  matches?: RouterState['matches'];
   request: Request;
 
   /**
@@ -80,6 +85,8 @@ export interface ICoreRenderParams<TAppProps = Record<string, any>> {
   createApp: (children: ReactNode, context: ISsrRequestContext<TAppProps>) => ReactNode;
   handler: StaticHandler;
   renderToStream: TRenderToStream;
+  policy?: SsrPolicy;
+  spaShell?: ReturnType<typeof createSpaShell>;
 }
 
 export interface ICoreRenderOptions<
@@ -225,7 +232,7 @@ const prepareHtmlResponse = <TAppProps,>(
  * Coordinate router queries, React rendering and the final Fetch response.
  */
 const renderResponse = async <TAppProps,>(
-  { createApp, handler, renderToStream }: ICoreRenderParams<TAppProps>,
+  { createApp, handler, renderToStream, policy, spaShell }: ICoreRenderParams<TAppProps>,
   context: ISsrRequestContext<TAppProps>,
   {
     abortDelay = 15_000,
@@ -246,6 +253,35 @@ const renderResponse = async <TAppProps,>(
   }: ICoreRenderOptions<TAppProps>,
   executionContext?: ISsrExecutionContext,
 ): Promise<Response> => {
+  const mode = policy?.select(context.request, context.diagnostics) ?? 'ssr';
+
+  if (policy?.active && !context.response.headers.has('Cache-Control')) {
+    context.response.headers.set('Cache-Control', 'no-store');
+  }
+
+  if (mode === 'spa') {
+    context.isSpa = true;
+    context.isStream = false;
+    context.matches =
+      matchRoutes(handler.dataRoutes, new URL(context.request.url), policy?.basename) ?? [];
+    context.html = spaShell!(context.html);
+
+    await prepare?.({ context, executionContext });
+
+    // Document policies apply to SPA shells too; the no-store default above is their baseline.
+    if (rules) {
+      context.response.headers = documentHeaders(rules, { sessionCookie, protectPrivate })(context);
+    }
+
+    context.response.status = 200;
+    context.response.headers.set(CONTENT_TYPE, 'text/html; charset=utf-8');
+
+    return new Response(
+      context.request.method === 'HEAD' ? null : context.html.header + context.html.footer,
+      { headers: context.response.headers, status: 200 },
+    );
+  }
+
   const queried = await handler.query(context.request, {
     requestContext: routerRequestContext ?? context,
   });
@@ -255,6 +291,7 @@ const renderResponse = async <TAppProps,>(
   }
 
   context.routerContext = queried;
+  context.matches = queried.matches;
   const dataStream = new DataStream(queried, context.diagnostics, nonce);
 
   try {

--- a/src/core/spa-html.ts
+++ b/src/core/spa-html.ts
@@ -1,0 +1,30 @@
+/**
+ * Generate the SPA mount marker for built indexes and server response shells.
+ * The document marker also supports applications using a custom browser root id.
+ */
+const createSpaHtml = (html: string, rootId = 'root'): string => {
+  let isMarked = false;
+  const result = html.replace(/<[^!/>][^>]*>/g, (tag) => {
+    const id = /\sid\s*=\s*(["'])(.*?)\1/.exec(tag)?.[2];
+
+    if (id !== rootId) {
+      return tag;
+    }
+
+    isMarked = true;
+
+    return /\bdata-force-spa\s*=/.test(tag)
+      ? tag.replace(/\bdata-force-spa\s*=\s*(["']).*?\1/, 'data-force-spa="1"')
+      : tag.replace(/(\sid\s*=\s*(["']).*?\2)/, '$1 data-force-spa="1"');
+  });
+
+  return isMarked
+    ? result
+    : result.replace(/<html\b[^>]*>/i, (tag) =>
+        /\bdata-force-spa\s*=/.test(tag)
+          ? tag.replace(/\bdata-force-spa\s*=\s*(["']).*?\1/, 'data-force-spa="1"')
+          : tag.replace(/<html\b/i, '<html data-force-spa="1"'),
+      );
+};
+
+export default createSpaHtml;

--- a/src/core/spa-shell.ts
+++ b/src/core/spa-shell.ts
@@ -1,0 +1,22 @@
+import type { IHtmlShell } from '@core/handler';
+import createSpaHtml from '@core/spa-html';
+
+/**
+ * Cache generation for the current template, returning isolated mutable request shells.
+ * Compare the source so development edits and request-specific getHtml values stay fresh.
+ */
+const createSpaShell = (): ((html: IHtmlShell) => IHtmlShell) => {
+  let source: IHtmlShell | undefined;
+  let shell: IHtmlShell;
+
+  return (html) => {
+    if (source?.header !== html.header || source?.footer !== html.footer) {
+      source = { ...html };
+      shell = { header: createSpaHtml(html.header), footer: html.footer };
+    }
+
+    return { ...shell };
+  };
+};
+
+export default createSpaShell;

--- a/src/core/ssr-policy.ts
+++ b/src/core/ssr-policy.ts
@@ -1,0 +1,193 @@
+import { isbot } from 'isbot';
+import { pathToRegexp } from 'path-to-regexp';
+import type { StaticHandler } from 'react-router';
+import { matchPath } from 'react-router';
+import type Diagnostics from '@services/diagnostics';
+
+type TRenderMode = 'ssr' | 'spa';
+
+interface ISsrPolicy {
+  mode?: 'all' | 'include' | 'exclude';
+  routes?: (string | RegExp)[];
+  bots?: 'ssr' | 'policy';
+  decide?: (params: { request: Request; url: URL; isBot: boolean }) => TRenderMode | undefined;
+}
+
+interface IPolicyPattern {
+  pattern: string | RegExp;
+  exclude: boolean;
+  test: (pathname: string) => boolean;
+}
+
+/**
+ * Compile once without sharing mutable RegExp.lastIndex with application code.
+ */
+const compilePattern = (pattern: string | RegExp, exclude: boolean): IPolicyPattern => {
+  if (pattern === '') {
+    throw new Error('SSR route patterns cannot be empty.');
+  }
+
+  const regexp =
+    typeof pattern === 'string'
+      ? pathToRegexp(pattern).regexp
+      : new RegExp(pattern.source, pattern.flags);
+
+  return {
+    pattern,
+    exclude,
+    test: (pathname) => {
+      regexp.lastIndex = 0;
+
+      return regexp.test(pathname);
+    },
+  };
+};
+
+/**
+ * Collect URL paths alongside their route ids without resolving lazy modules or loaders.
+ */
+const routePaths = (
+  routes: StaticHandler['dataRoutes'],
+  parent = '',
+): { id: string; path: string }[] =>
+  routes.flatMap((route) => {
+    const path =
+      (route.path?.startsWith('/') ? route.path : `${parent}/${route.path ?? ''}`)
+        .replace(/\/+/g, '/')
+        .replace(/\/$/, '') || '/';
+
+    return [{ id: route.id, path }, ...routePaths(route.children ?? [], path)];
+  });
+
+/**
+ * Snapshot environment policy when the application entry/handler is created at startup.
+ */
+class SsrPolicy {
+  public readonly active: boolean;
+
+  public readonly basename: string;
+
+  protected readonly patterns: IPolicyPattern[];
+
+  protected readonly mode: NonNullable<ISsrPolicy['mode']>;
+
+  protected readonly bots: NonNullable<ISsrPolicy['bots']>;
+
+  protected readonly decide?: ISsrPolicy['decide'];
+
+  protected readonly source: string;
+
+  protected readonly paths: ReturnType<typeof routePaths>;
+
+  protected hasInspected = false;
+
+  public constructor(
+    { mode = 'all', routes = [], bots = 'ssr', decide }: ISsrPolicy = {},
+    dataRoutes: StaticHandler['dataRoutes'] = [],
+    basename = '/',
+    env = typeof process === 'undefined' ? undefined : process.env.SSR_BOOST_SSR_ROUTES,
+  ) {
+    this.basename = basename;
+    this.bots = bots;
+    this.paths = routePaths(dataRoutes).map((route) => ({
+      ...route,
+      path: `${basename.replace(/\/$/, '')}${route.path}`,
+    }));
+
+    if (env !== undefined) {
+      const values = env
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+
+      this.mode = !values.length
+        ? 'all'
+        : values.some((value) => !value.startsWith('!'))
+          ? 'include'
+          : 'exclude';
+      this.patterns = values.map((value) => {
+        const isExcluded = value.startsWith('!');
+
+        return compilePattern(isExcluded ? value.slice(1) : value, isExcluded);
+      });
+      this.source = 'SSR_BOOST_SSR_ROUTES';
+    } else {
+      this.mode = mode;
+      this.patterns =
+        mode === 'all' ? [] : routes.map((pattern) => compilePattern(pattern, mode === 'exclude'));
+      this.decide = decide;
+      this.source = 'config';
+    }
+
+    this.active = this.mode !== 'all' || Boolean(this.decide);
+  }
+
+  /**
+   * Explain typos using declared paths, including concrete URLs for dynamic route ids.
+   * A global 404 catch-all must not hide a misspelled policy.
+   */
+  protected inspect(diagnostics?: Diagnostics): void {
+    if (!diagnostics || this.hasInspected) {
+      return;
+    }
+
+    this.hasInspected = true;
+
+    for (const { pattern, test } of this.patterns) {
+      const hasMatch = this.paths.some(
+        ({ path }) =>
+          path !== '/*' &&
+          (test(path) || (typeof pattern === 'string' && Boolean(matchPath(path, pattern)))),
+      );
+
+      if (!hasMatch) {
+        diagnostics.policyUnmatched(String(pattern));
+      }
+    }
+  }
+
+  /**
+   * Crawler protection wins over both runtime decisions and environment rollback rules.
+   */
+  public select(request: Request, diagnostics?: Diagnostics): TRenderMode {
+    if (!this.active) {
+      return 'ssr';
+    }
+
+    this.inspect(diagnostics);
+
+    const url = new URL(request.url);
+    const isBot = isbot(request.headers.get('user-agent'));
+    const matched = this.patterns.filter(({ test }) => test(url.pathname));
+    const excluded = matched.find(({ exclude }) => exclude);
+    let mode: TRenderMode =
+      excluded || (this.mode === 'include' && !matched.length) ? 'spa' : 'ssr';
+    let source = `${this.source} ${this.mode}`;
+
+    if (isBot && this.bots === 'ssr') {
+      mode = 'ssr';
+      source = 'bots: ssr';
+    } else {
+      const decision = this.decide?.({ request, url, isBot });
+
+      if (decision !== undefined) {
+        mode = decision;
+        source = 'config decide';
+      }
+    }
+
+    const pattern =
+      excluded?.pattern ??
+      matched[0]?.pattern ??
+      [...this.paths].reverse().find(({ path }) => matchPath(path, url.pathname))?.path ??
+      '(unmatched URL)';
+
+    diagnostics?.policyDecision(String(pattern), mode, source);
+
+    return mode;
+  }
+}
+
+export type { ISsrPolicy, TRenderMode };
+
+export default SsrPolicy;

--- a/src/plugins/create-spa-index.ts
+++ b/src/plugins/create-spa-index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'vite';
 import PLUGIN_NAME from '@constants/plugin-name';
+import createSpaHtml from '@core/spa-html';
 import { getCurrentEntrypointName } from '@plugins/handle-custom-entrypoint';
 
 export interface IPluginOptions {
@@ -30,7 +31,7 @@ function ViteCreateSPAIndexPlugin(options: IPluginOptions = {}): Plugin {
       return command === 'build' && !isSsrBuild && !getCurrentEntrypointName();
     },
     transformIndexHtml(html): string {
-      spaHtml = html.replace(`id="${rootId}"`, `id="${rootId}" data-force-spa="1"`);
+      spaHtml = createSpaHtml(html, rootId);
 
       return html;
     },

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -4,6 +4,8 @@ import Logger from '@services/logger';
 type TDiagnosticCode =
   | 'SSR_BOOST_CACHE_PRIVATE_LEAK'
   | 'SSR_BOOST_DEPRECATED_REQ_RES'
+  | 'SSR_BOOST_SSR_POLICY'
+  | 'SSR_BOOST_SSR_POLICY_UNMATCHED'
   | 'SSR_BOOST_LOADER_NOT_SERIALIZABLE'
   | 'SSR_BOOST_STREAM_PROMISE_ABORTED'
   | 'SSR_BOOST_STATE_NOT_SERIALIZABLE'
@@ -172,7 +174,7 @@ class Diagnostics {
 
   public constructor(
     protected readonly route: string,
-    protected readonly logger: Pick<Logger, 'warn'> = new Logger(),
+    protected readonly logger: Pick<Logger, 'warn'> & Partial<Pick<Logger, 'info'>> = new Logger(),
   ) {}
 
   /**
@@ -193,6 +195,32 @@ class Diagnostics {
     this.warn(
       'SSR_BOOST_DEPRECATED_REQ_RES',
       'context.req and context.res are deprecated in 8.x and planned for removal in 9.0; use context.request, context.response.headers/context.response.status and React Router HTTP helpers such as redirect().',
+    );
+  }
+
+  /**
+   * Report policy choices without logging concrete parameter, cookie or query values.
+   */
+  public policyDecision(pattern: string, mode: string, source: string): void {
+    const message = formatDiagnostic(
+      'SSR_BOOST_SSR_POLICY',
+      `Pattern ${JSON.stringify(pattern)} selects ${mode} via ${source}.`,
+    );
+    const reported = (registry[warnedKey] ??= new Set<string>());
+
+    if (!reported.has(message)) {
+      reported.add(message);
+      this.logger.info?.(message, {});
+    }
+  }
+
+  /**
+   * Warn once for a configured pattern with no corresponding route id.
+   */
+  public policyUnmatched(pattern: string): void {
+    this.warn(
+      'SSR_BOOST_SSR_POLICY_UNMATCHED',
+      `Pattern ${JSON.stringify(pattern)} matches no known route id; check its URL path and router basename.`,
     );
   }
 

--- a/src/services/route-assets.ts
+++ b/src/services/route-assets.ts
@@ -25,6 +25,8 @@ interface IInjectAssetsContext {
     header: string;
   };
   routerContext?: StaticHandlerContext;
+  matches?: RouterState['matches'];
+  isSpa?: boolean;
 }
 
 /**
@@ -90,7 +92,9 @@ class RouteAssets {
   /**
    * Get route assets
    */
-  protected getAssets(routes?: RouterState['matches']): IAsset[] {
+  // The development manifest uses the SPA flag to preload unqueried lazy routes.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getAssets(routes?: RouterState['matches'], _isSpa?: boolean): IAsset[] {
     const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
 
     if (!routeIds.length) {
@@ -127,8 +131,8 @@ class RouteAssets {
   /**
    * Inject route assets to head html
    */
-  public injectAssets({ routerContext, html }: IInjectAssetsContext): Headers {
-    const assets = this.getAssets(routerContext?.matches);
+  public injectAssets({ routerContext, matches, html, isSpa }: IInjectAssetsContext): Headers {
+    const assets = this.getAssets(matches ?? routerContext?.matches, isSpa);
     const htmlAssets = assets
       .map(({ type, url, isPreload, content = '' }) => {
         switch (type) {
@@ -139,7 +143,7 @@ class RouteAssets {
 
           case AssetType.script:
             return isPreload
-              ? this.modulePreload
+              ? this.modulePreload || isSpa
                 ? // can reduce lighthouse performance
                   `<link rel="modulepreload" as="script" crossorigin href="${url}">`
                 : null

--- a/src/services/ssr-manifest.ts
+++ b/src/services/ssr-manifest.ts
@@ -264,18 +264,26 @@ class SsrManifest extends RouteAssets {
   /**
    * Get route assets from Vite in development or the built manifest in production.
    */
-  protected getAssets(routes?: RouterState['matches']): IAsset[] {
-    return this.isDev ? this.getAssetsDev(routes) : super.getAssets(routes);
+  protected getAssets(routes?: RouterState['matches'], isSpa?: boolean): IAsset[] {
+    return this.isDev ? this.getAssetsDev(routes, isSpa) : super.getAssets(routes);
+  }
+
+  /**
+   * Resolve structural route metadata without importing the server's lazy component.
+   */
+  protected getDevRouteIds(routes?: RouterState['matches']): string[] {
+    return (
+      (routes
+        ?.map(({ route }) => this.pathNormalize.getAppPath((route as IAsyncRoute)?.pathId, true))
+        .filter(Boolean) as string[]) ?? []
+    );
   }
 
   /**
    * Get development route assets
    */
   protected getDevModules(routes?: RouterState['matches']): ModuleNode[] {
-    const routeIds =
-      (routes
-        ?.map(({ route }) => this.pathNormalize.getAppPath((route as IAsyncRoute)?.pathId, true))
-        .filter(Boolean) as string[]) ?? [];
+    const routeIds = this.getDevRouteIds(routes);
 
     const postfixes = this.pathNormalize.getImportPostfix();
     const pluginConfig = this.config.getPluginConfig();
@@ -302,11 +310,23 @@ class SsrManifest extends RouteAssets {
   /**
    * Compile SSR graph styles before the browser has populated the client graph.
    */
-  public async prepareDevAssets(routes?: RouterState['matches']): Promise<void> {
+  public async prepareDevAssets(routes?: RouterState['matches'], isSpa = false): Promise<void> {
     const vite = this.config.getVite();
 
     if (!vite) {
       return;
+    }
+
+    if (isSpa) {
+      await Promise.all(
+        this.getDevRouteIds(routes).map(async (id) => {
+          const file = this.pathNormalize.findAppFile(id);
+
+          if (file) {
+            await vite.transformRequest(`/@fs/${file}`);
+          }
+        }),
+      );
     }
 
     const visited = new Set<string>();
@@ -334,13 +354,34 @@ class SsrManifest extends RouteAssets {
   /**
    * Collect development assets from the current server and client module graphs.
    */
-  protected getAssetsDev(routes?: RouterState['matches']): IAsset[] {
+  protected getAssetsDev(routes?: RouterState['matches'], isSpa = false): IAsset[] {
     const assets = Object.assign(
       {},
       ...this.getDevModules(routes).map((module) => this.getModuleAssets(module)),
     ) as TAssets;
 
-    return Object.values(assets);
+    const scripts: IAsset[] = isSpa
+      ? this.getDevRouteIds(routes).flatMap((id) => {
+          const module = this.pathNormalize
+            .getImportPostfix()
+            .map((ext) => this.config.getVite()?.moduleGraph.getModuleById(`${id}${ext}`))
+            .find(Boolean);
+
+          return module
+            ? [
+                {
+                  type: AssetType.script,
+                  url: module.url,
+                  weight: 2,
+                  isNested: false,
+                  isPreload: true,
+                },
+              ]
+            : [];
+        })
+      : [];
+
+    return [...Object.values(assets), ...scripts];
   }
 
   /**


### PR DESCRIPTION
One SSR application can now serve selected URLs as the SPA shell, with per-request decisions and rollback by restarting the existing build:

- `ssr` option on the managed Express entry and on Fetch `createHandler`: `mode: 'all' | 'include' | 'exclude'`, `routes` as path-to-regexp strings or RegExps, `bots: 'ssr' | 'policy'` (detected crawlers stay on SSR by default), and a synchronous `decide({ request, url, isBot })` override.
- `SSR_BOOST_SSR_ROUTES` environment override (`/,/articles/:slug` to include, `!/details` to exclude) read once at startup replaces the configured `mode`, `routes` and `decide`, so a route can be rolled back to SPA without a rebuild.
- SPA responses reuse the `spaIndex` shell generation (`data-force-spa="1"`, status 200, HTML content type), keep the matched route's CSS and module preloads through structural route matching without importing lazy server modules or running loaders, and skip hydration/custom state and render hooks; `onRequest` redirects and headers still apply. Active policies default documents to `Cache-Control: no-store` unless the application sets a policy.
- The browser entry reports `isSSRMode` per document, so the same client bundle handles both modes and client navigation between them stays in one document.
- Development diagnostics `SSR_BOOST_SSR_POLICY` (which pattern selected which mode and why) and `SSR_BOOST_SSR_POLICY_UNMATCHED` (a pattern that matches no declared route path).
- New guide `docs/guide/incremental-ssr.md` with the rollout and rollback procedure and the configuration reference; API and migration docs updated. `isbot` and `path-to-regexp` become direct runtime dependencies.

Template acceptance gains development and production rollback runs (`SSR_BOOST_SSR_ROUTES='!/details'`): the SPA shell with its assets, SSR for other URLs and for Googlebot on the excluded URL, and HEAD handling.

Verified locally on Node 22.23.2 after rebasing onto staging: lint, types, 747 unit/integration tests (policy matching, shell generation, Fetch and Express integration, jsdom navigation), build, size budgets, `test:core:no-optional`, docs build, the template acceptance including the rollback runs, and the Playwright suite in Chromium (the new test needed a non-headless user agent because `isbot` classifies HeadlessChrome as a crawler).
