### PR TITLE
feat: add the cloudflare workers handler, in-memory route assets and a workerd preview flow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,6 +23,7 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
+      - run: npm run test:worker:browser
 
   react:
     uses: ./.github/workflows/react-compatibility.yml
@@ -80,6 +81,9 @@ jobs:
 
       - name: Boot the built edge package in workerd
         run: npm run test:edge:packed
+
+      - name: Build and boot the packed Worker with static assets and KV
+        run: npm run test:worker:packed
 
       - name: Prove public exports (including node/production) and core without optional adapters
         run: npm run test:core:no-optional

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
+      - run: npm run test:worker:browser
 
   react:
     uses: ./.github/workflows/react-compatibility.yml
@@ -82,6 +83,9 @@ jobs:
 
       - name: Boot the built edge package in workerd
         run: npm run test:edge:packed
+
+      - name: Build and boot the packed Worker with static assets and KV
+        run: npm run test:worker:packed
 
       - name: Prove core works without optional adapters
         run: npm run test:core:no-optional

--- a/__fixtures__/worker-template/package.json.txt
+++ b/__fixtures__/worker-template/package.json.txt
@@ -1,0 +1,11 @@
+{
+  "name": "ssr-boost-worker-template",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ssr-boost dev",
+    "build": "ssr-boost build --focus-only all",
+    "preview": "wrangler dev --local",
+    "deploy": "npm run build && wrangler deploy"
+  }
+}

--- a/__fixtures__/worker-template/public/assets/plain.txt.txt
+++ b/__fixtures__/worker-template/public/assets/plain.txt.txt
@@ -1,0 +1,1 @@
+not content hashed

--- a/__fixtures__/worker-template/public/health.txt
+++ b/__fixtures__/worker-template/public/health.txt
@@ -1,0 +1,1 @@
+static health

--- a/__fixtures__/worker-template/public/robots.txt.txt
+++ b/__fixtures__/worker-template/public/robots.txt.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/__fixtures__/worker-template/src/About.tsx.txt
+++ b/__fixtures__/worker-template/src/About.tsx.txt
@@ -1,0 +1,3 @@
+import React from 'react';
+import './about.css';
+export const Component = () => <h1 className="about">Lazy Worker route</h1>;

--- a/__fixtures__/worker-template/src/App.tsx.txt
+++ b/__fixtures__/worker-template/src/App.tsx.txt
@@ -1,0 +1,2 @@
+import React from 'react';
+export default function App({ children }: React.PropsWithChildren) { return <>{children}</>; }

--- a/__fixtures__/worker-template/src/about.css.txt
+++ b/__fixtures__/worker-template/src/about.css.txt
@@ -1,0 +1,1 @@
+.about { color: rgb(12, 34, 56); }

--- a/__fixtures__/worker-template/src/client.tsx.txt
+++ b/__fixtures__/worker-template/src/client.tsx.txt
@@ -1,0 +1,4 @@
+import entryClient from '@lomray/vite-ssr-boost/browser/entry';
+import App from './App';
+import routes from './routes';
+void entryClient(App, routes);

--- a/__fixtures__/worker-template/src/env.d.ts.txt
+++ b/__fixtures__/worker-template/src/env.d.ts.txt
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/__fixtures__/worker-template/src/index.html.txt
+++ b/__fixtures__/worker-template/src/index.html.txt
@@ -1,0 +1,3 @@
+<!doctype html>
+<html><head><meta charset="UTF-8"><title>Worker template</title></head>
+<body><div id="root"><!--ssr-outlet--></div><script async type="module" src="/client.tsx"></script></body></html>

--- a/__fixtures__/worker-template/src/routes.tsx.txt
+++ b/__fixtures__/worker-template/src/routes.tsx.txt
@@ -1,0 +1,35 @@
+import type { TRouteObject } from '@lomray/vite-ssr-boost/interfaces/route-object';
+import type { ISsrRequestContext } from '@lomray/vite-ssr-boost/core/render';
+import type { IWorkerPlatform } from '@lomray/vite-ssr-boost/cloudflare';
+import type { Env } from './worker';
+import React, { Suspense, useState } from 'react';
+import { Await, Link, Outlet, redirect, useLoaderData } from 'react-router';
+import ResponseStatus from '@lomray/vite-ssr-boost/components/response-status';
+
+function Layout() {
+  const [count, setCount] = useState(0);
+  return <main><button onClick={() => setCount(count + 1)}>Count {count}</button>
+    <Link to="/">Home</Link> <Link to="/about">About</Link> <Link to="/deferred">Deferred</Link>
+    <Outlet /></main>;
+}
+function Data() { const data = useLoaderData(); return <p>{JSON.stringify(data)}</p>; }
+function Deferred() {
+  const data = useLoaderData();
+  return <Suspense fallback={<p data-fallback>Loading message</p>}>
+    <Await resolve={data.slow}>{message => <p data-resolved>{message}</p>}</Await>
+  </Suspense>;
+}
+const routes = [{ path: '/', Component: Layout, children: [
+  { index: true, Component: () => <h1>Worker home</h1> },
+  { id: 'about', path: 'about', lazy: () => import('./About') },
+  { path: 'redirect', loader: () => redirect('/about', 301) },
+  { path: 'cookie', Component: Data, loader: ({ context }) => ({ visits: (context as unknown as ISsrRequestContext<{ visits: number }>)?.appProps?.visits ?? 0 }) },
+  { path: 'bindings', Component: Data, loader: async ({ context }) => ({
+    message: await ((context as unknown as ISsrRequestContext)?.executionContext?.platform as IWorkerPlatform<Env> | undefined)?.env.MESSAGES.get('greeting') ?? 'Node development',
+  }) },
+  { path: 'deferred', Component: Deferred, loader: () => ({
+    slow: new Promise<string>(resolve => setTimeout(() => resolve('Resolved in workerd'), 1500)),
+  }) },
+  { path: '*', Component: () => <><ResponseStatus status={404} /><h1>Missing page</h1></> },
+]}] satisfies TRouteObject[];
+export default routes;

--- a/__fixtures__/worker-template/src/server.tsx.txt
+++ b/__fixtures__/worker-template/src/server.tsx.txt
@@ -1,0 +1,4 @@
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import App from './App';
+import routes from './routes';
+export default entryServer(App, routes);

--- a/__fixtures__/worker-template/src/worker.ts.txt
+++ b/__fixtures__/worker-template/src/worker.ts.txt
@@ -1,0 +1,28 @@
+import { createWorkerHandler, getHtmlFromAssets } from '@lomray/vite-ssr-boost/cloudflare';
+import manifest from '../build/client/assets-manifest.json';
+import App from './App';
+import routes from './routes';
+
+export interface Env { ASSETS: Fetcher; MESSAGES: KVNamespace; }
+
+export default {
+  fetch: createWorkerHandler<Env>({
+    App, routes, manifest,
+    hydration: 'early',
+    getHtml: async (_request, env) => (await getHtmlFromAssets(env, '/index.html'))(),
+    onRequest: ({ request, executionContext }) => {
+      const visits = Number(request.headers.get('Cookie')?.match(/visits=(\d+)/)?.[1] ?? 0) + 1;
+      if (new URL(request.url).pathname === '/bindings') {
+        executionContext.waitUntil(executionContext.platform.env.MESSAGES.put('background', 'done'));
+      }
+      return { appProps: { visits }, headers: { 'Set-Cookie': `visits=${visits}; Path=/; HttpOnly; SameSite=Lax` } };
+    },
+    prepare: ({ context, executionContext }) => {
+      if (!executionContext || executionContext.onEarlyHints || context.executionContext !== executionContext) {
+        throw new Error('Incorrect Worker execution context');
+      }
+      context.response.headers.set('X-Worker-Hook', 'ready');
+    },
+    getState: () => ({ worker: { ready: true } }),
+  }),
+} satisfies ExportedHandler<Env>;

--- a/__fixtures__/worker-template/tsconfig.worker.json.txt
+++ b/__fixtures__/worker-template/tsconfig.worker.json.txt
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "jsx": "react",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/worker.ts", "src/*.d.ts"]
+}

--- a/__fixtures__/worker-template/vite.config.ts.txt
+++ b/__fixtures__/worker-template/vite.config.ts.txt
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import SsrBoost from '@lomray/vite-ssr-boost/plugin';
+
+export default defineConfig({
+  root: 'src',
+  publicDir: '../public',
+  build: { outDir: '../build' },
+  plugins: [SsrBoost({
+    clientFile: 'client.tsx',
+    serverFile: 'server.tsx',
+    tsconfigAliases: false,
+    entrypoint: [{ name: 'worker', type: 'ssr', serverFile: 'worker.ts' }],
+  })],
+});

--- a/__fixtures__/worker-template/wrangler.jsonc.txt
+++ b/__fixtures__/worker-template/wrangler.jsonc.txt
@@ -1,0 +1,14 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "ssr-boost-worker-template",
+  "main": "build/worker/worker.js",
+  "compatibility_date": "2026-07-30",
+  "assets": {
+    "directory": "build/client",
+    "binding": "ASSETS",
+    "run_worker_first": true,
+    "html_handling": "none",
+    "not_found_handling": "none"
+  },
+  "kv_namespaces": [{ "binding": "MESSAGES", "id": "00000000000000000000000000000000" }]
+}

--- a/__tests__/cloudflare.tsx
+++ b/__tests__/cloudflare.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment node
+import React from 'react';
+import { createStaticHandler } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { createRouteAssetPreparer } from '@node/production';
+import NodeRouteAssets from '@services/route-assets';
+import type { TRouteAssetsManifest } from '@services/route-assets-memory';
+import { createWorkerHandler, getHtmlFromAssets, RouteAssets } from '../src/cloudflare';
+import type { IAssetsBinding } from '../src/cloudflare';
+
+const document =
+  '<!doctype html><html><head></head><body><div id="root"><!--ssr-outlet--></div></body></html>';
+const manifest = {
+  about: [
+    {
+      type: 'style',
+      url: '/assets/about-abcdefgh.css',
+      weight: 1,
+      isNested: false,
+      isPreload: false,
+    },
+    {
+      type: 'script',
+      url: '/assets/about-abcdefgh.js',
+      weight: 2,
+      isNested: false,
+      isPreload: true,
+    },
+  ],
+} satisfies TRouteAssetsManifest;
+const routes = [{ id: 'about', path: '/about', Component: () => <p>About</p> }];
+const App = ({ children }: React.PropsWithChildren) => <>{children}</>;
+
+const context = async () => {
+  const request = new Request('https://worker.example/about');
+  const routerContext = await createStaticHandler(routes).query(request);
+  if (routerContext instanceof Response) throw new Error('Expected router context');
+  return {
+    request,
+    routerContext,
+    appProps: {},
+    response: { headers: new Headers() },
+    html: { header: '<head></head>', footer: 'footer' },
+  };
+};
+
+describe('in-memory route assets', () => {
+  it('supports both constructors, a parsed JSON object and immutable manifests', async () => {
+    const parsed = JSON.parse(JSON.stringify(manifest)) as TRouteAssetsManifest;
+    Object.values(parsed).forEach(Object.freeze);
+    Object.freeze(parsed);
+    for (const Assets of [RouteAssets, NodeRouteAssets]) {
+      const assets = new Assets(parsed, true);
+      const first = await context();
+      const second = await context();
+      assets.injectAssets(first);
+      assets.injectAssets(second);
+      expect(first.html).toEqual(second.html);
+      expect(first.html.header).toContain(
+        '<link rel="stylesheet" href="/assets/about-abcdefgh.css">',
+      );
+      expect(first.html.header).toContain('rel="modulepreload"');
+      expect(first.html.footer).toBe('footer');
+      expect(parsed).toEqual(manifest);
+    }
+  });
+
+  it('accepts manifest in the Node preparer and skips unsupported Early Hints', async () => {
+    const hints = vi.spyOn(RouteAssets.prototype, 'getEarlyHints');
+    try {
+      const first = await context();
+      await createRouteAssetPreparer({ manifest })({ context: first });
+      expect(first.html.header).toContain('rel="stylesheet"');
+      expect(hints).not.toHaveBeenCalled();
+      const onEarlyHints = vi.fn();
+      await createRouteAssetPreparer({ manifest })({
+        context: await context(),
+        executionContext: { onEarlyHints },
+      });
+      expect(onEarlyHints).toHaveBeenCalledOnce();
+      expect(hints).toHaveBeenCalledOnce();
+    } finally {
+      hints.mockRestore();
+    }
+  });
+
+  it('keeps independent manifests and unmatched routes isolated', async () => {
+    const first = await context();
+    const second = await context();
+    new RouteAssets({}).injectAssets(first);
+    new RouteAssets(manifest).injectAssets(second);
+    expect(first.html.header).toBe('<head></head>');
+    expect(second.html.header).toContain('/assets/about-abcdefgh.css');
+  });
+});
+
+describe('getHtmlFromAssets', () => {
+  it('loads once across concurrent calls and returns fresh shells for every request', async () => {
+    const fetch = vi.fn(async () => new Response(document));
+    const env = { ASSETS: { fetch } };
+    const [getHtml, again] = await Promise.all([getHtmlFromAssets(env), getHtmlFromAssets(env)]);
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch.mock.calls[0]).toHaveLength(1);
+    const first = getHtml();
+    const second = again();
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    first.header = 'request mutation';
+    expect(getHtml()).toEqual(second);
+    await getHtmlFromAssets({ ASSETS: env.ASSETS });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('keys its cache by binding, path and outlet, including custom names', async () => {
+    const fetch = vi.fn(async () => new Response(document));
+    const env = { STATIC: { fetch } };
+    await getHtmlFromAssets(env, '/index.html', 'STATIC');
+    await getHtmlFromAssets(env, '/other.html', 'STATIC');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const alternate = await getHtmlFromAssets(
+      { STATIC: { fetch: async () => new Response('a{{app}}b') } },
+      '/shell.html',
+      'STATIC',
+      '{{app}}',
+    );
+    expect(alternate()).toEqual({ header: 'a', footer: 'b' });
+  });
+
+  it('reports missing bindings, non-200 shells and invalid outlets; retries failures', async () => {
+    await expect(getHtmlFromAssets({})).rejects.toThrow('Missing Workers assets binding "ASSETS"');
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('missing', { status: 404 }))
+      .mockResolvedValueOnce(new Response('no outlet'))
+      .mockResolvedValueOnce(new Response('<!--ssr-outlet--><!--ssr-outlet-->'))
+      .mockResolvedValueOnce(new Response(document));
+    const env = { ASSETS: { fetch } };
+    await expect(getHtmlFromAssets(env)).rejects.toThrow('/index.html');
+    await expect(getHtmlFromAssets(env)).rejects.toThrow('expected exactly one');
+    await expect(getHtmlFromAssets(env)).rejects.toThrow('expected exactly one');
+    expect((await getHtmlFromAssets(env))().header).toContain('<head>');
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('createWorkerHandler', () => {
+  it('forwards per-request bindings to all hooks and loaders', async () => {
+    const seen: unknown[] = [];
+    const nativeContext = {
+      waitUntil: vi.fn(function (this: unknown) {
+        expect(this).toBe(nativeContext);
+      }),
+    };
+    const worker = createWorkerHandler<{ greeting: string }>({
+      App,
+      manifest,
+      indexHtml: document,
+      assets: false,
+      routes: [
+        {
+          path: '/',
+          Component: () => <p>Worker</p>,
+          loader: ({ context: requestContext }) => {
+            seen.push((requestContext as any).executionContext.platform.env.greeting);
+            return null;
+          },
+        },
+      ],
+      onRequest: ({ executionContext }) => {
+        expect(executionContext.platform.ctx).toBe(nativeContext);
+        expect(executionContext.onEarlyHints).toBeUndefined();
+        executionContext.waitUntil(Promise.resolve());
+        return {};
+      },
+      prepare: ({ context: requestContext, executionContext }) => {
+        expect(requestContext.executionContext).toBe(executionContext);
+        seen.push(executionContext?.platform);
+      },
+      onShellReady: ({ context: requestContext }) => {
+        expect(requestContext.executionContext?.platform).toBeDefined();
+        return {};
+      },
+    });
+    await Promise.all(
+      ['one', 'two'].map(async (greeting) => {
+        const response = await worker(
+          new Request('https://worker.example/'),
+          { greeting },
+          nativeContext,
+        );
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain('<p>Worker</p>');
+      }),
+    );
+    expect(seen).toContain('one');
+    expect(seen).toContain('two');
+    expect(nativeContext.waitUntil).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses custom assets, preserves headers, falls back on misses and never caches plain files forever', async () => {
+    const fetch = vi.fn(async (request: Request) => {
+      const path = new URL(request.url).pathname;
+      return path === '/about'
+        ? new Response(null, { status: 404 })
+        : new Response('asset', { headers: { ETag: 'version', 'Cache-Control': 'no-cache' } });
+    });
+    const worker = createWorkerHandler<{ STATIC: IAssetsBinding }>({
+      App,
+      routes,
+      manifest,
+      indexHtml: document,
+      assets: 'STATIC',
+    });
+    const env = { STATIC: { fetch } };
+    const ctx = { waitUntil: vi.fn() };
+    const hashed = await worker(
+      new Request('https://worker.example/assets/a-abcdefgh.css'),
+      env,
+      ctx,
+    );
+    expect(hashed.headers.get('ETag')).toBe('version');
+    expect(hashed.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+    expect(await hashed.text()).toBe('asset');
+    const plain = await worker(new Request('https://worker.example/robots.txt'), env, ctx);
+    expect(plain.headers.get('Cache-Control')).toBe('no-cache');
+    const ssr = await worker(new Request('https://worker.example/about'), env, ctx);
+    expect(await ssr.text()).toContain('<p>About</p>');
+    const head = await worker(
+      new Request('https://worker.example/assets/a-abcdefgh.css', { method: 'HEAD' }),
+      env,
+      ctx,
+    );
+    expect(await head.text()).toBe('');
+  });
+
+  it('bypasses assets for actions and supports onRequest response takeover', async () => {
+    const fetch = vi.fn();
+    const worker = createWorkerHandler({
+      App,
+      routes,
+      manifest,
+      indexHtml: document,
+      onRequest: () => new Response('hook', { status: 202 }),
+    });
+    const response = await worker(
+      new Request('https://worker.example/about', { method: 'POST' }),
+      { ASSETS: { fetch } },
+      { waitUntil: vi.fn() },
+    );
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe('hook');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/ssr-manifest.ts
+++ b/__tests__/services/ssr-manifest.ts
@@ -124,7 +124,7 @@ describe('SsrManifest', () => {
     manifest.pathNormalize.getImportPostfix = vi.fn(() => ['', '.ts']);
     manifest.pathNormalize.getAppPath = vi.fn((val: string) => val);
     parseMock.mockReturnValue([{ import: 'src/routes', children: [], index: 0 }]);
-    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     vi.spyOn(manifest, 'loadClientManifest').mockReturnValue({
       'src/routes': {
         assets: ['img.png'],
@@ -152,7 +152,23 @@ describe('SsrManifest', () => {
 
     manifest.buildRoutesManifest();
 
-    expect(writeFileSync).toHaveBeenCalled();
+    expect(writeFileSync).toHaveBeenCalledWith('/root/dist/server/assets-manifest.json', expect.any(String), { encoding: 'utf-8' });
+    expect(writeFileSync).toHaveBeenCalledWith('/root/dist/client/assets-manifest.json', writeFileSync.mock.calls[0][1], { encoding: 'utf-8' });
+  });
+
+  it('keeps server-only builds working without a client output directory', () => {
+    const writeFileSync = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    parseMock.mockReturnValue([]);
+    const manifest = SsrManifest.get(createConfig(), { buildDir: 'dist' });
+
+    manifest.buildRoutesManifest();
+
+    expect(writeFileSync).toHaveBeenCalledExactlyOnceWith(
+      '/root/dist/server/assets-manifest.json',
+      '{}',
+      { encoding: 'utf-8' },
+    );
   });
 
   it('should collect assets in prod and dev modes', () => {

--- a/browser-tests/worker/hydration.spec.mjs
+++ b/browser-tests/worker/hydration.spec.mjs
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test('hydrates workerd HTML, preserves client state across navigation and loads lazy CSS', async ({
+  page,
+}) => {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (
+      message.type() === 'error' &&
+      /hydrat|did not match|Minified React error/i.test(message.text())
+    )
+      errors.push(message.text());
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Count 0' }).click();
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  await page.getByRole('link', { name: 'About', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Lazy Worker route' })).toHaveCSS(
+    'color',
+    'rgb(12, 34, 56)',
+  );
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Lazy Worker route' })).toHaveCSS(
+    'color',
+    'rgb(12, 34, 56)',
+  );
+  await page.getByRole('button', { name: 'Count 0' }).click();
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test('hydrates the pending shell before a deferred workerd boundary resolves', async ({ page }) => {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (
+      message.type() === 'error' &&
+      /hydrat|did not match|Minified React error/i.test(message.text())
+    )
+      errors.push(message.text());
+  });
+  await page.goto('/deferred', { waitUntil: 'commit' });
+  await expect(page.locator('[data-fallback]')).toBeVisible();
+  await page.getByRole('button', { name: 'Count 0' }).click();
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  await expect(page.locator('[data-fallback]')).toBeVisible();
+  await expect(page.locator('[data-resolved]')).toHaveText('Resolved in workerd');
+  await expect(page.locator('[data-fallback]')).toHaveCount(0);
+  expect(errors).toEqual([]);
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
           { text: 'Runtime Adapters', link: '/guide/runtime-adapters' },
           { text: 'Deployment', link: '/guide/deployment' },
           { text: 'Caching', link: '/guide/caching' },
+          { text: 'Cloudflare Workers', link: '/guide/cloudflare' },
         ],
       },
       {

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -15,6 +15,7 @@ The package declares `engines.node: ">=22.12.0"` and peers for Vite `>=5`, React
 ## Public entrypoints
 
 - Vite plugin: `@lomray/vite-ssr-boost/plugin`.
+- Cloudflare Workers: `@lomray/vite-ssr-boost/cloudflare` (`createWorkerHandler`, `getHtmlFromAssets`, `RouteAssets`, `TRouteAssetsManifest`); see [Cloudflare Workers](/guide/cloudflare).
 - Browser entry: `@lomray/vite-ssr-boost/browser/entry`.
 - Managed CLI server entry: `@lomray/vite-ssr-boost/adapters/express/entry`.
 - Fetch core: default export `createHandler` from `@lomray/vite-ssr-boost/core/handler`.

--- a/docs/api/node-production.md
+++ b/docs/api/node-production.md
@@ -12,6 +12,7 @@ import type {
   IHtmlShell,
   ILoadHtmlShellOptions,
   IRouteAssetPreparerOptions,
+  TRouteAssetsManifest,
 } from '@lomray/vite-ssr-boost/node/production';
 ```
 
@@ -44,10 +45,10 @@ Load a new shell when deploying a new build.
 ## `createRouteAssetPreparer`
 
 ```ts
-interface IRouteAssetPreparerOptions {
-  buildDir: string;
-  modulePreload?: boolean; // Default: false
-}
+type IRouteAssetPreparerOptions = (
+  | { buildDir: string; manifest?: never }
+  | { manifest: TRouteAssetsManifest; buildDir?: never }
+) & { modulePreload?: boolean }; // Default: false
 
 function createRouteAssetPreparer<TAppProps>(
   options: IRouteAssetPreparerOptions,
@@ -62,6 +63,20 @@ preparer caches its own manifest and shares the managed server's asset injection
 not discover builds from the working directory or use the managed server's manifest singleton.
 Relative paths resolve against the working directory at creation; use an absolute path to start
 the application from any directory.
+
+Alternatively, import the parsed **`build/client/assets-manifest.json`** and pass `{ manifest }`:
+
+```ts
+import manifest from './build/client/assets-manifest.json';
+const prepare = createRouteAssetPreparer({ manifest });
+```
+
+The CLI emits this alongside the identical `build/server/assets-manifest.json` after the normal
+server build. It is not Vite's `.vite/manifest.json`. The exported `TRouteAssetsManifest` type accepts
+a JSON import directly. `RouteAssets` from `services/route-assets` also accepts the object as its
+first constructor argument, with `modulePreload` as the second. Manifest objects are not mutated.
+For Workers use the edge-safe [Cloudflare entry](/guide/cloudflare), which uses the same injection
+logic without importing the Node helpers.
 
 The hook runs after React Router matches the request. It inserts matching route styles and scripts
 before `</head>` in `context.html.header`; the shell must contain that closing tag. Lazy route IDs

--- a/docs/guide/cloudflare.md
+++ b/docs/guide/cloudflare.md
@@ -1,0 +1,264 @@
+# Cloudflare Workers
+
+Use `@lomray/vite-ssr-boost/cloudflare` to serve a built React Router Data mode application in
+Workers. It provides a Fetch handler, route asset injection, streaming HTML and access to bindings.
+Keep your Express server entry for `ssr-boost dev`.
+
+## Build a Worker entry
+
+Install Wrangler in your application:
+
+```bash
+npm install --save-dev wrangler
+```
+
+Add an extra SSR entry to your existing Vite config. This example uses `src` as the Vite root:
+
+```ts
+import { defineConfig } from 'vite';
+import SsrBoost from '@lomray/vite-ssr-boost/plugin';
+
+export default defineConfig({
+  root: 'src',
+  publicDir: '../public',
+  build: { outDir: '../build' },
+  plugins: [
+    SsrBoost({
+      clientFile: 'client.tsx',
+      serverFile: 'server.tsx', // Existing Express entry for development.
+      entrypoint: [{ name: 'worker', type: 'ssr', serverFile: 'worker.ts' }],
+    }),
+    // Keep your existing React and other Vite plugins here.
+  ],
+});
+```
+
+Create `src/worker.ts` alongside your shared `App` and routes:
+
+```ts
+import {
+  createWorkerHandler,
+  getHtmlFromAssets,
+} from '@lomray/vite-ssr-boost/cloudflare';
+import manifest from '../build/client/assets-manifest.json';
+import App from './App';
+import routes from './routes';
+
+export default {
+  fetch: createWorkerHandler({
+    routes,
+    App,
+    manifest,
+    getHtml: async (_request, env) => (await getHtmlFromAssets(env, '/index.html'))(),
+  }),
+};
+```
+
+The exact JSON import is **`build/client/assets-manifest.json`**, relative to the Worker source.
+It is the route-ID-to-assets manifest, not Vite's `.vite/manifest.json`. The CLI writes it alongside
+`build/server/assets-manifest.json` after building the client and regular server. The extra Worker
+entry is built afterward, so its JSON import exists on a clean build. Do not import the Worker
+entry from your client or regular server entry.
+
+Run all build entries:
+
+```bash
+npx ssr-boost build --focus-only all
+```
+
+The default `ssr-boost build` builds only the app. `--focus-only all` also builds the configured
+Worker, emitting `build/worker/worker.js`. No separate Vite invocation or new server-entry flag is
+needed. Rebuild all entries after changing routes or assets. The managed watch preview does not
+regenerate this production manifest for a Worker.
+
+`App` receives `{ server: appProps, children }`, matching the managed server's wrapper convention.
+The handler also accepts `routerOptions`, `modulePreload`, `outlet`, and the Fetch core's lifecycle,
+state, nonce, timeout, hydration and router context options. `getHtml(request, env, ctx)` may load a
+custom shell. Alternatively, pass `indexHtml` containing the complete built HTML string with exactly
+one `<!--ssr-outlet-->` (or your custom `outlet`); do not pass a filename as `indexHtml`.
+
+## Wrangler configuration
+
+Create `wrangler.jsonc` at the project root:
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-ssr-app",
+  "main": "build/worker/worker.js",
+  "compatibility_date": "2026-07-30",
+  "assets": {
+    "directory": "build/client",
+    "binding": "ASSETS",
+    "run_worker_first": true,
+    "html_handling": "none",
+    "not_found_handling": "none"
+  }
+}
+```
+
+`run_worker_first` lets the handler render `/` and apply cache headers to static responses.
+`html_handling: "none"` lets the shell helper fetch `/index.html` without a redirect. Keep
+`not_found_handling: "none"` so a static miss reaches SSR and can return a real 404.
+See [Workers Static Assets](https://developers.cloudflare.com/workers/static-assets/) and
+[Wrangler configuration](https://developers.cloudflare.com/workers/wrangler/configuration/).
+
+GET and HEAD requests try the binding for static files, including public files such as
+`robots.txt` and extensionless files. `/` always renders; `/index.html` is also routed through SSR.
+A binding 404 falls through to React Router. Other binding responses retain their status and
+headers. Actions and other methods go directly to SSR. Static hits bypass SSR request hooks;
+wrap the returned fetch function if your application needs authentication for static files too.
+
+Successful files matching Vite's default `/assets/name-HASH.ext` convention (at least eight hash
+characters) receive `Cache-Control: public, max-age=31536000, immutable`, including conditional
+304 responses. Unhashed public files retain the binding's cache policy. Keep Vite's hashed naming
+convention; configure your own cache policy if you customize asset names.
+
+To rename the binding, use `assets: 'STATIC'` in `createWorkerHandler`, `binding: 'STATIC'` in
+Wrangler, and `getHtmlFromAssets(env, '/index.html', 'STATIC')`. `assets: false` disables static
+routing when another layer serves the files; you still need a shell provider.
+
+`getHtmlFromAssets` returns `Promise<() => { header: string; footer: string }>`. It fetches once per
+binding, path and outlet, coalesces concurrent loads, and supplies a fresh object for every request.
+Failed loads are retried on the next call. Call it during a request, when Workers permits binding I/O.
+Its fourth argument changes the outlet. Build a new Worker deployment when the HTML changes.
+
+## Preview and deploy
+
+```bash
+# Build client, regular server, route manifest, then Worker.
+npx ssr-boost build --focus-only all
+
+# Preview the built app with local Workers bindings in workerd.
+npx wrangler dev --local
+
+# Optional: inspect the deployable bundle without publishing.
+npx wrangler deploy --dry-run
+
+# Publish the Worker and its static assets together.
+npx wrangler deploy
+```
+
+Wrangler bundles the emitted Worker and dependencies. The minimal template runs without
+`nodejs_compat`. Do not import `node/production`, the Express adapter, or filesystem helpers into
+the Worker. The `cloudflare` entry and its library dependency graph contain no Node builtin imports.
+
+## Bindings in hooks and loaders
+
+Generate Worker globals with `wrangler types`, or use `@cloudflare/workers-types` in a Worker-specific
+TypeScript config. Avoid mixing DOM and Workers global Fetch types in that config.
+
+```ts
+interface Env {
+  ASSETS: Fetcher;
+  MESSAGES: KVNamespace;
+}
+
+const fetch = createWorkerHandler<Env>({
+  App, routes, manifest,
+  getHtml: async (_request, env) => (await getHtmlFromAssets(env))(),
+  onRequest: ({ request, executionContext }) => {
+    const { env, ctx } = executionContext.platform;
+    executionContext.waitUntil(env.MESSAGES.put('last-path', new URL(request.url).pathname));
+    // ctx is the original Worker execution context.
+    return { headers: { 'X-Runtime': 'workerd' } };
+  },
+});
+
+export default { fetch } satisfies ExportedHandler<Env>;
+```
+
+Add your KV namespace to Wrangler with `kv_namespaces: [{ binding: 'MESSAGES', id: 'YOUR_KV_ID' }]`.
+The local preview uses local KV data; seed it with
+`npx wrangler kv key put --binding MESSAGES --local greeting 'Hello from KV'`.
+
+All render hooks receive `context.executionContext`. `onRequest` and `prepare` also receive
+`executionContext` directly. The default loader context is the SSR request context:
+
+```ts
+import type { LoaderFunctionArgs } from 'react-router';
+import type { ISsrRequestContext } from '@lomray/vite-ssr-boost/core/render';
+import type { IWorkerPlatform } from '@lomray/vite-ssr-boost/cloudflare';
+
+export async function loader({ context }: LoaderFunctionArgs) {
+  const requestContext = context as unknown as ISsrRequestContext;
+  const { env } = requestContext.executionContext!.platform as IWorkerPlatform<Env>;
+  return { message: await env.MESSAGES.get('greeting') };
+}
+```
+
+An explicit `routerRequestContext` replaces the default loader context. Browser navigation runs
+Data mode loaders in the browser: use an HTTP endpoint for binding-backed data on client navigation.
+Do not serialize bindings or the execution context with `getState`.
+
+## Streaming and runtime limits
+
+Streamed HTML defaults to `Content-Encoding: identity` and appends `Cache-Control: no-transform`
+to preserve early chunks. In local workerd, automatic gzip buffered a small pending shell until the
+loader resolved; identity delivered the shell immediately. Static assets retain normal platform
+compression. You can override these defaults in `onShellReady` if you prefer platform compression;
+verify chunk delivery with your application and deployment. See
+[Cloudflare compression](https://developers.cloudflare.com/speed/optimization/content/compression/).
+
+The default streams HTML and deferred loader frames. Bot user agents, including Googlebot, wait
+for all content; `onRouterReady` can override `isStream`. `hydration: 'early'` enables interactive
+pending shells with an async browser entry. See [Stream loader data](/guide/data-streaming).
+
+Workers has no Early Hints transport for this handler. It never installs `onEarlyHints`; route
+styles and preload links are still injected into the document.
+
+Rendering consumes CPU time; awaiting I/O and elapsed request time are separate constraints.
+Choose `abortDelay` for your rendering deadline, give loaders their own I/O deadlines, and check
+your plan's [CPU, memory and duration limits](https://developers.cloudflare.com/workers/platform/limits/).
+`abortDelay` begins after loader preparation and does not extend Cloudflare's limits.
+Use bound `waitUntil` only for background work; its lifetime is limited too.
+See [Worker execution context](https://developers.cloudflare.com/workers/runtime-apis/context/).
+
+Workers cannot read your local build filesystem. Bundle the JSON manifest and fetch static files
+through the binding. Add `nodejs_compat` only when an application dependency needs supported Node
+APIs, then test that dependency in workerd. It does not turn a Worker into a Node server or give
+access to local build paths. See [Node compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+
+## Development
+
+Use `ssr-boost dev` for Express + Vite development, lazy route styles and HMR. Use a full build and
+`wrangler dev --local` to exercise Worker bindings and streaming before deployment.
+
+The Cloudflare Vite plugin assessment is recorded here after running the reproducible
+`node scripts/probe-worker-vite.mjs` probe. It uses `cloudflare({ viteEnvironment: { name: 'ssr' } })`
+with `SsrBoost()` and a source Worker with an empty development manifest. The production manifest
+is generated by a build and cannot supply current development route styles.
+
+Tested with Vite 8.2.2 and `@cloudflare/vite-plugin` 1.54.4:
+
+| Capability | Observed result |
+| --- | --- |
+| Worker modules and SSR | Loaded and rendered after restarting with inline `indexHtml` and `assets: false`. |
+| Assets-backed shell | The plugin rejected the helper's synthetic `/index.html` request with 403. |
+| Bindings | KV reads and bound `waitUntil` worked in the inline-shell configuration. |
+| Lazy route CSS | Absent from the initial SSR document. With static routing disabled, CSS requests returned 404. |
+| Browser entry | Returned 404 in the inline-shell configuration; the source shell had no Vite client injection. |
+| SSR reload | Editing the lazy route did not update subsequent SSR responses during the probe. |
+| Browser hydration / HMR | Not verified in a browser; the missing entry and styles already prevent recommending this configuration. |
+
+Use the managed development path. The probe's temporary inline-shell variant isolates module
+loading and bindings from the asset failures.
+
+Cloudflare's plugin supplies a Workers environment and HMR support, but the SSR BOOST integration
+must also provide the development HTML, route styles and hydration behavior.
+See [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) and
+[Vite environments](https://developers.cloudflare.com/workers/vite-plugin/reference/vite-environments/).
+
+## Tests
+
+From the SSR BOOST repository, after `npm run build`:
+
+```bash
+npm run test:worker:packed
+npm run test:worker:browser
+```
+
+The packed test installs the tarball into a temporary minimal template, builds all entries, checks
+Worker types, bundles with Wrangler, and boots workerd with Static Assets and KV. It checks routes,
+cookies, deferred frames, bot buffering, binding reads, `waitUntil`, cache headers and HEAD requests.
+The browser suite checks hydration, navigation, lazy CSS and interactive deferred boundaries.

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -34,6 +34,11 @@ When server output is built, the package also generates an SSR manifest for rout
 
 This is useful when you want production-like behavior locally without switching to a manual build plus start sequence.
 
+## Cloudflare Workers
+
+See [Cloudflare Workers](/guide/cloudflare) for the Worker entry, Static Assets binding,
+`ssr-boost build --focus-only all`, Wrangler preview and deployment.
+
 ## Docker
 
 ```bash

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -9,8 +9,9 @@ type SsrHandler = (
 ) => Promise<Response>;
 ```
 
-`SsrExecutionContext` is optional and only carries capabilities that cannot fit in a final
-`Response`, currently `onEarlyHints`.
+`SsrExecutionContext` is optional and carries `onEarlyHints`, adapter-specific `platform` data
+and `waitUntil`. Hooks and default loader context can also access it as `context.executionContext`.
+See [Cloudflare Workers](/guide/cloudflare) for a complete Worker build and Static Assets path.
 
 Choose the managed CLI server for Vite development, HMR, asset manifests and production static
 files. It still uses Express. Choose a Fetch handler when your application or hosting platform

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "@babel/parser": "^8.0.4",
         "@babel/traverse": "^8.0.4",
         "@babel/types": "^8.0.4",
+        "@cloudflare/vite-plugin": "^1.54.4",
+        "@cloudflare/workers-types": "^5.20260906.1",
         "@commitlint/cli": "^21.2.2",
         "@commitlint/config-conventional": "^21.2.2",
         "@lomray/eslint-config": "^7.0.0",
@@ -75,7 +77,8 @@
         "typescript-eslint": "^8.69.0",
         "vite": "^8.2.2",
         "vitepress": "^1.6.4",
-        "vitest": "^5.0.0"
+        "vitest": "^5.0.0",
+        "wrangler": "^4.129.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -636,6 +639,188 @@
         "keyv": "^5.6.0"
       }
     },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.54.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.54.4.tgz",
+      "integrity": "sha512-UkwrW3lcjm9dbRnOyWr8M5e5GzdVLGd6Tz92qk1K7XOE5uEuuE4BtfnfNlKe9IoimZijqsU3Bwdlyxhquk1yMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.1",
+        "miniflare": "5.20260903.0-alpha",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260903.1",
+        "wrangler": "4.129.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "cf-vite": "bin/cf-vite"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.129.0"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/miniflare": {
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260903.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin/node_modules/workerd": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20260730.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
@@ -720,6 +905,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260906.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260906.1.tgz",
+      "integrity": "sha512-mRKC5n+9OP7tZiOu7vMv2MZ+Arh3tX4b9gVAt43WFns83LNzWchhfRs9o2IkFCnYKovHo4m4Af1P4zPQWdLx0g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -6657,6 +6849,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -14096,6 +14295,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -16784,6 +16990,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
@@ -18012,6 +18228,667 @@
         "@cloudflare/workerd-linux-64": "1.20260730.1",
         "@cloudflare/workerd-linux-arm64": "1.20260730.1",
         "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260903.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260903.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260903.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260903.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,9 @@
     "test:template": "npm run build && node scripts/test-template.mjs",
     "test:coverage": "vitest run --coverage",
     "prepare": "husky",
-    "test:browser": "playwright test --config playwright.config.mjs"
+    "test:browser": "playwright test --config playwright.config.mjs",
+    "test:worker:packed": "node scripts/test-packed-worker.mjs",
+    "test:worker:browser": "playwright test --config playwright.worker.config.mjs"
   },
   "dependencies": {
     "chalk": "^6.0.0",
@@ -117,6 +119,8 @@
     "@babel/parser": "^8.0.4",
     "@babel/traverse": "^8.0.4",
     "@babel/types": "^8.0.4",
+    "@cloudflare/vite-plugin": "^1.54.4",
+    "@cloudflare/workers-types": "^5.20260906.1",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@lomray/eslint-config": "^7.0.0",
@@ -164,7 +168,8 @@
     "typescript-eslint": "^8.69.0",
     "vite": "^8.2.2",
     "vitepress": "^1.6.4",
-    "vitest": "^5.0.0"
+    "vitest": "^5.0.0",
+    "wrangler": "^4.129.0"
   },
   "peerDependencies": {
     "@babel/generator": ">=7.23.0",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './browser-tests',
-  testIgnore: 'template.spec.mjs',
+  testIgnore: ['template.spec.mjs', '**/worker/**'],
   workers: 1,
   timeout: 30_000,
   reporter: 'list',

--- a/playwright.worker.config.mjs
+++ b/playwright.worker.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './browser-tests/worker',
+  workers: 1,
+  timeout: 30_000,
+  reporter: 'list',
+  use: { baseURL: 'http://127.0.0.1:4180' },
+  webServer: {
+    command: 'node scripts/worker-browser-server.mjs',
+    url: 'http://127.0.0.1:4180',
+    reuseExistingServer: false,
+    timeout: 180_000,
+  },
+});

--- a/scripts/helpers/worker-fixture.mjs
+++ b/scripts/helpers/worker-fixture.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { Miniflare } from 'miniflare';
+
+export const createWorkerFixture = async ({ keep = false } = {}) => {
+  const root = resolve(import.meta.dirname, '../..');
+  const directory = await mkdtemp(join(tmpdir(), 'ssr-boost-worker-'));
+  const env = {
+    ...process.env,
+    PATH: `${join(directory, 'node_modules/.bin')}:${process.env.PATH}`,
+  };
+  delete env.NO_COLOR;
+  const run = (command, args) =>
+    execFileSync(command, args, { cwd: directory, env, stdio: 'inherit' });
+  const dispose = () =>
+    keep
+      ? console.info(`Worker fixture retained: ${directory}`)
+      : rm(directory, { force: true, recursive: true });
+  try {
+    const fixture = join(root, '__fixtures__/worker-template');
+    for (const file of await readdir(fixture, { recursive: true })) {
+      if (!file.endsWith('.txt')) continue;
+      const target = join(directory, file.slice(0, -4));
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, await readFile(join(fixture, file)));
+    }
+    const packed = execFileSync(
+      'npm',
+      ['pack', join(root, 'lib'), '--ignore-scripts', '--json', '--pack-destination', directory],
+      { cwd: root, env, encoding: 'utf8' },
+    );
+    const [archive] = JSON.parse(packed);
+    const packages = [join(directory, archive.filename)];
+    for (const name of [
+      'vite',
+      'react',
+      'react-dom',
+      'react-router',
+      'wrangler',
+      'typescript',
+      '@cloudflare/workers-types',
+      '@types/react',
+      '@types/react-dom',
+      '@babel/generator',
+      '@babel/parser',
+      '@babel/traverse',
+      '@babel/types',
+    ]) {
+      const { version } = JSON.parse(
+        await readFile(join(root, 'node_modules', name, 'package.json'), 'utf8'),
+      );
+      packages.push(`${name}@${version}`);
+    }
+    run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', ...packages]);
+    run(process.execPath, [
+      join(directory, 'node_modules/@lomray/vite-ssr-boost/cli.js'),
+      'build',
+      '--focus-only',
+      'all',
+    ]);
+    run(process.execPath, [
+      join(directory, 'node_modules/typescript/bin/tsc'),
+      '--project',
+      'tsconfig.worker.json',
+    ]);
+    console.info('PASS Worker entry satisfies ExportedHandler<Env> with Cloudflare globals');
+    const manifest = JSON.parse(
+      await readFile(join(directory, 'build/client/assets-manifest.json'), 'utf8'),
+    );
+    assert.deepEqual(
+      manifest,
+      JSON.parse(await readFile(join(directory, 'build/server/assets-manifest.json'), 'utf8')),
+    );
+    assert.ok(
+      manifest.about.some((asset) => asset.type === 'style'),
+      'CLI must generate lazy route CSS',
+    );
+    run(process.execPath, [
+      join(directory, 'node_modules/wrangler/bin/wrangler.js'),
+      'deploy',
+      '--dry-run',
+      '--outdir',
+      '.worker-bundle',
+    ]);
+    const scriptPath = join(directory, '.worker-bundle/worker.js');
+    const script = await readFile(scriptPath, 'utf8');
+    assert.doesNotMatch(
+      script,
+      /(?:\bfrom\s*|\bimport\s*\(?\s*)['"]node:/,
+      'Worker must bundle without Node builtins',
+    );
+    console.info(
+      'Worker fixture: packed install, CLI client/server/worker build and Wrangler dry run passed',
+    );
+    return { directory, manifest, scriptPath, dispose, run };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+};
+
+export const bootWorkerFixture = async (fixture, port) => {
+  const config = JSON.parse(await readFile(join(fixture.directory, 'wrangler.jsonc'), 'utf8'));
+  assert.equal(
+    config.compatibility_flags,
+    undefined,
+    'Minimal Worker must not require nodejs_compat',
+  );
+  const runtime = new Miniflare({
+    modules: [
+      { type: 'ESModule', path: 'worker.js', contents: await readFile(fixture.scriptPath, 'utf8') },
+    ],
+    compatibilityDate: config.compatibility_date,
+    compatibilityFlags: [],
+    host: '127.0.0.1',
+    port,
+    assets: {
+      directory: join(fixture.directory, config.assets.directory),
+      binding: config.assets.binding,
+      routerConfig: {
+        has_user_worker: true,
+        invoke_user_worker_ahead_of_assets: config.assets.run_worker_first,
+      },
+      assetConfig: {
+        html_handling: config.assets.html_handling,
+        not_found_handling: config.assets.not_found_handling,
+      },
+    },
+    kvNamespaces: config.kv_namespaces.map(({ binding }) => binding),
+  });
+  try {
+    await runtime.ready;
+    const kv = await runtime.getKVNamespace('MESSAGES');
+    await kv.put('greeting', 'Hello from KV');
+    return { runtime, kv };
+  } catch (error) {
+    await runtime.dispose();
+    throw error;
+  }
+};

--- a/scripts/probe-worker-vite.mjs
+++ b/scripts/probe-worker-vite.mjs
@@ -1,0 +1,157 @@
+// Reproduce the optional Cloudflare Vite integration assessment in a temporary app.
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createWorkerFixture } from './helpers/worker-fixture.mjs';
+
+const fixture = await createWorkerFixture();
+let child;
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+try {
+  const { version } = JSON.parse(
+    await readFile(
+      new URL('../node_modules/@cloudflare/vite-plugin/package.json', import.meta.url),
+      'utf8',
+    ),
+  );
+  fixture.run('npm', [
+    'install',
+    '--save-dev',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    `@cloudflare/vite-plugin@${version}`,
+  ]);
+  const config = JSON.parse(await readFile(join(fixture.directory, 'wrangler.jsonc'), 'utf8'));
+  config.main = 'src/worker-dev.ts';
+  delete config.assets.directory;
+  await writeFile(join(fixture.directory, 'wrangler.dev.jsonc'), JSON.stringify(config, null, 2));
+  const worker = await readFile(join(fixture.directory, 'src/worker.ts'), 'utf8');
+  await writeFile(
+    join(fixture.directory, 'src/worker-dev.ts'),
+    worker.replace(
+      "import manifest from '../build/client/assets-manifest.json';",
+      'const manifest = {};',
+    ),
+  );
+  const viteConfig = await readFile(join(fixture.directory, 'vite.config.ts'), 'utf8');
+  await writeFile(
+    join(fixture.directory, 'vite.dev.config.ts'),
+    `import { cloudflare } from '@cloudflare/vite-plugin';\n${viteConfig.replace('plugins: [SsrBoost', "plugins: [cloudflare({ configPath: '../wrangler.dev.jsonc', viteEnvironment: { name: 'ssr' } }), SsrBoost")}`,
+  );
+  const env = { ...process.env };
+  delete env.NO_COLOR;
+  const stop = async () => {
+    if (child && child.exitCode === null) {
+      const closed = once(child, 'close');
+      child.kill('SIGTERM');
+      const timeout = setTimeout(() => child.kill('SIGKILL'), 5000);
+      await closed;
+      clearTimeout(timeout);
+    }
+  };
+  const start = async () => {
+    child = spawn(
+      process.execPath,
+      [
+        join(fixture.directory, 'node_modules/vite/bin/vite.js'),
+        '--config',
+        'vite.dev.config.ts',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        '4181',
+        '--strictPort',
+      ],
+      { cwd: fixture.directory, env, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let output = '';
+    const capture = (chunk) => {
+      output += chunk;
+      process.stdout.write(chunk);
+    };
+    child.stdout.on('data', capture);
+    child.stderr.on('data', capture);
+    for (let i = 0; !output.includes('Local:') && i < 300; i++) {
+      if (child.exitCode !== null) throw new Error('Vite exited before startup');
+      await delay(100);
+    }
+  };
+  await start();
+  const origin = 'http://127.0.0.1:4181';
+  const inspect = async (path) => {
+    const response = await fetch(`${origin}${path}`, { signal: AbortSignal.timeout(20_000) });
+    const html = await response.text();
+    console.info(
+      `Vite probe ${path}: ${response.status}; SSR=${html.includes('window.__staticRouterHydrationData')}; Vite client=${html.includes('/@vite/client')}`,
+    );
+    return { response, html };
+  };
+  let home = await inspect('/');
+  if (home.response.status !== 200) {
+    console.info(
+      'Assets-backed HTML shell: GAP (see binding error above); trying the supported inline indexHtml option.',
+    );
+    const inlineWorker = worker
+      .replace(
+        "import manifest from '../build/client/assets-manifest.json';",
+        "import indexHtml from './index.html?raw';\nconst manifest = {};",
+      )
+      .replace(
+        "getHtml: async (_request, env) => (await getHtmlFromAssets(env, '/index.html'))(),",
+        'indexHtml, assets: false,',
+      );
+    await writeFile(join(fixture.directory, 'src/worker-dev.ts'), inlineWorker);
+    await stop();
+    await start();
+    home = await inspect('/');
+  }
+  console.info(
+    `Module loading: ${home.response.status === 200 && home.html.includes('Worker home') ? 'PASS Worker SSR' : 'GAP Worker SSR failed'}`,
+  );
+  const about = await inspect('/about');
+  console.info(
+    `Lazy CSS in initial SSR HTML: ${about.html.includes('window.__staticRouterHydrationData') && /about\.css|\.about\s*\{/.test(about.html) ? 'present' : 'GAP absent'}`,
+  );
+  const css = await fetch(`${origin}/about.css`);
+  console.info(
+    `Vite CSS module: ${css.status}; ${(await css.text()).includes('12, 34, 56') ? 'style available' : 'style absent'}`,
+  );
+  const bindings = await inspect('/bindings');
+  console.info(
+    `Bindings: ${bindings.response.status === 200 && bindings.response.headers.get('X-Worker-Hook') === 'ready' ? 'KV read and waitUntil reached workerd' : 'GAP request failed'}`,
+  );
+  const filename = join(fixture.directory, 'src/About.tsx');
+  const original = await readFile(filename, 'utf8');
+  await writeFile(filename, original.replace('Lazy Worker route', 'Worker module updated'));
+  let updated = false;
+  for (let i = 0; i < 50; i++) {
+    const html = await fetch(`${origin}/about`).then((response) => response.text());
+    if (html.includes('Worker module updated')) {
+      updated = true;
+      break;
+    }
+    await delay(100);
+  }
+  console.info(`SSR module reload after edit: ${updated ? 'PASS' : 'GAP no update'}`);
+  const client = await inspect('/client.tsx');
+  console.info(`Browser entry module loading: ${client.response.status}`);
+  console.info(
+    'Browser HMR and hydration: not run (requires browser); HTTP module reload is not proof of browser HMR.',
+  );
+  console.info(
+    `Cloudflare Vite plugin ${version} probe complete; use ssr-boost dev until SSR lazy CSS and browser hydration/HMR work end to end.`,
+  );
+  assert.ok(child.exitCode === null, 'Vite must remain running during probe');
+} finally {
+  if (child && child.exitCode === null) {
+    const closed = once(child, 'close');
+    child.kill('SIGTERM');
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 5000);
+    await closed;
+    clearTimeout(timeout);
+  }
+  await fixture.dispose();
+}

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -35,7 +35,7 @@ const { exports: publicExports } = JSON.parse(await readFile(resolve(projectRoot
 const excludedPaths = [
   // The HTTP policy entry is server-side, even though it also supports edge runtimes.
   /^http\.js$/,
-  /^(?:server|core|edge|node|testing|adapters?|cli|plugins?|services|workflow)(?:\/|\.js$)/,
+  /^(?:server|cloudflare|core|edge|node|testing|adapters?|cli|plugins?|services|workflow)(?:\/|\.js$)/,
   /^constants\/(?:cli-|plugin-|stream-error\.js$)/,
   /^helpers\/(?:build-(?:custom|router)-state|create-focus-only|dev-marker|html-escape|is-route-file|obtain-stream-error|plugin-config|print-server-(?:info|urls)|process-stop|resolve-server-urls|serialize-errors|vite-aliases)\.js$/,
   // These exports have declarations but no browser runtime.

--- a/scripts/test-packed-worker.mjs
+++ b/scripts/test-packed-worker.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { bootWorkerFixture, createWorkerFixture } from './helpers/worker-fixture.mjs';
+
+const fixture = await createWorkerFixture({ keep: process.env.SSR_BOOST_KEEP_WORKER === '1' });
+let runtime;
+try {
+  const booted = await bootWorkerFixture(fixture);
+  runtime = booted.runtime;
+  const origin = String(await runtime.ready);
+  const request = (path, init = {}) =>
+    fetch(new URL(path, origin), { redirect: 'manual', ...init });
+  await Promise.all(
+    Array.from({ length: 3 }, async () => {
+      const response = await request('/');
+      assert.equal(response.status, 200);
+      assert.match(await response.text(), /Worker home/);
+    }),
+  );
+  console.info('PASS concurrent cold requests share the HTML shell safely');
+  for (const [path, status, content] of [
+    ['/', 200, 'Worker home'],
+    ['/index.html', 404, 'Missing page'],
+    ['/about', 200, 'Lazy Worker route'],
+    ['/missing', 404, 'Missing page'],
+  ]) {
+    const response = await request(path);
+    const html = await response.text();
+    assert.equal(response.status, status, path);
+    assert.ok(html.includes(content), path);
+    assert.match(html, /window\.__staticRouterHydrationData/);
+    assert.match(
+      html,
+      /<script\b[^>]*async[^>]*type="module"/,
+      'Early hydration requires an async browser entry',
+    );
+    assert.equal(response.headers.get('X-Worker-Hook'), 'ready');
+    if (path === '/about') {
+      const style = fixture.manifest.about.find((asset) => asset.type === 'style').url;
+      assert.ok(html.includes(`<link rel="stylesheet" href="${style}">`));
+    }
+  }
+  console.info(
+    'PASS / SSR + hydration state; /about lazy CSS; /missing 404; /index.html never leaks the raw shell',
+  );
+  const redirect = await request('/redirect');
+  assert.equal(redirect.status, 301);
+  assert.equal(redirect.headers.get('Location'), '/about');
+  assert.match(redirect.headers.get('Set-Cookie'), /visits=1/);
+  await redirect.arrayBuffer();
+  const cookie = await request('/cookie');
+  const setCookie = cookie.headers.get('Set-Cookie').split(';')[0];
+  assert.match(await cookie.text(), /visits.*1/);
+  const roundTrip = await request('/cookie', { headers: { Cookie: setCookie } });
+  assert.equal(roundTrip.status, 200);
+  assert.match(await roundTrip.text(), /visits.*2/);
+  assert.match(roundTrip.headers.get('Set-Cookie'), /visits=2/);
+  console.info('PASS /redirect 301 and onRequest cookie round trip');
+  const bindings = await request('/bindings');
+  assert.equal(bindings.status, 200);
+  assert.match(await bindings.text(), /Hello from KV/);
+  for (let attempt = 0; attempt < 30 && (await booted.kv.get('background')) !== 'done'; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.equal(await booted.kv.get('background'), 'done');
+  console.info('PASS loader KV read, executionContext in hooks and bound waitUntil KV write');
+  const streamed = await request('/deferred');
+  assert.equal(streamed.status, 200);
+  const reader = streamed.body.getReader();
+  const decoder = new TextDecoder();
+  let html = '';
+  let chunks = 0;
+  let sawPending = false;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks += 1;
+    html += decoder.decode(value, { stream: true });
+    if (html.includes('data-fallback') && !html.includes('Resolved in workerd')) sawPending = true;
+  }
+  html += decoder.decode();
+  assert.ok(sawPending, 'Must receive pending shell before resolved HTML');
+  assert.ok(chunks > 1);
+  assert.match(html, /\["resolve"/);
+  assert.match(html, /data-resolved/);
+  assert.ok(
+    html.indexOf('["resolve"') < html.indexOf('<p data-resolved'),
+    'Data frames precede resolved HTML',
+  );
+  assert.match(html, /Resolved in workerd/);
+  assert.match(html, /<\/html>/);
+  const bot = await request('/deferred', { headers: { 'User-Agent': 'Googlebot' } });
+  const buffered = await bot.text();
+  assert.equal(bot.status, 200);
+  assert.doesNotMatch(buffered, /<!--\$\?-->/);
+  assert.match(buffered, /Resolved in workerd/);
+  console.info(
+    `PASS /deferred streamed shell, data frames then resolved HTML (${chunks} chunks); Googlebot has zero pending boundaries`,
+  );
+  const assets = fixture.manifest.about.filter((asset) => ['style', 'script'].includes(asset.type));
+  for (const asset of assets) {
+    const response = await request(asset.url);
+    assert.equal(response.status, 200, asset.url);
+    assert.equal(response.headers.get('Cache-Control'), 'public, max-age=31536000, immutable');
+    const etag = response.headers.get('ETag');
+    await response.arrayBuffer();
+    if (etag) {
+      const conditional = await request(asset.url, { headers: { 'If-None-Match': etag } });
+      assert.equal(conditional.status, 304);
+      assert.equal(conditional.headers.get('Cache-Control'), 'public, max-age=31536000, immutable');
+    }
+  }
+  for (const path of ['/robots.txt', '/health', '/assets/plain.txt']) {
+    const response = await request(path);
+    assert.equal(response.status, 200);
+    assert.ok(!response.headers.get('Cache-Control')?.includes('immutable'));
+    assert.doesNotMatch(await response.text(), /window\.__staticRouterHydrationData/);
+  }
+  for (const path of ['/', '/about', assets[0].url]) {
+    const response = await request(path, { method: 'HEAD' });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '');
+  }
+  console.info(
+    'PASS hashed static assets immutable (including 304), public files, extensionless file and HEAD',
+  );
+  console.info('Packed Worker acceptance passed in workerd without nodejs_compat.');
+} finally {
+  await runtime?.dispose();
+  await fixture.dispose();
+}

--- a/scripts/worker-browser-server.mjs
+++ b/scripts/worker-browser-server.mjs
@@ -1,0 +1,18 @@
+import { bootWorkerFixture, createWorkerFixture } from './helpers/worker-fixture.mjs';
+
+const fixture = await createWorkerFixture();
+let runtime;
+const stop = async () => {
+  await runtime?.dispose();
+  await fixture.dispose();
+};
+try {
+  ({ runtime } = await bootWorkerFixture(fixture, 4180));
+  console.info(`Worker browser fixture ready: ${await runtime.ready}`);
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.once(signal, () => void stop().then(() => process.exit(0)));
+  }
+} catch (error) {
+  await stop();
+  throw error;
+}

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -1,0 +1,244 @@
+import type { FC, PropsWithChildren } from 'react';
+import { createElement } from 'react';
+import type { RouteObject } from 'react-router';
+import { createStaticHandler } from 'react-router';
+import createHandler from '@core/handler';
+import type { ICreateHandlerOptions, IHtmlShell } from '@core/handler';
+import headResponse from '@core/head-response';
+import type { ISsrExecutionContext } from '@core/types';
+import renderToStream from '@edge/render-to-stream';
+import type { TRouteObject } from '@interfaces/route-object';
+import { splitHtmlShell } from '@services/diagnostics';
+import createAssetPreparer from '@services/route-asset-preparer';
+import RouteAssets from '@services/route-assets-memory';
+import type { TRouteAssetsManifest } from '@services/route-assets-memory';
+
+/** Structural types keep Cloudflare's global declarations optional for consumers. */
+export interface IAssetsBinding {
+  fetch: (request: Request) => Promise<Response>;
+}
+
+export interface IWorkerContext {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+
+export interface IWorkerPlatform<TEnv = Record<string, unknown>> {
+  env: TEnv;
+  ctx: IWorkerContext;
+}
+
+export interface IWorkerExecutionContext<TEnv> extends ISsrExecutionContext<IWorkerPlatform<TEnv>> {
+  platform: IWorkerPlatform<TEnv>;
+  waitUntil: IWorkerContext['waitUntil'];
+}
+
+export type TWorkerHandler<TEnv = Record<string, unknown>> = (
+  request: Request,
+  env: TEnv,
+  ctx: IWorkerContext,
+) => Promise<Response>;
+
+type TWorkerHtml<TEnv> =
+  | {
+      getHtml: (
+        request: Request,
+        env: TEnv,
+        ctx: IWorkerContext,
+      ) => IHtmlShell | Promise<IHtmlShell>;
+      indexHtml?: never;
+    }
+  | { indexHtml: string; getHtml?: never };
+
+export type IWorkerHandlerOptions<
+  TEnv = Record<string, unknown>,
+  TAppProps = Record<string, any>,
+> = Omit<ICreateHandlerOptions<TAppProps>, 'getHtml' | 'onRequest'> &
+  TWorkerHtml<TEnv> & {
+    routes: TRouteObject[];
+    App: FC<PropsWithChildren<{ server: TAppProps }>>;
+    manifest: TRouteAssetsManifest;
+    /** Assets binding name, or false to delegate static delivery elsewhere. Default: ASSETS. */
+    assets?: string | false;
+    modulePreload?: boolean;
+    outlet?: string;
+    routerOptions?: Parameters<typeof createStaticHandler>[1];
+    onRequest?: (params: {
+      request: Request;
+      executionContext: IWorkerExecutionContext<TEnv>;
+    }) => ReturnType<NonNullable<ICreateHandlerOptions<TAppProps>['onRequest']>>;
+  };
+
+const CACHE_CONTROL = 'Cache-Control';
+
+const htmlCache = new WeakMap<object, Map<string, Promise<() => IHtmlShell>>>();
+
+/**
+ * Resolve a named static assets binding with an actionable configuration error.
+ */
+const getAssetsBinding = (env: object, name: string): IAssetsBinding => {
+  const binding = Reflect.get(env, name) as IAssetsBinding | undefined;
+
+  if (!binding || typeof binding.fetch !== 'function') {
+    throw new Error(`[ssr-boost] Missing Workers assets binding "${name}".`);
+  }
+
+  return binding;
+};
+
+/**
+ * Fetch and split the built HTML once per binding and path, returning fresh request shells.
+ * Failed loads are evicted so a transient binding error does not poison the isolate.
+ */
+export const getHtmlFromAssets = async (
+  env: object,
+  indexPath = '/index.html',
+  bindingName = 'ASSETS',
+  outlet = '<!--ssr-outlet-->',
+): Promise<() => IHtmlShell> => {
+  const binding = getAssetsBinding(env, bindingName);
+  let cache = htmlCache.get(binding);
+
+  if (!cache) {
+    cache = new Map();
+    htmlCache.set(binding, cache);
+  }
+
+  const key = JSON.stringify([indexPath, outlet]);
+  let pending = cache.get(key);
+
+  if (!pending) {
+    pending = (async () => {
+      const response = await binding.fetch(new Request(new URL(indexPath, 'https://assets.local')));
+
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(
+          `[ssr-boost] Failed to load "${indexPath}" from assets: ${response.status}.`,
+        );
+      }
+
+      const [header, footer] = splitHtmlShell(await response.text(), indexPath, outlet);
+
+      return () => ({ header, footer });
+    })();
+    cache.set(key, pending);
+    void pending.catch(() => cache.delete(key));
+  }
+
+  return pending;
+};
+
+/**
+ * Create a Fetch Worker with in-memory route assets and the Web stream renderer.
+ */
+export const createWorkerHandler = <
+  TEnv extends object = Record<string, unknown>,
+  TAppProps = Record<string, any>,
+>({
+  routes,
+  App,
+  manifest,
+  getHtml,
+  indexHtml,
+  assets = 'ASSETS',
+  modulePreload = false,
+  outlet = '<!--ssr-outlet-->',
+  routerOptions,
+  onRequest,
+  onRouterReady,
+  onShellReady,
+  prepare,
+  ...options
+}: IWorkerHandlerOptions<TEnv, TAppProps>): TWorkerHandler<TEnv> => {
+  const handler = createStaticHandler(routes as RouteObject[], routerOptions);
+  const prepareAssets = createAssetPreparer<TAppProps>(new RouteAssets(manifest, modulePreload));
+  const shell =
+    indexHtml === undefined ? undefined : splitHtmlShell(indexHtml, 'indexHtml', outlet);
+
+  return async (request, env, ctx) => {
+    const { pathname } = new URL(request.url);
+
+    if (
+      assets !== false &&
+      ['GET', 'HEAD'].includes(request.method) &&
+      pathname !== '/' &&
+      pathname !== '/index.html'
+    ) {
+      const response = await getAssetsBinding(env, assets).fetch(request);
+
+      if (response.status !== 404) {
+        if (
+          (response.ok || response.status === 304) &&
+          /\/assets\/[^/]+-[\w-]{8,}\.[^/]+$/.test(pathname)
+        ) {
+          const headers = new Headers(response.headers);
+
+          headers.set(CACHE_CONTROL, 'public, max-age=31536000, immutable');
+
+          return headResponse(
+            request,
+            new Response(response.body, {
+              status: response.status,
+              statusText: response.statusText,
+              headers,
+            }),
+          );
+        }
+
+        return headResponse(request, response);
+      }
+
+      await response.body?.cancel();
+    }
+
+    const executionContext: IWorkerExecutionContext<TEnv> = {
+      platform: { env, ctx },
+      waitUntil: ctx.waitUntil.bind(ctx) as IWorkerContext['waitUntil'],
+    };
+    const render = createHandler<TAppProps>(
+      {
+        handler,
+        createApp: (children, context) =>
+          createElement(App, { server: context.appProps }, children),
+        renderToStream,
+      },
+      {
+        diagnostics: false,
+        ...options,
+        getHtml: () =>
+          getHtml ? getHtml(request, env, ctx) : { header: shell![0], footer: shell![1] },
+        onRequest: onRequest ? () => onRequest({ request, executionContext }) : undefined,
+        prepare: async (params) => {
+          await prepareAssets(params);
+          await prepare?.(params);
+        },
+        onShellReady: (params) => {
+          const { context } = params;
+
+          // workerd's automatic gzip can buffer a small pending shell until allReady.
+          if (context.isStream && !context.response.headers.has('Content-Encoding')) {
+            context.response.headers.set('Content-Encoding', 'identity');
+
+            if (!context.response.headers.get(CACHE_CONTROL)?.includes('no-transform')) {
+              context.response.headers.append(CACHE_CONTROL, 'no-transform');
+            }
+          }
+
+          return onShellReady?.(params) ?? {};
+        },
+        onRouterReady: async (params) => ({
+          isStream: !/bot|crawler|spider|slurp|bingpreview/i.test(
+            request.headers.get('User-Agent') ?? '',
+          ),
+          ...(await onRouterReady?.(params)),
+        }),
+      },
+    );
+
+    return render(request, executionContext);
+  };
+};
+
+export { RouteAssets };
+
+export type { TRouteAssetsManifest, IHtmlShell };

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -81,6 +81,7 @@ const createHandler = <TAppProps = Record<string, any>>(
       const context: ISsrRequestContext<TAppProps> = {
         appProps: (metadata?.appProps ?? {}) as NonNullable<TAppProps>,
         diagnostics: isEnabled ? new Diagnostics(new URL(request.url).pathname) : undefined,
+        executionContext,
         html: isBypass ? { header: '', footer: '' } : await getHtml(request),
         request,
         response: {

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -26,6 +26,7 @@ export interface ISsrRequestContext<TAppProps = Record<string, any>> {
   appProps: NonNullable<TAppProps>;
   diagnostics?: Diagnostics;
   timeline?: RequestTimeline;
+  executionContext?: ISsrExecutionContext;
 
   /**
    * First render failure, or the explicit timeout/cancellation classification.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,9 @@
-export interface ISsrExecutionContext {
+export interface ISsrExecutionContext<TPlatform = unknown> {
+  /** Runtime bindings and the native execution context, supplied by an adapter. */
+  platform?: TPlatform;
+  /** Extend request lifetime for background work supported by the runtime. */
+  waitUntil?: (promise: Promise<unknown>) => void;
+
   /**
    * Deliver informational headers outside the final Fetch response when supported.
    */

--- a/src/node/production.ts
+++ b/src/node/production.ts
@@ -1,17 +1,18 @@
 import { readFile } from 'node:fs/promises';
 import type { ICreateHandlerOptions, IHtmlShell } from '@core/handler';
 import { splitHtmlShell } from '@services/diagnostics';
+import createAssetPreparer from '@services/route-asset-preparer';
 import RouteAssets from '@services/route-assets';
+import type { TRouteAssetsManifest } from '@services/route-assets';
 
 interface ILoadHtmlShellOptions {
   indexFile: string;
   outlet?: string;
 }
 
-interface IRouteAssetPreparerOptions {
-  buildDir: string;
-  modulePreload?: boolean;
-}
+type IRouteAssetPreparerOptions = (
+  { buildDir: string; manifest?: never } | { manifest: TRouteAssetsManifest; buildDir?: never }
+) & { modulePreload?: boolean };
 
 /**
  * Read a built document once and supply a fresh shell for each request.
@@ -31,19 +32,12 @@ const loadHtmlShell = async ({
  */
 const createRouteAssetPreparer = <TAppProps = Record<string, any>>({
   buildDir,
+  manifest,
   modulePreload = false,
 }: IRouteAssetPreparerOptions): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
-  const assets = new RouteAssets(buildDir, modulePreload);
-
-  return async ({ context, executionContext }) => {
-    const hints = assets.injectAssets(context);
-
-    if (hints.has('Link')) {
-      await executionContext?.onEarlyHints?.(hints);
-    }
-  };
+  return createAssetPreparer(new RouteAssets(manifest ?? buildDir, modulePreload));
 };
 
 export { createRouteAssetPreparer, loadHtmlShell };
 
-export type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions };
+export type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions, TRouteAssetsManifest };

--- a/src/services/route-asset-preparer.ts
+++ b/src/services/route-asset-preparer.ts
@@ -1,0 +1,19 @@
+import type { ICreateHandlerOptions } from '@core/handler';
+import type RouteAssets from '@services/route-assets-memory';
+
+/**
+ * Share route injection across runtimes, computing hints only for supported transports.
+ */
+const createAssetPreparer = <TAppProps = Record<string, any>>(
+  assets: RouteAssets,
+): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
+  return async ({ context, executionContext }) => {
+    const hints = assets.injectAssets(context, Boolean(executionContext?.onEarlyHints));
+
+    if (hints.has('Link')) {
+      await executionContext?.onEarlyHints?.(hints);
+    }
+  };
+};
+
+export default createAssetPreparer;

--- a/src/services/route-assets-memory.ts
+++ b/src/services/route-assets-memory.ts
@@ -1,0 +1,147 @@
+import type { RouterState, StaticHandlerContext } from 'react-router';
+
+enum AssetType {
+  style = 'style',
+  script = 'script',
+  image = 'image',
+  font = 'font',
+}
+
+interface IAsset {
+  type: string;
+  url: string;
+  weight: number;
+  isNested: boolean;
+  isPreload: boolean;
+  content?: string;
+}
+
+type TAssets = { [id: string]: IAsset };
+
+/** Parsed build/client/assets-manifest.json; accepts a JSON module directly. */
+type TRouteAssetsManifest = Readonly<Record<string, readonly IAsset[]>>;
+
+interface IInjectAssetsContext {
+  html: {
+    header: string;
+  };
+  routerContext?: StaticHandlerContext;
+  matches?: RouterState['matches'];
+  isSpa?: boolean;
+}
+
+/**
+ * Load and inject route assets with an independent cache for one build.
+ */
+class RouteAssets {
+  protected readonly modulePreload: boolean;
+
+  protected routesAssets: TRouteAssetsManifest | null;
+
+  constructor(manifest: TRouteAssetsManifest, modulePreload = false) {
+    this.routesAssets = manifest;
+    this.modulePreload = modulePreload;
+  }
+
+  /**
+   * Development manifests override this to inject inline styles.
+   */
+  protected get isDev(): boolean {
+    return false;
+  }
+
+  /**
+   * Read the manifest without requiring a filesystem.
+   */
+  protected loadAssetsManifest(): TRouteAssetsManifest {
+    return this.routesAssets ?? {};
+  }
+
+  /**
+   * Sort assets
+   */
+  protected sortAssets(assets: IAsset[]): IAsset[] {
+    return assets.sort((a, b) =>
+      a.weight === b.weight ? Number(a.isNested) - Number(b.isNested) : a.weight - b.weight,
+    );
+  }
+
+  /**
+   * Get route assets
+   */
+  // The development manifest uses the SPA flag to preload unqueried lazy routes.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getAssets(routes?: RouterState['matches'], _isSpa?: boolean): IAsset[] {
+    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
+
+    if (!routeIds.length) {
+      return [];
+    }
+
+    const routesAssets = this.loadAssetsManifest();
+
+    return this.sortAssets(
+      routeIds
+        .map((routeId) => routesAssets[routeId])
+        .flat()
+        .filter(Boolean),
+    );
+  }
+
+  /**
+   * Build preload hints without depending on a particular HTTP transport.
+   */
+  public getEarlyHints(assets: IAsset[]): Headers {
+    const headers = new Headers();
+
+    assets.forEach(({ type, url }) => {
+      if (!type || !['style', 'script'].includes(type)) {
+        return;
+      }
+
+      headers.append('Link', `<${url}>; rel=preload; as=${type}`);
+    });
+
+    return headers;
+  }
+
+  /**
+   * Inject route assets to head html
+   */
+  public injectAssets(
+    { routerContext, matches, html, isSpa }: IInjectAssetsContext,
+    earlyHints = true,
+  ): Headers {
+    const assets = this.getAssets(matches ?? routerContext?.matches, isSpa);
+    const htmlAssets = assets
+      .map(({ type, url, isPreload, content = '' }) => {
+        switch (type) {
+          case 'style':
+            return this.isDev
+              ? `<style data-vite-dev-id="${url}">${content}</style>`
+              : `<link rel="stylesheet" href="${url}">`;
+
+          case 'script':
+            return isPreload
+              ? this.modulePreload || isSpa
+                ? // can reduce lighthouse performance
+                  `<link rel="modulepreload" as="script" crossorigin href="${url}">`
+                : null
+              : `<script async type="module" crossorigin src="${url}"></script>`;
+        }
+
+        return null;
+      })
+      .filter(Boolean);
+
+    html.header = html.header.replace('</head>', `${htmlAssets.join('\n')}</head>`);
+
+    return earlyHints ? this.getEarlyHints(assets) : new Headers();
+  }
+}
+
+export { AssetType };
+
+export type { IAsset, TAssets, TRouteAssetsManifest };
+
+export default RouteAssets;

--- a/src/services/route-assets.ts
+++ b/src/services/route-assets.ts
@@ -1,54 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { RouterState, StaticHandlerContext } from 'react-router';
-
-enum AssetType {
-  style = 'style',
-  script = 'script',
-  image = 'image',
-  font = 'font',
-}
-
-interface IAsset {
-  type: AssetType;
-  url: string;
-  weight: number;
-  isNested: boolean;
-  isPreload: boolean;
-  content?: string;
-}
-
-type TAssets = { [id: string]: IAsset };
-
-interface IInjectAssetsContext {
-  html: {
-    header: string;
-  };
-  routerContext?: StaticHandlerContext;
-  matches?: RouterState['matches'];
-  isSpa?: boolean;
-}
+import MemoryRouteAssets from '@services/route-assets-memory';
+import type { TRouteAssetsManifest } from '@services/route-assets-memory';
 
 /**
- * Load and inject route assets with an independent cache for one build.
+ * Keep the Node manifest cache while also accepting a parsed JSON manifest.
  */
-class RouteAssets {
+class RouteAssets extends MemoryRouteAssets {
   protected readonly outputDir: string;
 
-  protected readonly modulePreload: boolean;
-
-  protected routesAssets: Record<string, IAsset[]> | null = null;
-
-  constructor(buildDir: string, modulePreload = false) {
-    this.outputDir = path.resolve(buildDir);
-    this.modulePreload = modulePreload;
-  }
-
-  /**
-   * Development manifests override this to inject inline styles.
-   */
-  protected get isDev(): boolean {
-    return false;
+  constructor(buildDir: string | TRouteAssetsManifest, modulePreload = false) {
+    super(typeof buildDir === 'string' ? {} : buildDir, modulePreload);
+    this.outputDir = typeof buildDir === 'string' ? path.resolve(buildDir) : '';
+    this.routesAssets = typeof buildDir === 'string' ? null : buildDir;
   }
 
   /**
@@ -59,9 +23,9 @@ class RouteAssets {
   }
 
   /**
-   * Load assets manifest
+   * Load and cache the Node manifest on first use.
    */
-  protected loadAssetsManifest(): Record<string, IAsset[]> {
+  protected loadAssetsManifest(): TRouteAssetsManifest {
     if (this.routesAssets !== null) {
       return this.routesAssets;
     }
@@ -72,96 +36,14 @@ class RouteAssets {
       return {};
     }
 
-    this.routesAssets = JSON.parse(fs.readFileSync(manifestFile, { encoding: 'utf-8' })) as Record<
-      string,
-      IAsset[]
-    >;
+    this.routesAssets = JSON.parse(fs.readFileSync(manifestFile, 'utf8')) as TRouteAssetsManifest;
 
     return this.routesAssets;
   }
-
-  /**
-   * Sort assets
-   */
-  protected sortAssets(assets: IAsset[]): IAsset[] {
-    return assets.sort((a, b) =>
-      a.weight === b.weight ? Number(a.isNested) - Number(b.isNested) : a.weight - b.weight,
-    );
-  }
-
-  /**
-   * Get route assets
-   */
-  // The development manifest uses the SPA flag to preload unqueried lazy routes.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getAssets(routes?: RouterState['matches'], _isSpa?: boolean): IAsset[] {
-    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
-
-    if (!routeIds.length) {
-      return [];
-    }
-
-    const routesAssets = this.loadAssetsManifest();
-
-    return this.sortAssets(
-      routeIds
-        .map((routeId) => routesAssets[routeId])
-        .flat()
-        .filter(Boolean),
-    );
-  }
-
-  /**
-   * Build preload hints without depending on a particular HTTP transport.
-   */
-  public getEarlyHints(assets: IAsset[]): Headers {
-    const headers = new Headers();
-
-    assets.forEach(({ type, url }) => {
-      if (!type || !['style', 'script'].includes(type)) {
-        return;
-      }
-
-      headers.append('Link', `<${url}>; rel=preload; as=${type}`);
-    });
-
-    return headers;
-  }
-
-  /**
-   * Inject route assets to head html
-   */
-  public injectAssets({ routerContext, matches, html, isSpa }: IInjectAssetsContext): Headers {
-    const assets = this.getAssets(matches ?? routerContext?.matches, isSpa);
-    const htmlAssets = assets
-      .map(({ type, url, isPreload, content = '' }) => {
-        switch (type) {
-          case AssetType.style:
-            return this.isDev
-              ? `<style data-vite-dev-id="${url}">${content}</style>`
-              : `<link rel="stylesheet" href="${url}">`;
-
-          case AssetType.script:
-            return isPreload
-              ? this.modulePreload || isSpa
-                ? // can reduce lighthouse performance
-                  `<link rel="modulepreload" as="script" crossorigin href="${url}">`
-                : null
-              : `<script async type="module" crossorigin src="${url}"></script>`;
-        }
-
-        return null;
-      })
-      .filter(Boolean);
-
-    html.header = html.header.replace('</head>', `${htmlAssets.join('\n')}</head>`);
-
-    return this.getEarlyHints(assets);
-  }
 }
 
-export { AssetType };
+export { AssetType } from '@services/route-assets-memory';
 
-export type { IAsset, TAssets };
+export type { IAsset, TAssets, TRouteAssetsManifest } from '@services/route-assets-memory';
 
 export default RouteAssets;

--- a/src/services/ssr-manifest.ts
+++ b/src/services/ssr-manifest.ts
@@ -256,9 +256,15 @@ class SsrManifest extends RouteAssets {
       result[routeId] = this.sortAssets(Object.values(this.getRouteAssets(manifest, routeMeta)));
     });
 
-    fs.writeFileSync(this.getAssetsManifestFile(), JSON.stringify(result, null, 2), {
-      encoding: 'utf-8',
-    });
+    const json = JSON.stringify(result, null, 2);
+
+    fs.writeFileSync(this.getAssetsManifestFile(), json, { encoding: 'utf-8' });
+    const clientDir = path.join(this.getOutDir(), 'client');
+
+    // A server-only build has no client output directory to copy the manifest into.
+    if (fs.existsSync(clientDir)) {
+      fs.writeFileSync(path.join(clientDir, 'assets-manifest.json'), json, { encoding: 'utf-8' });
+    }
   }
 
   /**


### PR DESCRIPTION
A complete Cloudflare Workers path:

- New edge-safe entry `@lomray/vite-ssr-boost/cloudflare`: `createWorkerHandler({ routes, App, manifest, getHtml | indexHtml, assets, ... })` returns a Worker `fetch(request, env, ctx)`. GET/HEAD requests try the Workers Static Assets binding first (hashed `/assets/name-HASH.ext` files get `public, max-age=31536000, immutable`, including 304s; a binding 404 falls through to SSR), everything else renders through the Fetch core with the Web-stream renderer. `env` and `ctx` reach hooks and loaders through `executionContext.platform`, with a bound `waitUntil`; Early Hints are never installed. `getHtmlFromAssets(env, indexPath, binding, outlet)` loads and splits `index.html` once per binding and returns fresh shells.
- Route assets without a file system: the asset injection moved to an in-memory implementation (`route-assets-memory`), the Node class wraps it, `createRouteAssetPreparer` accepts `{ manifest }` next to `{ buildDir }`, and full builds (`ssr-boost build --focus-only all`) emit the client-importable `build/client/assets-manifest.json` and the extra Worker entry.
- Streamed HTML in Workers defaults to `Content-Encoding: identity` plus `Cache-Control: no-transform`, because workerd's automatic gzip buffered the pending shell in the tests; hooks can override it.
- Guide `docs/guide/cloudflare.md` (worker entry, wrangler config, build/preview/deploy, bindings in hooks and loaders, limits) including a recorded assessment of `@cloudflare/vite-plugin` for development: module loading and bindings work, but the assets-backed shell, lazy route CSS and the browser entry do not, so `ssr-boost dev` stays the development path (a reproducible probe script is kept).
- Tests: unit coverage for the in-memory assets, shell loading and the Worker handler; `npm run test:worker:packed` packs the library into a minimal Worker template, builds all entries, checks the Worker types, bundles with Wrangler and boots workerd with real Static Assets and KV (routes, lazy CSS, 404, redirect and cookie round trip, KV read in a loader, `waitUntil` write, streamed `/deferred` frames, Googlebot buffering, immutable assets, HEAD); `npm run test:worker:browser` hydrates the workerd output in Chromium. Both are wired into PR and release CI.

Rebased onto staging with incremental SSR: the SPA-shell asset changes (`matches`, `isSpa`, module preloads) are ported into the in-memory implementation.

Verified locally on Node 22.23.2: lint, types, 843 unit/integration tests, build, the packed Worker suite in workerd and the two Chromium hydration tests.
