### PR TITLE
chore: document class members and helpers added in phase 3

### DIFF
--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -271,13 +271,15 @@ async function render(
       }
     }
 
+    const { response: initialResponse } = coreContext;
+
     syncResponse(coreContext, res, {
-      headers: new Headers(coreContext.response.headers),
-      status: coreContext.response.status,
+      headers: new Headers(initialResponse.headers),
+      status: initialResponse.status,
     });
 
-    if (coreContext.response.status === 200) {
-      coreContext.response.status = undefined;
+    if (initialResponse.status === 200) {
+      initialResponse.status = undefined;
     }
 
     /**
@@ -401,8 +403,9 @@ async function render(
         prepare: async ({ context: updated, executionContext }) => {
           const legacyContext = syncContext(updated);
           const manifest = SsrManifest.get(config);
+          const { matches, isSpa } = updated;
 
-          await manifest.prepareDevAssets(updated.matches, updated.isSpa);
+          await manifest.prepareDevAssets(matches, isSpa);
 
           const hints = manifest.injectAssets(legacyContext);
 

--- a/src/browser/entry.tsx
+++ b/src/browser/entry.tsx
@@ -121,6 +121,10 @@ async function entry<TAppProps>(
 
   const router = createRouter(routes as RouteObject[], routerOptions);
   const root = document.getElementById(rootId) as HTMLElement;
+
+  /**
+   * Honor SPA shell markers before choosing hydration or a client render.
+   */
   const isSSRMode =
     IS_SSR_MODE &&
     root.dataset['forceSpa'] !== '1' &&

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -49,17 +49,22 @@ type TWorkerHtml<TEnv> =
     }
   | { indexHtml: string; getHtml?: never };
 
-export type IWorkerHandlerOptions<
-  TEnv = Record<string, unknown>,
-  TAppProps = Record<string, any>,
-> = Omit<ICreateHandlerOptions<TAppProps>, 'getHtml' | 'onRequest'> &
+type TWorkerHandlerOptions<TEnv = Record<string, unknown>, TAppProps = Record<string, any>> = Omit<
+  ICreateHandlerOptions<TAppProps>,
+  'getHtml' | 'onRequest'
+> &
   TWorkerHtml<TEnv> & {
     routes: TRouteObject[];
     App: FC<PropsWithChildren<{ server: TAppProps }>>;
     manifest: TRouteAssetsManifest;
+
     /** Assets binding name, or false to delegate static delivery elsewhere. Default: ASSETS. */
     assets?: string | false;
+
+    /** Emit module preload hints when enabled; defaults to false. */
     modulePreload?: boolean;
+
+    /** HTML insertion marker; defaults to <!--ssr-outlet-->. */
     outlet?: string;
     routerOptions?: Parameters<typeof createStaticHandler>[1];
     onRequest?: (params: {
@@ -68,8 +73,14 @@ export type IWorkerHandlerOptions<
     }) => ReturnType<NonNullable<ICreateHandlerOptions<TAppProps>['onRequest']>>;
   };
 
+/**
+ * Share the cache policy field name across static and streamed responses.
+ */
 const CACHE_CONTROL = 'Cache-Control';
 
+/**
+ * Reuse HTML loads within a binding without retaining expired bindings.
+ */
 const htmlCache = new WeakMap<object, Map<string, Promise<() => IHtmlShell>>>();
 
 /**
@@ -107,21 +118,30 @@ export const getHtmlFromAssets = async (
   let pending = cache.get(key);
 
   if (!pending) {
+    /**
+     * Fetch the source document and retain its reusable shell factory.
+     */
     pending = (async () => {
       const response = await binding.fetch(new Request(new URL(indexPath, 'https://assets.local')));
+      const { ok: isOk, body, status } = response;
 
-      if (!response.ok) {
-        await response.body?.cancel();
-        throw new Error(
-          `[ssr-boost] Failed to load "${indexPath}" from assets: ${response.status}.`,
-        );
+      if (!isOk) {
+        await body?.cancel();
+        throw new Error(`[ssr-boost] Failed to load "${indexPath}" from assets: ${status}.`);
       }
 
       const [header, footer] = splitHtmlShell(await response.text(), indexPath, outlet);
 
+      /**
+       * Isolate mutable shell values for each request.
+       */
       return () => ({ header, footer });
     })();
     cache.set(key, pending);
+
+    /**
+     * Allow a later request to retry a failed asset load.
+     */
     void pending.catch(() => cache.delete(key));
   }
 
@@ -140,46 +160,48 @@ export const createWorkerHandler = <
   manifest,
   getHtml,
   indexHtml,
-  assets = 'ASSETS',
-  modulePreload = false,
-  outlet = '<!--ssr-outlet-->',
   routerOptions,
   onRequest,
   onRouterReady,
   onShellReady,
   prepare,
+  assets = 'ASSETS',
+  modulePreload = false,
+  outlet = '<!--ssr-outlet-->',
   ...options
-}: IWorkerHandlerOptions<TEnv, TAppProps>): TWorkerHandler<TEnv> => {
+}: TWorkerHandlerOptions<TEnv, TAppProps>): TWorkerHandler<TEnv> => {
   const handler = createStaticHandler(routes as RouteObject[], routerOptions);
   const prepareAssets = createAssetPreparer<TAppProps>(new RouteAssets(manifest, modulePreload));
   const shell =
     indexHtml === undefined ? undefined : splitHtmlShell(indexHtml, 'indexHtml', outlet);
 
+  /**
+   * Serve static assets or render the matched application request.
+   */
   return async (request, env, ctx) => {
-    const { pathname } = new URL(request.url);
+    const { url, method, headers: requestHeaders } = request;
+    const { pathname } = new URL(url);
 
     if (
       assets !== false &&
-      ['GET', 'HEAD'].includes(request.method) &&
+      ['GET', 'HEAD'].includes(method) &&
       pathname !== '/' &&
       pathname !== '/index.html'
     ) {
       const response = await getAssetsBinding(env, assets).fetch(request);
+      const { status, ok: isOk, headers: responseHeaders, body, statusText } = response;
 
-      if (response.status !== 404) {
-        if (
-          (response.ok || response.status === 304) &&
-          /\/assets\/[^/]+-[\w-]{8,}\.[^/]+$/.test(pathname)
-        ) {
-          const headers = new Headers(response.headers);
+      if (status !== 404) {
+        if ((isOk || status === 304) && /\/assets\/[^/]+-[\w-]{8,}\.[^/]+$/.test(pathname)) {
+          const headers = new Headers(responseHeaders);
 
           headers.set(CACHE_CONTROL, 'public, max-age=31536000, immutable');
 
           return headResponse(
             request,
-            new Response(response.body, {
-              status: response.status,
-              statusText: response.statusText,
+            new Response(body, {
+              status,
+              statusText,
               headers,
             }),
           );
@@ -188,7 +210,7 @@ export const createWorkerHandler = <
         return headResponse(request, response);
       }
 
-      await response.body?.cancel();
+      await body?.cancel();
     }
 
     const executionContext: IWorkerExecutionContext<TEnv> = {
@@ -198,6 +220,10 @@ export const createWorkerHandler = <
     const render = createHandler<TAppProps>(
       {
         handler,
+
+        /**
+         * Supply request props to the application's server wrapper.
+         */
         createApp: (children, context) =>
           createElement(App, { server: context.appProps }, children),
         renderToStream,
@@ -205,30 +231,52 @@ export const createWorkerHandler = <
       {
         diagnostics: false,
         ...options,
+
+        /**
+         * Resolve a request shell from the configured source.
+         */
         getHtml: () =>
           getHtml ? getHtml(request, env, ctx) : { header: shell![0], footer: shell![1] },
+
+        /**
+         * Expose Worker bindings and lifetime hooks to request initialization.
+         */
         onRequest: onRequest ? () => onRequest({ request, executionContext }) : undefined,
+
+        /**
+         * Inject route assets before running application preparation.
+         */
         prepare: async (params) => {
           await prepareAssets(params);
           await prepare?.(params);
         },
+
+        /**
+         * Keep the pending shell flushable before applying the application hook.
+         */
         onShellReady: (params) => {
           const { context } = params;
+          const { isStream, response } = context;
+          const { headers } = response;
 
           // workerd's automatic gzip can buffer a small pending shell until allReady.
-          if (context.isStream && !context.response.headers.has('Content-Encoding')) {
-            context.response.headers.set('Content-Encoding', 'identity');
+          if (isStream && !headers.has('Content-Encoding')) {
+            headers.set('Content-Encoding', 'identity');
 
-            if (!context.response.headers.get(CACHE_CONTROL)?.includes('no-transform')) {
-              context.response.headers.append(CACHE_CONTROL, 'no-transform');
+            if (!headers.get(CACHE_CONTROL)?.includes('no-transform')) {
+              headers.append(CACHE_CONTROL, 'no-transform');
             }
           }
 
           return onShellReady?.(params) ?? {};
         },
+
+        /**
+         * Default crawlers to buffered rendering while allowing an application override.
+         */
         onRouterReady: async (params) => ({
           isStream: !/bot|crawler|spider|slurp|bingpreview/i.test(
-            request.headers.get('User-Agent') ?? '',
+            requestHeaders.get('User-Agent') ?? '',
           ),
           ...(await onRouterReady?.(params)),
         }),
@@ -241,4 +289,4 @@ export const createWorkerHandler = <
 
 export { RouteAssets };
 
-export type { TRouteAssetsManifest, IHtmlShell };
+export type { TWorkerHandlerOptions as IWorkerHandlerOptions, TRouteAssetsManifest, IHtmlShell };

--- a/src/core/cache-control.ts
+++ b/src/core/cache-control.ts
@@ -1,9 +1,17 @@
 export interface ICachePolicy {
   public?: boolean;
   private?: boolean;
+
+  /** Non-negative integer seconds of freshness in any cache. */
   maxAge?: number;
+
+  /** Non-negative integer seconds of freshness in shared caches. */
   sMaxAge?: number;
+
+  /** Non-negative integer seconds to serve stale content during revalidation. */
   staleWhileRevalidate?: number;
+
+  /** Non-negative integer seconds to serve stale content after an error. */
   staleIfError?: number;
   noStore?: boolean;
   noCache?: boolean;
@@ -11,6 +19,9 @@ export interface ICachePolicy {
   immutable?: boolean;
 }
 
+/**
+ * Preserve a stable wire name and output order for each supported directive.
+ */
 const directives = {
   public: 'public',
   private: 'private',
@@ -23,6 +34,10 @@ const directives = {
   mustRevalidate: 'must-revalidate',
   immutable: 'immutable',
 } as const;
+
+/**
+ * Identify directives that require duration validation.
+ */
 const seconds = new Set(['maxAge', 'sMaxAge', 'staleWhileRevalidate', 'staleIfError']);
 
 /** Build a deterministic Cache-Control field; durations are non-negative integer seconds. */
@@ -49,23 +64,38 @@ const cacheControl = (policy: ICachePolicy): string => {
     }
   }
 
-  if (policy.public && policy.private) {
+  const {
+    public: isPublic,
+    private: isPrivate,
+    noStore: isNoStore,
+    immutable: isImmutable,
+    sMaxAge,
+    noCache: isNoCache,
+    mustRevalidate: shouldRevalidate,
+    staleWhileRevalidate,
+    staleIfError,
+  } = policy;
+
+  if (isPublic && isPrivate) {
     throw new TypeError('Cache policy cannot be both public and private.');
   }
 
   if (
-    (policy.noStore &&
-      (policy.public ||
-        policy.immutable ||
+    (isNoStore &&
+      (isPublic ||
+        isImmutable ||
         [...seconds].some((name) => policy[name as keyof ICachePolicy] !== undefined))) ||
-    (policy.private && policy.sMaxAge !== undefined) ||
-    (policy.immutable && (policy.noCache || policy.mustRevalidate)) ||
-    ((policy.noCache || policy.mustRevalidate) &&
-      (policy.staleWhileRevalidate !== undefined || policy.staleIfError !== undefined))
+    (isPrivate && sMaxAge !== undefined) ||
+    (isImmutable && (isNoCache || shouldRevalidate)) ||
+    ((isNoCache || shouldRevalidate) &&
+      (staleWhileRevalidate !== undefined || staleIfError !== undefined))
   ) {
     throw new TypeError('Cache policy contains conflicting directives.');
   }
 
+  /**
+   * Emit enabled directives in their declared order.
+   */
   return Object.entries(directives)
     .flatMap(([name, directive]) => {
       const value = policy[name as keyof ICachePolicy];

--- a/src/core/conditional-request.ts
+++ b/src/core/conditional-request.ts
@@ -1,11 +1,19 @@
 export interface IConditionalValidators {
   /** Quoted entity tag, optionally prefixed with W/. Must identify the selected representation. */
   etag?: string;
+
+  /** Modification time of the selected representation; must parse as a valid date. */
   lastModified?: string | Date;
 }
 
+/**
+ * Accept only quoted HTTP entity tags.
+ */
 const entityTag = /^(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"$/;
-// HTTP-date includes the two obsolete wire formats; exclude Date.parse's ISO/year shortcuts.
+
+/**
+ * HTTP-date includes the two obsolete wire formats; exclude Date.parse's ISO/year shortcuts.
+ */
 const httpDate =
   /^(?:[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT|[A-Za-z]+, \d{2}-[A-Za-z]{3}-\d{2} \d{2}:\d{2}:\d{2} GMT|[A-Za-z]{3} [A-Za-z]{3} [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
 
@@ -15,7 +23,7 @@ const httpDate =
  * Call before sending a buffered response; this helper never reads or hashes a stream.
  */
 const conditionalRequest = (
-  request: Request,
+  { method, headers: requestHeaders }: Request,
   { etag, lastModified }: IConditionalValidators,
 ): Response | undefined => {
   if (etag !== undefined && !entityTag.test(etag)) {
@@ -28,15 +36,17 @@ const conditionalRequest = (
     throw new TypeError('Last-Modified must be a valid date.');
   }
 
-  if (!['GET', 'HEAD'].includes(request.method)) {
+  if (!['GET', 'HEAD'].includes(method)) {
     return undefined;
   }
 
-  const noneMatch = request.headers.get('If-None-Match');
+  const noneMatch = requestHeaders.get('If-None-Match');
   let hasMatch = false;
 
   if (noneMatch !== null) {
-    // Commas are legal inside an opaque tag, so splitting on commas is incorrect.
+    /**
+     * Commas are legal inside an opaque tag, so splitting on commas is incorrect.
+     */
     const list: string[] = noneMatch.match(/(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"|\*/g) ?? [];
     const isValidList =
       /^(?:\*|(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*"(?:\s*,\s*(?:W\/)?"[\x21\x23-\x7e\x80-\xff]*")*)$/.test(
@@ -49,7 +59,7 @@ const conditionalRequest = (
         (tag) => tag === '*' || (etag && tag.replace(/^W\//, '') === etag.replace(/^W\//, '')),
       );
   } else if (modified !== undefined) {
-    const since = request.headers.get('If-Modified-Since');
+    const since = requestHeaders.get('If-Modified-Since');
     const timestamp = since !== null && httpDate.test(since) ? Date.parse(since) : NaN;
 
     hasMatch =

--- a/src/core/copy-loader-headers.ts
+++ b/src/core/copy-loader-headers.ts
@@ -6,7 +6,11 @@ import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
  * The first ordinary value wins (including Cache-Control); all cookies are appended.
  */
 const copyLoaderHeaders = (
-  routerContext: Pick<StaticHandlerContext, 'matches' | 'loaderHeaders' | 'actionHeaders'>,
+  {
+    matches,
+    loaderHeaders,
+    actionHeaders,
+  }: Pick<StaticHandlerContext, 'matches' | 'loaderHeaders' | 'actionHeaders'>,
   { allow }: { allow: readonly string[] },
 ): Headers => {
   const headers = new Headers();
@@ -14,15 +18,17 @@ const copyLoaderHeaders = (
 
   allowed.delete('content-type');
 
-  for (const { route } of routerContext.matches) {
-    for (const source of [
-      routerContext.loaderHeaders[route.id],
-      routerContext.actionHeaders[route.id],
-    ]) {
+  for (const {
+    route: { id },
+  } of matches) {
+    for (const source of [loaderHeaders[id], actionHeaders[id]]) {
       if (!source) {
         continue;
       }
 
+      /**
+       * Keep the first allowed ordinary header across matched loaders and actions.
+       */
       getHeaderEntries(source).forEach(([name, value]) => {
         if (allowed.has(name.toLowerCase()) && !headers.has(name)) {
           headers.set(name, value);

--- a/src/core/document-headers.ts
+++ b/src/core/document-headers.ts
@@ -4,6 +4,7 @@ import { getHeaderEntries, getSetCookieHeaders } from '@core/headers';
 export interface IDocumentHeadersOptions {
   /** Exact, case-sensitive cookie name. Empty values count as present. */
   sessionCookie?: string;
+
   /** Explicit escape hatch: let rules control credentialed responses too. Default: true. */
   protectPrivate?: boolean;
 }
@@ -17,6 +18,7 @@ export interface IDocumentHeaderContext {
 export interface IDocumentRuleContext {
   request: Request;
   url: URL;
+
   /** User-Agent heuristic for policy selection, never an authentication signal. */
   isBot: boolean;
   hasCookie: (name: string) => boolean;
@@ -44,12 +46,20 @@ const documentHeaders = (
   rules: readonly IDocumentHeaderRule[],
   { sessionCookie, protectPrivate = true }: IDocumentHeadersOptions = {},
 ): ((context: IDocumentHeaderContext) => Headers) => {
+  /**
+   * Apply matching rules and credential protection to this response.
+   */
   return ({ request, routerContext, response }) => {
+    const { url, headers: requestHeaders } = request;
     const headers = new Headers(response.headers);
     const ruleContext: IDocumentRuleContext = {
       request,
-      url: new URL(request.url),
-      isBot: /bot|crawler|spider|crawling/i.test(request.headers.get('User-Agent') ?? ''),
+      url: new URL(url),
+      isBot: /bot|crawler|spider|crawling/i.test(requestHeaders.get('User-Agent') ?? ''),
+
+      /**
+       * Bind cookie presence checks to the current request.
+       */
       hasCookie: (name) => hasCookie(request, name),
       routerContext,
     };
@@ -68,14 +78,16 @@ const documentHeaders = (
     if (
       protectPrivate &&
       (headers.has('Set-Cookie') ||
-        request.headers.has('Authorization') ||
+        requestHeaders.has('Authorization') ||
         (sessionCookie && hasCookie(request, sessionCookie)))
     ) {
       headers.set('Cache-Control', 'private, no-store');
     }
 
-    // Vary: Cookie fragments a shared cache by entire cookie strings. Bypass the
-    // cache on session presence instead; this helper never emits that Vary token.
+    /**
+     * Vary: Cookie fragments a shared cache by entire cookie strings. Bypass the
+     * cache on session presence instead; this helper never emits that Vary token.
+     */
     const vary = (headers.get('Vary') ?? '')
       .split(',')
       .map((name) => name.trim())

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -94,9 +94,11 @@ const createHandler = <TAppProps = Record<string, any>>(
       onContext?.({ context });
 
       if (isBypass) {
+        const { sessionCookie } = options;
+
         context.diagnostics?.inspectCachePolicy(
           requestInit.headers,
-          Boolean(options.sessionCookie && hasCookie(request, options.sessionCookie)),
+          Boolean(sessionCookie && hasCookie(request, sessionCookie)),
         );
 
         const response = await headResponse(request, requestInit);

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -35,6 +35,7 @@ export interface ISsrRequestContext<TAppProps = Record<string, any>> {
   html: { footer: string; header: string };
   isStream?: boolean;
   isSpa?: boolean;
+
   /** Structural route matches are available to prepare even when loaders are skipped. */
   matches?: RouterState['matches'];
   request: Request;
@@ -98,6 +99,7 @@ export interface ICoreRenderOptions<
 > extends IDocumentHeadersOptions {
   /** Opt in to document policies after onShellReady; redirects keep their header contract. */
   documentHeaders?: readonly IDocumentHeaderRule[];
+
   /** Hydrate the parsed shell while deferred boundaries are still pending. */
   hydration?: 'early' | 'footer';
   nonce?: string;
@@ -523,10 +525,11 @@ const render = async <TAppProps,>(
 
   try {
     const response = await renderResponse(params, context, options, executionContext);
+    const { sessionCookie } = options;
 
     context.diagnostics?.inspectCachePolicy(
       response.headers,
-      Boolean(options.sessionCookie && hasCookie(context.request, options.sessionCookie)),
+      Boolean(sessionCookie && hasCookie(context.request, sessionCookie)),
     );
 
     return timeline?.response(response) ?? response;

--- a/src/core/spa-html.ts
+++ b/src/core/spa-html.ts
@@ -4,6 +4,10 @@
  */
 const createSpaHtml = (html: string, rootId = 'root'): string => {
   let isMarked = false;
+
+  /**
+   * Mark the configured mount element without changing its other attributes.
+   */
   const result = html.replace(/<[^!/>][^>]*>/g, (tag) => {
     const id = /\sid\s*=\s*(["'])(.*?)\1/.exec(tag)?.[2];
 
@@ -18,6 +22,9 @@ const createSpaHtml = (html: string, rootId = 'root'): string => {
       : tag.replace(/(\sid\s*=\s*(["']).*?\2)/, '$1 data-force-spa="1"');
   });
 
+  /**
+   * Mark the document when the configured mount element is absent.
+   */
   return isMarked
     ? result
     : result.replace(/<html\b[^>]*>/i, (tag) =>

--- a/src/core/spa-shell.ts
+++ b/src/core/spa-shell.ts
@@ -9,10 +9,15 @@ const createSpaShell = (): ((html: IHtmlShell) => IHtmlShell) => {
   let source: IHtmlShell | undefined;
   let shell: IHtmlShell;
 
+  /**
+   * Rebuild changed templates and isolate the shell returned to each request.
+   */
   return (html) => {
-    if (source?.header !== html.header || source?.footer !== html.footer) {
+    const { header, footer } = html;
+
+    if (source?.header !== header || source?.footer !== footer) {
       source = { ...html };
-      shell = { header: createSpaHtml(html.header), footer: html.footer };
+      shell = { header: createSpaHtml(header), footer };
     }
 
     return { ...shell };

--- a/src/core/ssr-policy.ts
+++ b/src/core/ssr-policy.ts
@@ -7,9 +7,14 @@ import type Diagnostics from '@services/diagnostics';
 type TRenderMode = 'ssr' | 'spa';
 
 interface ISsrPolicy {
+  /** Select all routes by default. */
   mode?: 'all' | 'include' | 'exclude';
   routes?: (string | RegExp)[];
+
+  /** Render crawlers with SSR by default, regardless of route policy. */
   bots?: 'ssr' | 'policy';
+
+  /** Return undefined to keep the matched policy decision. */
   decide?: (params: { request: Request; url: URL; isBot: boolean }) => TRenderMode | undefined;
 }
 
@@ -35,6 +40,10 @@ const compilePattern = (pattern: string | RegExp, exclude: boolean): IPolicyPatt
   return {
     pattern,
     exclude,
+
+    /**
+     * Reset stateful expressions before checking each pathname.
+     */
     test: (pathname) => {
       regexp.lastIndex = 0;
 
@@ -50,37 +59,67 @@ const routePaths = (
   routes: StaticHandler['dataRoutes'],
   parent = '',
 ): { id: string; path: string }[] =>
-  routes.flatMap((route) => {
+  routes.flatMap(({ id, path: routePath, children }) => {
     const path =
-      (route.path?.startsWith('/') ? route.path : `${parent}/${route.path ?? ''}`)
+      (routePath?.startsWith('/') ? routePath : `${parent}/${routePath ?? ''}`)
         .replace(/\/+/g, '/')
         .replace(/\/$/, '') || '/';
 
-    return [{ id: route.id, path }, ...routePaths(route.children ?? [], path)];
+    return [{ id, path }, ...routePaths(children ?? [], path)];
   });
 
 /**
  * Snapshot environment policy when the application entry/handler is created at startup.
  */
 class SsrPolicy {
+  /**
+   * Skip policy work when every request uses SSR.
+   */
   public readonly active: boolean;
 
+  /**
+   * Keep policy paths aligned with the router's mount path.
+   */
   public readonly basename: string;
 
+  /**
+   * Retain compiled inclusion and exclusion checks.
+   */
   protected readonly patterns: IPolicyPattern[];
 
+  /**
+   * Choose how unmatched requests are rendered.
+   */
   protected readonly mode: NonNullable<ISsrPolicy['mode']>;
 
+  /**
+   * Control whether crawlers bypass route policy.
+   */
   protected readonly bots: NonNullable<ISsrPolicy['bots']>;
 
+  /**
+   * Allow application decisions after route matching.
+   */
   protected readonly decide?: ISsrPolicy['decide'];
 
+  /**
+   * Identify the effective configuration in diagnostics.
+   */
   protected readonly source: string;
 
+  /**
+   * Retain declared paths for policy diagnostics.
+   */
   protected readonly paths: ReturnType<typeof routePaths>;
 
+  /**
+   * Inspect configured patterns only once per policy.
+   */
   protected hasInspected = false;
 
+  /**
+   * Compile the startup policy with environment overrides taking precedence.
+   */
   public constructor(
     { mode = 'all', routes = [], bots = 'ssr', decide }: ISsrPolicy = {},
     dataRoutes: StaticHandler['dataRoutes'] = [],
@@ -89,6 +128,10 @@ class SsrPolicy {
   ) {
     this.basename = basename;
     this.bots = bots;
+
+    /**
+     * Prefix declared paths with the router's configured basename.
+     */
     this.paths = routePaths(dataRoutes).map((route) => ({
       ...route,
       path: `${basename.replace(/\/$/, '')}${route.path}`,
@@ -105,6 +148,10 @@ class SsrPolicy {
         : values.some((value) => !value.startsWith('!'))
           ? 'include'
           : 'exclude';
+
+      /**
+       * Compile environment entries with their explicit exclusion markers.
+       */
       this.patterns = values.map((value) => {
         const isExcluded = value.startsWith('!');
 
@@ -123,30 +170,6 @@ class SsrPolicy {
   }
 
   /**
-   * Explain typos using declared paths, including concrete URLs for dynamic route ids.
-   * A global 404 catch-all must not hide a misspelled policy.
-   */
-  protected inspect(diagnostics?: Diagnostics): void {
-    if (!diagnostics || this.hasInspected) {
-      return;
-    }
-
-    this.hasInspected = true;
-
-    for (const { pattern, test } of this.patterns) {
-      const hasMatch = this.paths.some(
-        ({ path }) =>
-          path !== '/*' &&
-          (test(path) || (typeof pattern === 'string' && Boolean(matchPath(path, pattern)))),
-      );
-
-      if (!hasMatch) {
-        diagnostics.policyUnmatched(String(pattern));
-      }
-    }
-  }
-
-  /**
    * Crawler protection wins over both runtime decisions and environment rollback rules.
    */
   public select(request: Request, diagnostics?: Diagnostics): TRenderMode {
@@ -156,8 +179,9 @@ class SsrPolicy {
 
     this.inspect(diagnostics);
 
-    const url = new URL(request.url);
-    const isBot = isbot(request.headers.get('user-agent'));
+    const { url: requestUrl, headers } = request;
+    const url = new URL(requestUrl);
+    const isBot = isbot(headers.get('user-agent'));
     const matched = this.patterns.filter(({ test }) => test(url.pathname));
     const excluded = matched.find(({ exclude }) => exclude);
     let mode: TRenderMode =
@@ -185,6 +209,33 @@ class SsrPolicy {
     diagnostics?.policyDecision(String(pattern), mode, source);
 
     return mode;
+  }
+
+  /**
+   * Explain typos using declared paths, including concrete URLs for dynamic route ids.
+   * A global 404 catch-all must not hide a misspelled policy.
+   */
+  protected inspect(diagnostics?: Diagnostics): void {
+    if (!diagnostics || this.hasInspected) {
+      return;
+    }
+
+    this.hasInspected = true;
+
+    for (const { pattern, test } of this.patterns) {
+      /**
+       * Check declared paths without allowing a catch-all to hide policy typos.
+       */
+      const hasMatch = this.paths.some(
+        ({ path }) =>
+          path !== '/*' &&
+          (test(path) || (typeof pattern === 'string' && Boolean(matchPath(path, pattern)))),
+      );
+
+      if (!hasMatch) {
+        diagnostics.policyUnmatched(String(pattern));
+      }
+    }
   }
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,14 +1,25 @@
-// Server-only HTTP helpers use Fetch primitives and can also run on the edge.
+/**
+ * Server-only HTTP helpers use Fetch primitives and can also run on the edge.
+ */
 export { default as cacheControl } from '@core/cache-control';
 
 export type { ICachePolicy } from '@core/cache-control';
 
+/**
+ * Evaluate conditional requests against application-supplied validators.
+ */
 export { default as conditionalRequest } from '@core/conditional-request';
 
 export type { IConditionalValidators } from '@core/conditional-request';
 
+/**
+ * Copy explicitly allowed loader and action headers to a document response.
+ */
 export { default as copyLoaderHeaders } from '@core/copy-loader-headers';
 
+/**
+ * Apply document header rules with credential protection.
+ */
 export { default as documentHeaders } from '@core/document-headers';
 
 export type {

--- a/src/node/production.ts
+++ b/src/node/production.ts
@@ -10,7 +10,7 @@ interface ILoadHtmlShellOptions {
   outlet?: string;
 }
 
-type IRouteAssetPreparerOptions = (
+type TRouteAssetPreparerOptions = (
   { buildDir: string; manifest?: never } | { manifest: TRouteAssetsManifest; buildDir?: never }
 ) & { modulePreload?: boolean };
 
@@ -34,10 +34,15 @@ const createRouteAssetPreparer = <TAppProps = Record<string, any>>({
   buildDir,
   manifest,
   modulePreload = false,
-}: IRouteAssetPreparerOptions): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
+}: TRouteAssetPreparerOptions): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
   return createAssetPreparer(new RouteAssets(manifest ?? buildDir, modulePreload));
 };
 
 export { createRouteAssetPreparer, loadHtmlShell };
 
-export type { IHtmlShell, ILoadHtmlShellOptions, IRouteAssetPreparerOptions, TRouteAssetsManifest };
+export type {
+  IHtmlShell,
+  ILoadHtmlShellOptions,
+  TRouteAssetPreparerOptions as IRouteAssetPreparerOptions,
+  TRouteAssetsManifest,
+};

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -172,8 +172,18 @@ const walkSerializable = (
 class Diagnostics {
   protected chunks: string[] = [];
 
+  /**
+   * Attach route context and the logger used for request diagnostics.
+   */
   public constructor(
+    /**
+     * Identify the route in request diagnostics.
+     */
     protected readonly route: string,
+
+    /**
+     * Deliver warnings and optional policy decisions through the runtime logger.
+     */
     protected readonly logger: Pick<Logger, 'warn'> & Partial<Pick<Logger, 'info'>> = new Logger(),
   ) {}
 

--- a/src/services/request-timeline.ts
+++ b/src/services/request-timeline.ts
@@ -11,6 +11,8 @@ type TRequestStage =
 
 interface ITimelineEvent {
   stage: TRequestStage;
+
+  /** Milliseconds since the request timeline started. */
   at: number;
   id?: number;
   placement?: 'early' | 'footer';
@@ -36,20 +38,43 @@ const describeReason = (reason: unknown): string => {
 
 /** Request-local observations; never constructed on the disabled path. */
 class RequestTimeline {
+  /**
+   * Retain observations in emission order.
+   */
   public readonly events: ITimelineEvent[] = [];
+
+  /**
+   * Anchor event offsets to a monotonic clock.
+   */
   public readonly started = performance.now();
+
+  /**
+   * Prevent observations after response completion.
+   */
   protected ended = false;
+
+  /**
+   * Record only the first cancellation reason.
+   */
   protected aborted = false;
 
-  public constructor(protected readonly request: Request) {
-    if (request.signal.aborted) {
+  /**
+   * Observe cancellation from the request's signal.
+   */
+  public constructor(
+    /**
+     * Retain request metadata and its cancellation signal.
+     */
+    protected readonly request: Request,
+  ) {
+    const { signal } = request;
+
+    if (signal.aborted) {
       this.onAbort();
     } else {
-      request.signal.addEventListener('abort', this.onAbort, { once: true });
+      signal.addEventListener('abort', this.onAbort, { once: true });
     }
   }
-
-  protected onAbort = (): void => this.abort(this.request.signal.reason);
 
   /** Offsets mark completion/emission, not the beginning of a stage. */
   public record(stage: TRequestStage, detail?: Omit<ITimelineEvent, 'stage' | 'at'>): void {
@@ -58,6 +83,9 @@ class RequestTimeline {
     }
   }
 
+  /**
+   * Attach the first cancellation reason to the timeline.
+   */
   public abort(reason?: unknown): void {
     if (!this.aborted) {
       this.aborted = true;
@@ -93,14 +121,20 @@ class RequestTimeline {
 
   /** Observe final transformed bytes without reading ahead of the consumer. */
   public response(response: Response): Response {
-    if (!response.body) {
+    const { body: responseBody } = response;
+
+    if (!responseBody) {
       this.end();
 
       return response;
     }
 
-    const reader = response.body.getReader();
+    const reader = responseBody.getReader();
     let isStopped = false;
+
+    /**
+     * Release the stream reader and complete the request timeline.
+     */
     const finish = (): void => {
       isStopped = true;
       reader.releaseLock();
@@ -108,6 +142,9 @@ class RequestTimeline {
     };
     const body = new ReadableStream<Uint8Array>(
       {
+        /**
+         * Forward consumer cancellation and finish observation.
+         */
         cancel: async (reason) => {
           isStopped = true;
           this.abort(reason);
@@ -118,19 +155,23 @@ class RequestTimeline {
             finish();
           }
         },
+
+        /**
+         * Forward one chunk at a time and record completion or failure.
+         */
         pull: async (controller) => {
           try {
-            const chunk = await reader.read();
+            const { done: isDone, value } = await reader.read();
 
             if (isStopped) {
               return;
             }
 
-            if (chunk.done) {
+            if (isDone) {
               finish();
               controller.close();
             } else {
-              controller.enqueue(chunk.value);
+              controller.enqueue(value);
             }
           } catch (error) {
             if (!isStopped) {
@@ -146,6 +187,11 @@ class RequestTimeline {
 
     return new Response(body, response);
   }
+
+  /**
+   * Forward request cancellation without losing the timeline receiver.
+   */
+  protected onAbort = (): void => this.abort(this.request.signal.reason);
 }
 
 /** Keep the constructor, event array and clock reads behind the enablement check. */

--- a/src/services/route-asset-preparer.ts
+++ b/src/services/route-asset-preparer.ts
@@ -7,6 +7,9 @@ import type RouteAssets from '@services/route-assets-memory';
 const createAssetPreparer = <TAppProps = Record<string, any>>(
   assets: RouteAssets,
 ): NonNullable<ICreateHandlerOptions<TAppProps>['prepare']> => {
+  /**
+   * Inject this request's matched assets and forward available early hints.
+   */
   return async ({ context, executionContext }) => {
     const hints = assets.injectAssets(context, Boolean(executionContext?.onEarlyHints));
 

--- a/src/services/route-assets-memory.ts
+++ b/src/services/route-assets-memory.ts
@@ -10,7 +10,11 @@ enum AssetType {
 interface IAsset {
   type: string;
   url: string;
+
+  /** Lower weights are injected first. */
   weight: number;
+
+  /** Nested assets follow top-level assets with the same weight. */
   isNested: boolean;
   isPreload: boolean;
   content?: string;
@@ -34,10 +38,19 @@ interface IInjectAssetsContext {
  * Load and inject route assets with an independent cache for one build.
  */
 class RouteAssets {
+  /**
+   * Control module preload hints for matched scripts.
+   */
   protected readonly modulePreload: boolean;
 
+  /**
+   * Keep the build's route assets isolated from other handler instances.
+   */
   protected routesAssets: TRouteAssetsManifest | null;
 
+  /**
+   * Retain the supplied manifest and preload preference.
+   */
   constructor(manifest: TRouteAssetsManifest, modulePreload = false) {
     this.routesAssets = manifest;
     this.modulePreload = modulePreload;
@@ -51,49 +64,14 @@ class RouteAssets {
   }
 
   /**
-   * Read the manifest without requiring a filesystem.
-   */
-  protected loadAssetsManifest(): TRouteAssetsManifest {
-    return this.routesAssets ?? {};
-  }
-
-  /**
-   * Sort assets
-   */
-  protected sortAssets(assets: IAsset[]): IAsset[] {
-    return assets.sort((a, b) =>
-      a.weight === b.weight ? Number(a.isNested) - Number(b.isNested) : a.weight - b.weight,
-    );
-  }
-
-  /**
-   * Get route assets
-   */
-  // The development manifest uses the SPA flag to preload unqueried lazy routes.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getAssets(routes?: RouterState['matches'], _isSpa?: boolean): IAsset[] {
-    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
-
-    if (!routeIds.length) {
-      return [];
-    }
-
-    const routesAssets = this.loadAssetsManifest();
-
-    return this.sortAssets(
-      routeIds
-        .map((routeId) => routesAssets[routeId])
-        .flat()
-        .filter(Boolean),
-    );
-  }
-
-  /**
    * Build preload hints without depending on a particular HTTP transport.
    */
   public getEarlyHints(assets: IAsset[]): Headers {
     const headers = new Headers();
 
+    /**
+     * Advertise only styles and scripts as HTTP preload hints.
+     */
     assets.forEach(({ type, url }) => {
       if (!type || !['style', 'script'].includes(type)) {
         return;
@@ -113,6 +91,10 @@ class RouteAssets {
     earlyHints = true,
   ): Headers {
     const assets = this.getAssets(matches ?? routerContext?.matches, isSpa);
+
+    /**
+     * Render each matched style or script using the current runtime's asset mode.
+     */
     const htmlAssets = assets
       .map(({ type, url, isPreload, content = '' }) => {
         switch (type) {
@@ -137,6 +119,44 @@ class RouteAssets {
     html.header = html.header.replace('</head>', `${htmlAssets.join('\n')}</head>`);
 
     return earlyHints ? this.getEarlyHints(assets) : new Headers();
+  }
+
+  /**
+   * Read the manifest without requiring a filesystem.
+   */
+  protected loadAssetsManifest(): TRouteAssetsManifest {
+    return this.routesAssets ?? {};
+  }
+
+  /**
+   * Sort assets
+   */
+  protected sortAssets(assets: IAsset[]): IAsset[] {
+    return assets.sort(({ weight, isNested }, { weight: nextWeight, isNested: isNextNested }) =>
+      weight === nextWeight ? Number(isNested) - Number(isNextNested) : weight - nextWeight,
+    );
+  }
+
+  /**
+   * Get route assets
+   * The development manifest uses the SPA flag to preload unqueried lazy routes.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getAssets(routes?: RouterState['matches'], _isSpa?: boolean): IAsset[] {
+    const routeIds = routes?.map(({ route }) => route.id).filter(Boolean) ?? [];
+
+    if (!routeIds.length) {
+      return [];
+    }
+
+    const routesAssets = this.loadAssetsManifest();
+
+    return this.sortAssets(
+      routeIds
+        .map((routeId) => routesAssets[routeId])
+        .flat()
+        .filter(Boolean),
+    );
   }
 }
 

--- a/src/services/ssr-manifest.ts
+++ b/src/services/ssr-manifest.ts
@@ -114,6 +114,53 @@ class SsrManifest extends RouteAssets {
   }
 
   /**
+   * Compile SSR graph styles before the browser has populated the client graph.
+   */
+  public async prepareDevAssets(routes?: RouterState['matches'], isSpa = false): Promise<void> {
+    const vite = this.config.getVite();
+
+    if (!vite) {
+      return;
+    }
+
+    if (isSpa) {
+      /**
+       * Populate the client graph for structural matches without running lazy loaders.
+       */
+      await Promise.all(
+        this.getDevRouteIds(routes).map(async (id) => {
+          const file = this.pathNormalize.findAppFile(id);
+
+          if (file) {
+            await vite.transformRequest(`/@fs/${file}`);
+          }
+        }),
+      );
+    }
+
+    const visited = new Set<string>();
+
+    /**
+     * Transform each stylesheet once, including dependencies shared by several routes.
+     */
+    const visit = async (module: ModuleNode): Promise<void> => {
+      if (visited.has(module.url)) {
+        return;
+      }
+
+      visited.add(module.url);
+
+      if (module.file && /\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)$/.test(module.file)) {
+        await vite.transformRequest(module.url);
+      }
+
+      await Promise.all([...module.importedModules].map(visit));
+    };
+
+    await Promise.all(this.getDevModules(routes).map(visit));
+  }
+
+  /**
    * Get output dir.
    */
   protected getOutDir(): string {
@@ -314,50 +361,6 @@ class SsrManifest extends RouteAssets {
   }
 
   /**
-   * Compile SSR graph styles before the browser has populated the client graph.
-   */
-  public async prepareDevAssets(routes?: RouterState['matches'], isSpa = false): Promise<void> {
-    const vite = this.config.getVite();
-
-    if (!vite) {
-      return;
-    }
-
-    if (isSpa) {
-      await Promise.all(
-        this.getDevRouteIds(routes).map(async (id) => {
-          const file = this.pathNormalize.findAppFile(id);
-
-          if (file) {
-            await vite.transformRequest(`/@fs/${file}`);
-          }
-        }),
-      );
-    }
-
-    const visited = new Set<string>();
-
-    /**
-     * Transform each stylesheet once, including dependencies shared by several routes.
-     */
-    const visit = async (module: ModuleNode): Promise<void> => {
-      if (visited.has(module.url)) {
-        return;
-      }
-
-      visited.add(module.url);
-
-      if (module.file && /\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)$/.test(module.file)) {
-        await vite.transformRequest(module.url);
-      }
-
-      await Promise.all([...module.importedModules].map(visit));
-    };
-
-    await Promise.all(this.getDevModules(routes).map(visit));
-  }
-
-  /**
    * Collect development assets from the current server and client module graphs.
    */
   protected getAssetsDev(routes?: RouterState['matches'], isSpa = false): IAsset[] {
@@ -366,6 +369,9 @@ class SsrManifest extends RouteAssets {
       ...this.getDevModules(routes).map((module) => this.getModuleAssets(module)),
     ) as TAssets;
 
+    /**
+     * Preload SPA route modules that have not been queried on the server.
+     */
     const scripts: IAsset[] = isSpa
       ? this.getDevRouteIds(routes).flatMap((id) => {
           const module = this.pathNormalize

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,16 +1,28 @@
 import renderToStream from '@node/render-to-stream';
 import testHandlerFactory from './testing/create-handler';
 
+/**
+ * Create route test handlers with Node rendering and optional file-backed shells.
+ */
 const createTestHandler = testHandlerFactory(renderToStream, async (options) =>
   (await import('@node/production')).loadHtmlShell(options),
 );
 
 export { createTestHandler };
 
+/**
+ * Expose manual control over deferred loader settlement.
+ */
 export { default as createDeferred } from './testing/deferred';
 
+/**
+ * Supply browser and crawler request identities for route tests.
+ */
 export { browserRequest, crawlerRequest } from './testing/requests';
 
+/**
+ * Expose repeatable response assertions for route tests.
+ */
 export { default as TestResponse } from './testing/response';
 
 export type { ITestHandler, ITestHandlerOptions, ITestRequestInit } from './testing/create-handler';

--- a/src/testing/browser-observer.ts
+++ b/src/testing/browser-observer.ts
@@ -1,5 +1,7 @@
 interface IBrowserTimelineEvent {
   stage: 'shell' | 'router.ready' | 'init' | 'resolve' | 'reject' | 'response.end';
+
+  /** Monotonic milliseconds since the browser's time origin. */
   at: number;
   id?: number;
 }
@@ -8,12 +10,26 @@ interface IBrowserObservation {
   events: IBrowserTimelineEvent[];
   errors: string[];
   roots: Record<string, string>;
+
+  /** First visible observation of each element, in monotonic milliseconds. */
   seen: WeakMap<Element, number>;
+
+  /** First visible shell observation, in monotonic milliseconds. */
   shellAt?: number;
 }
 
+interface IHydrationInspection {
+  ready: boolean;
+  consumed: boolean;
+  pending: number;
+  duplicates: string[];
+  errors: string[];
+}
+
 declare global {
-  // Browser global augmentation keeps the platform interface name.
+  /**
+   * Browser global augmentation keeps the platform interface name.
+   */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Window {
     __ssrBoostTest?: IBrowserObservation;
@@ -32,22 +48,30 @@ const installBrowserObserver = (): void => {
     roots: {},
     seen: new WeakMap(),
   };
+  const { events, errors, roots, seen } = state;
 
   window.__ssrBoostTest = state;
 
+  /**
+   * Record browser milestones on the same monotonic clock.
+   */
   const record = (stage: IBrowserTimelineEvent['stage'], id?: number): void => {
-    state.events.push({ stage, at: performance.now(), ...(id === undefined ? {} : { id }) });
+    events.push({ stage, at: performance.now(), ...(id === undefined ? {} : { id }) });
   };
+
+  /**
+   * Observe the first visible shell and the first appearance of each element.
+   */
   const scan = (): void => {
     const at = performance.now();
 
     for (const element of document.querySelectorAll('body *')) {
-      const rect = element.getBoundingClientRect();
+      const { width, height } = element.getBoundingClientRect();
 
       if (
         !element.closest('script, style, template, [hidden]') &&
-        rect.width > 0 &&
-        rect.height > 0 &&
+        width > 0 &&
+        height > 0 &&
         getComputedStyle(element).visibility !== 'hidden'
       ) {
         if (state.shellAt === undefined) {
@@ -55,8 +79,8 @@ const installBrowserObserver = (): void => {
           record('shell');
         }
 
-        if (!state.seen.has(element)) {
-          state.seen.set(element, at);
+        if (!seen.has(element)) {
+          seen.set(element, at);
         }
       }
     }
@@ -67,25 +91,44 @@ const installBrowserObserver = (): void => {
 
   const originalError = console.error;
 
+  /**
+   * Retain console failures while preserving normal browser logging.
+   */
   console.error = (...args: unknown[]): void => {
-    state.errors.push(args.map(String).join(' '));
+    errors.push(args.map(String).join(' '));
     originalError(...args);
   };
-  window.addEventListener('error', (event) => state.errors.push(event.message));
+
+  /**
+   * Collect uncaught browser errors for hydration assertions.
+   */
+  window.addEventListener('error', (event) => errors.push(event.message));
+
+  /**
+   * Collect unhandled promise failures for hydration assertions.
+   */
   window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) =>
-    state.errors.push(String(event.reason)),
+    errors.push(String(event.reason)),
   );
+
+  /**
+   * Snapshot the server root before the router begins hydration.
+   */
   window.addEventListener('ssr-boost:router-ready', (event) => {
     const { rootId } = (event as CustomEvent<{ rootId: string }>).detail;
     const root = document.getElementById(rootId);
 
     if (root) {
-      state.roots[rootId] = root.innerHTML;
+      roots[rootId] = root.innerHTML;
     }
 
     scan();
     record('router.ready');
   });
+
+  /**
+   * Mark completion of the browser's document load.
+   */
   window.addEventListener('load', () => record('response.end'), { once: true });
 
   const queue: unknown[][] = [];
@@ -95,6 +138,10 @@ const installBrowserObserver = (): void => {
   // The browser receiver replaces push; retain observation around that replacement.
   Object.defineProperty(queue, 'push', {
     configurable: true,
+
+    /**
+     * Observe each transport frame once before forwarding it to the receiver.
+     */
     get:
       () =>
       (...frames: unknown[][]): number => {
@@ -113,20 +160,16 @@ const installBrowserObserver = (): void => {
 
         return downstream.apply(queue, frames) as number;
       },
+
+    /**
+     * Retain the browser receiver when it replaces queue delivery.
+     */
     set: (replacement: typeof downstream) => {
       downstream = replacement;
     },
   });
   Reflect.set(window, '__ssrBoostStream', queue);
 };
-
-interface IHydrationInspection {
-  ready: boolean;
-  consumed: boolean;
-  pending: number;
-  duplicates: string[];
-  errors: string[];
-}
 
 /** Compare server text multiplicities to the hydrated root, allowing existing repeats. */
 const inspectHydration = (selector: string): IHydrationInspection => {
@@ -137,6 +180,9 @@ const inspectHydration = (selector: string): IHydrationInspection => {
 
   server.innerHTML = html ?? '';
 
+  /**
+   * Count visible text fragments without including scripts or hidden boundaries.
+   */
   const texts = (element: Element): Map<string, number> => {
     const counts = new Map<string, number>();
 
@@ -161,12 +207,18 @@ const inspectHydration = (selector: string): IHydrationInspection => {
   };
   const before = texts(server);
   const after = root ? texts(root) : new Map<string, number>();
+
+  /**
+   * Count exact and concatenated copies of one server text fragment.
+   */
   const multiplicity = (counts: Map<string, number>, text: string): number => {
     let total = 0;
 
     for (const [candidate, count] of counts) {
-      // Also catch concatenated copies in a single text node, without matching
-      // short labels inside unrelated deferred content (for example 1 inside 100).
+      /**
+       * Also catch concatenated copies in a single text node, without matching
+       * short labels inside unrelated deferred content (for example 1 inside 100).
+       */
       const copies = candidate.length / text.length;
 
       if (Number.isInteger(copies) && text.repeat(copies) === candidate) {
@@ -193,6 +245,10 @@ const inspectHydration = (selector: string): IHydrationInspection => {
     consumed: Reflect.get(window, '__staticRouterHydrationData') === undefined,
     pending,
     duplicates,
+
+    /**
+     * Select React hydration failures from the collected browser errors.
+     */
     errors:
       state?.errors.filter((error) =>
         /(?:#|errors\/)(418|423|425)\b|hydrat(?:ion|ing|e|ed)|server rendered HTML|did not match/i.test(

--- a/src/testing/create-handler.tsx
+++ b/src/testing/create-handler.tsx
@@ -13,6 +13,7 @@ import TestResponse from './response';
 
 interface ITestRequestInit extends RequestInit {
   isStream?: boolean;
+
   /** Whole-request deadline, including loaders and body consumption. */
   timeout?: number;
 }
@@ -24,6 +25,8 @@ interface ITestHandlerOptions<TAppProps> extends Omit<ICreateHandlerOptions<TApp
   routerOptions?: Parameters<typeof createStaticHandler>[1];
   renderToStream?: TRenderToStream;
   signal?: AbortSignal;
+
+  /** Default whole-request deadline in milliseconds; omitted means no deadline. */
   timeout?: number;
 }
 
@@ -33,6 +36,9 @@ interface ITestHandler {
 
 type TLoadShell = (options: ILoadHtmlShellOptions) => Promise<() => IHtmlShell>;
 
+/**
+ * Supply a complete document around the rendered test application.
+ */
 const DEFAULT_SHELL: IHtmlShell = {
   header: '<!doctype html><html><head></head><body><div id="root">',
   footer: '</div><script type="module">/* test browser entry */</script></body></html>',
@@ -55,6 +61,10 @@ const testHandlerFactory =
   }: ITestHandlerOptions<TAppProps>): ITestHandler => {
     const handler = createStaticHandler(routes as RouteObject[], routerOptions);
     let fileShell: Promise<() => IHtmlShell> | undefined;
+
+    /**
+     * Cache file loading while returning a fresh shell for every request.
+     */
     const getHtml = async (): Promise<IHtmlShell> => {
       if ('indexFile' in shell) {
         fileShell ??= loadShell(shell);
@@ -66,6 +76,9 @@ const testHandlerFactory =
     };
 
     return {
+      /**
+       * Render one cancellable request and collect its response assertions.
+       */
       fetch: async (input, { isStream, timeout = defaultTimeout, signal, ...init } = {}) => {
         const started = performance.now();
         const controller = new AbortController();
@@ -86,10 +99,22 @@ const testHandlerFactory =
         let timer: ReturnType<typeof setTimeout> | undefined;
         let timeline: RequestTimeline | undefined;
         let rejectAbort!: (reason: unknown) => void;
+
+        /**
+         * Allow cancellation to settle before hooks that ignore the signal.
+         */
         const aborted = new Promise<never>((_, reject) => {
           rejectAbort = reject;
         });
+
+        /**
+         * Reject pending rendering with the original abort reason.
+         */
         const onAbort = (): void => rejectAbort(combined.reason);
+
+        /**
+         * Release the deadline timer and abort listener after completion.
+         */
         const cleanup = (): void => {
           clearTimeout(timer);
           combined.removeEventListener('abort', onAbort);
@@ -103,6 +128,9 @@ const testHandlerFactory =
             throw new RangeError('timeout must be a finite, non-negative number of milliseconds.');
           }
 
+          /**
+           * Cancel rendering and body consumption when the deadline expires.
+           */
           timer = setTimeout(
             () =>
               controller.abort(
@@ -118,16 +146,28 @@ const testHandlerFactory =
             {
               handler,
               renderToStream,
+
+              /**
+               * Wrap matched content with the optional test application.
+               */
               createApp: (children, context) =>
                 App ? <App server={context.appProps}>{children}</App> : children,
             },
             {
               ...options,
               getHtml,
+
+              /**
+               * Retain the request timeline before forwarding context observation.
+               */
               onContext: (params) => {
                 ({ timeline } = params.context);
                 onContext?.(params);
               },
+
+              /**
+               * Apply a per-request streaming override after the application hook.
+               */
               onRouterReady: async (params) => {
                 const result = await onRouterReady?.(params);
 
@@ -137,7 +177,9 @@ const testHandlerFactory =
           );
           const pending = fetch(request);
 
-          // Hooks can ignore cancellation; release a response if it arrives after the deadline.
+          /**
+           * Hooks can ignore cancellation; release a response if it arrives after the deadline.
+           */
           void pending
             .then((response) => {
               if (combined.aborted) {

--- a/src/testing/deferred.ts
+++ b/src/testing/deferred.ts
@@ -8,9 +8,13 @@ interface IDeferred<T> {
 const createDeferred = <T>(): IDeferred<T> => {
   let resolve!: IDeferred<T>['resolve'];
   let reject!: IDeferred<T>['reject'];
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
+
+  /**
+   * Expose settlement controls to the caller.
+   */
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
   });
 
   // A test can reject before React Router has finished querying the other loaders.

--- a/src/testing/edge.ts
+++ b/src/testing/edge.ts
@@ -1,16 +1,28 @@
 import renderToStream from '@edge/render-to-stream';
 import testHandlerFactory from './create-handler';
 
+/**
+ * Create edge route test handlers that require an in-memory shell.
+ */
 const createTestHandler = testHandlerFactory(renderToStream, () => {
   throw new Error('shell.indexFile requires Node. In edge tests pass shell: { header, footer }.');
 });
 
 export { createTestHandler };
 
+/**
+ * Expose manual control over deferred loader settlement.
+ */
 export { default as createDeferred } from './deferred';
 
+/**
+ * Supply browser and crawler request identities for route tests.
+ */
 export { browserRequest, crawlerRequest } from './requests';
 
+/**
+ * Expose repeatable response assertions for route tests.
+ */
 export { default as TestResponse } from './response';
 
 export type { ITestHandler, ITestHandlerOptions, ITestRequestInit } from './create-handler';

--- a/src/testing/parse-response.ts
+++ b/src/testing/parse-response.ts
@@ -3,6 +3,7 @@ import { parse } from 'parse5';
 import type { DefaultTreeAdapterTypes } from 'parse5';
 
 type TStreamFrame = ['init', string, boolean] | ['resolve' | 'reject', number, string] | ['shell'];
+
 interface IRouterState {
   loaderData: Record<string, any>;
   actionData: Record<string, any> | null;
@@ -12,6 +13,10 @@ interface IRouterState {
 /** Parse only actual inline script nodes; never execute application JavaScript. */
 const scripts = (html: string): string[] => {
   const result: string[] = [];
+
+  /**
+   * Collect script text while traversing parsed document nodes.
+   */
   const visit = (node: DefaultTreeAdapterTypes.Node): void => {
     if ('tagName' in node && node.tagName === 'script') {
       result.push(node.childNodes.map((child) => ('value' in child ? child.value : '')).join(''));
@@ -62,14 +67,33 @@ const streamFrames = (html: string): TStreamFrame[] => {
 
 /** Distinguish transport placeholders from application objects containing an id. */
 class Placeholder {
-  public constructor(public readonly id: number) {}
+  /**
+   * Preserve the streamed promise identity until its settlement is decoded.
+   */
+  public constructor(
+    /**
+     * Link this placeholder to its stream settlement.
+     */
+    public readonly id: number,
+  ) {}
 }
 
 /** Decode the same value vocabulary as the browser receiver, without a DOM or eval. */
 const value = (payload: string): unknown =>
   decode(payload, {
+    /**
+     * Retain promise references until their settlements can be resolved.
+     */
     SSRBPromise: ([id]: [number]) => new Placeholder(id),
+
+    /**
+     * Restore own application object entries.
+     */
     SSRBObject: (entries: [string, unknown][]) => Object.fromEntries(entries),
+
+    /**
+     * Restore rejection properties without inventing a server stack.
+     */
     SSRBError: (entries: [string, unknown][]) => {
       const properties = Object.fromEntries(entries);
       const error = Object.assign(new Error('Streamed loader/action rejection'), properties);
@@ -80,6 +104,10 @@ const value = (payload: string): unknown =>
 
       return error;
     },
+
+    /**
+     * Restore explicit undefined values from the transport vocabulary.
+     */
     SSRBUndefined: () => undefined,
   });
 
@@ -126,6 +154,10 @@ const routerState = (html: string): IRouterState | undefined => {
   const visited = new WeakSet<object>();
   const resolving = new Set<number>();
   const resolved = new Map<number, unknown>();
+
+  /**
+   * Replace placeholders recursively while preserving shared and circular values.
+   */
   const resolve = (item: unknown): unknown => {
     if (item instanceof Placeholder) {
       const { id } = item;
@@ -161,11 +193,19 @@ const routerState = (html: string): IRouterState | undefined => {
       const entries = [...(item as Map<unknown, unknown>)];
 
       item.clear();
+
+      /**
+       * Resolve both keys and values while retaining the original map identity.
+       */
       entries.forEach(([key, child]) => item.set(resolve(key), resolve(child)));
     } else if (item instanceof Set) {
       const entries = [...(item as Set<unknown>)];
 
       item.clear();
+
+      /**
+       * Resolve members while retaining the original set identity.
+       */
       entries.forEach((child) => item.add(resolve(child)));
     } else {
       for (const key of Object.keys(item)) {

--- a/src/testing/playwright.ts
+++ b/src/testing/playwright.ts
@@ -3,7 +3,10 @@ import { installBrowserObserver, inspectHydration } from './browser-observer';
 import type { IBrowserTimelineEvent } from './browser-observer';
 
 interface IHydratedOptions {
+  /** Hydration root selector; defaults to #root. */
   root?: string;
+
+  /** Assertion deadline in milliseconds; defaults to 5,000. */
   timeout?: number;
 }
 
@@ -11,6 +14,9 @@ interface IStreamTimelineCollector {
   read: () => Promise<IBrowserTimelineEvent[]>;
 }
 
+/**
+ * Avoid installing duplicate observers on the same page.
+ */
 const installed = new WeakSet<Page>();
 
 /** Install before navigation so console failures and the original SSR DOM cannot be missed. */
@@ -21,6 +27,9 @@ const collectStreamTimeline = async (page: Page): Promise<IStreamTimelineCollect
   }
 
   return {
+    /**
+     * Read the milestones observed during the current navigation.
+     */
     read: () => page.evaluate(() => window.__ssrBoostTest?.events ?? []),
   };
 };
@@ -33,6 +42,10 @@ const expectHydrated = async (
   const { expect } = await import('@playwright/test');
 
   expect(installed.has(page), 'Call collectStreamTimeline(page) before page.goto().').toBe(true);
+
+  /**
+   * Wait until the observer captures the server root at router creation.
+   */
   await expect
     .poll(async () => (await page.evaluate(inspectHydration, root)).ready, {
       timeout,
@@ -40,23 +53,31 @@ const expectHydrated = async (
     })
     .toBe(true);
   await page.waitForLoadState('load', { timeout });
+
+  /**
+   * Wait until React finishes replacing pending server boundaries.
+   */
   await expect
     .poll(async () => (await page.evaluate(inspectHydration, root)).pending, {
       timeout,
       message: 'Streamed Suspense boundaries did not settle.',
     })
     .toBe(0);
+
+  /**
+   * Give the browser a rendering opportunity after streamed boundaries settle.
+   */
   await page.evaluate(
     () =>
       new Promise<void>((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       }),
   );
-  const result = await page.evaluate(inspectHydration, root);
+  const { consumed: isConsumed, errors, duplicates } = await page.evaluate(inspectHydration, root);
 
-  expect(result.consumed, 'Router hydration state was not consumed.').toBe(true);
-  expect(result.errors, 'React reported hydration errors.').toEqual([]);
-  expect(result.duplicates, 'Server text was duplicated during hydration.').toEqual([]);
+  expect(isConsumed, 'Router hydration state was not consumed.').toBe(true);
+  expect(errors, 'React reported hydration errors.').toEqual([]);
+  expect(duplicates, 'Server text was duplicated during hydration.').toEqual([]);
 };
 
 /** Require an observed shell before this element first became visible. */
@@ -67,16 +88,18 @@ const expectStreamed = async (page: Page, selector: string): Promise<void> => {
   const element = page.locator(selector);
 
   await expect(element).toBeVisible();
-  const timing = await element.evaluate((node) => ({
+
+  /**
+   * Compare shell visibility with the element's first observed appearance.
+   */
+  const { shell, element: elementAt } = await element.evaluate((node) => ({
     shell: window.__ssrBoostTest?.shellAt,
     element: window.__ssrBoostTest?.seen.get(node),
   }));
 
-  expect(timing.shell, 'No server shell was observed.').toBeDefined();
-  expect(timing.element, 'The element was not observed during this navigation.').toBeDefined();
-  expect(timing.element!, 'The element must appear after the shell.').toBeGreaterThan(
-    timing.shell!,
-  );
+  expect(shell, 'No server shell was observed.').toBeDefined();
+  expect(elementAt, 'The element was not observed during this navigation.').toBeDefined();
+  expect(elementAt!, 'The element must appear after the shell.').toBeGreaterThan(shell!);
 };
 
 export { collectStreamTimeline, expectHydrated, expectStreamed };

--- a/src/testing/requests.ts
+++ b/src/testing/requests.ts
@@ -1,3 +1,6 @@
+/**
+ * Give relative test URLs a stable origin without starting a server.
+ */
 const TEST_ORIGIN = 'http://localhost';
 
 /** Give relative test paths the same stable origin as createTestHandler.fetch. */

--- a/src/testing/response.ts
+++ b/src/testing/response.ts
@@ -5,17 +5,21 @@ import type { IRouterState, TStreamFrame } from './parse-response';
 
 interface ITestChunk {
   text: string;
+
+  /** Milliseconds since request start when the decoded text became available. */
   at: number;
 }
 
 interface ITestCookie {
   name: string;
   value: string;
+
   /** Lowercase attribute names; flags are true, other values remain strings. */
   attributes: Record<string, string | true>;
 }
 
 interface ITestResponseOptions {
+  /** Monotonic request start in milliseconds; defaults to construction time. */
   started?: number;
   timeline?: RequestTimeline;
   signal?: AbortSignal;
@@ -24,12 +28,33 @@ interface ITestResponseOptions {
 
 /** A single eager stream reader with repeatable, order-independent assertions. */
 class TestResponse {
+  /**
+   * Retain decoded chunks and their arrival offsets for repeatable assertions.
+   */
   protected readonly parts: ITestChunk[] = [];
+
+  /**
+   * Share one body-consumption result across all asynchronous assertions.
+   */
   protected readonly completed: Promise<void>;
+
+  /**
+   * Anchor chunk timing to the start of the request.
+   */
   protected readonly started: number;
 
+  /**
+   * Begin consuming the response once and retain failures for later assertions.
+   */
   public constructor(
+    /**
+     * Expose the original response and its metadata.
+     */
     public readonly response: Response,
+
+    /**
+     * Retain request timing, cancellation and completion hooks.
+     */
     protected readonly options: ITestResponseOptions = {},
   ) {
     this.started = options.started ?? performance.now();
@@ -37,57 +62,23 @@ class TestResponse {
     void this.completed.catch(() => undefined);
   }
 
+  /**
+   * Expose the committed HTTP status.
+   */
   public get status(): number {
     return this.response.status;
   }
 
+  /**
+   * Expose the committed response headers.
+   */
   public get headers(): Headers {
     return this.response.headers;
   }
 
-  /** Decode incrementally so multibyte characters survive arbitrary transport cuts. */
-  protected async read(): Promise<void> {
-    const reader = this.response.body?.getReader();
-    const decoder = new TextDecoder();
-    const { signal, onComplete } = this.options;
-    const onAbort = (): void => {
-      void reader?.cancel(signal?.reason).catch(() => undefined);
-    };
-
-    signal?.addEventListener('abort', onAbort, { once: true });
-
-    try {
-      signal?.throwIfAborted();
-
-      if (reader) {
-        while (true) {
-          const chunk = await reader.read();
-
-          signal?.throwIfAborted();
-
-          const text = chunk.done
-            ? decoder.decode()
-            : decoder.decode(chunk.value, { stream: true });
-
-          if (text) {
-            this.parts.push({ text, at: performance.now() - this.started });
-          }
-
-          if (chunk.done) {
-            break;
-          }
-        }
-      }
-    } catch (error) {
-      await reader?.cancel(error).catch(() => undefined);
-      throw error;
-    } finally {
-      reader?.releaseLock();
-      signal?.removeEventListener('abort', onAbort);
-      onComplete?.();
-    }
-  }
-
+  /**
+   * Join the fully consumed response body for repeatable assertions.
+   */
   public async text(): Promise<string> {
     await this.completed;
 
@@ -99,12 +90,18 @@ class TestResponse {
     return this.text();
   }
 
+  /**
+   * Return isolated chunk observations after body consumption completes.
+   */
   public async chunks(): Promise<ITestChunk[]> {
     await this.completed;
 
     return this.parts.map((chunk) => ({ ...chunk }));
   }
 
+  /**
+   * Reconstruct the loader and action state emitted in the document.
+   */
   public async routerState(): Promise<IRouterState | undefined> {
     return routerState(await this.text());
   }
@@ -114,6 +111,9 @@ class TestResponse {
     return (await this.text()).split('<!--$?-->').length - 1;
   }
 
+  /**
+   * Read validated SSR Boost transport frames in emission order.
+   */
   public async streamFrames(): Promise<TStreamFrame[]> {
     return streamFrames(await this.text());
   }
@@ -131,6 +131,9 @@ class TestResponse {
     const values =
       headers.getSetCookie?.() ?? headers.get('set-cookie')?.split(/,(?=\s*[^=;,\s]+=)/) ?? [];
 
+    /**
+     * Split each cookie into its value and normalized attributes.
+     */
     return values.map((cookie) => {
       const [pair, ...attributes] = cookie.split(';');
       const separator = pair.indexOf('=');
@@ -138,6 +141,10 @@ class TestResponse {
       return {
         name: pair.slice(0, separator).trim(),
         value: pair.slice(separator + 1).trim(),
+
+        /**
+         * Preserve attribute values and represent valueless flags as true.
+         */
         attributes: Object.fromEntries(
           attributes.map((attribute): [string, string | true] => {
             const index = attribute.indexOf('=');
@@ -149,6 +156,51 @@ class TestResponse {
         ),
       };
     });
+  }
+
+  /** Decode incrementally so multibyte characters survive arbitrary transport cuts. */
+  protected async read(): Promise<void> {
+    const reader = this.response.body?.getReader();
+    const decoder = new TextDecoder();
+    const { signal, onComplete } = this.options;
+
+    /**
+     * Cancel the active reader when the request signal aborts.
+     */
+    const onAbort = (): void => {
+      void reader?.cancel(signal?.reason).catch(() => undefined);
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      signal?.throwIfAborted();
+
+      if (reader) {
+        while (true) {
+          const { done: isDone, value } = await reader.read();
+
+          signal?.throwIfAborted();
+
+          const text = isDone ? decoder.decode() : decoder.decode(value, { stream: true });
+
+          if (text) {
+            this.parts.push({ text, at: performance.now() - this.started });
+          }
+
+          if (isDone) {
+            break;
+          }
+        }
+      }
+    } catch (error) {
+      await reader?.cancel(error).catch(() => undefined);
+      throw error;
+    } finally {
+      reader?.releaseLock();
+      signal?.removeEventListener('abort', onAbort);
+      onComplete?.();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Block comments on every class member, exported function and meaningful helper added in phase 3 (policy, SPA shell, cache helpers, Cloudflare entry, in-memory route assets, request timeline, testing kit), in the local `/** ... */` style without `@param`/`@returns`.
- Line comments used as documentation converted to block comments; parameters and objects used more than once destructured; class members ordered public state → protected dependencies → constructor → public methods → protected helpers.
- `IWorkerHandlerOptions` is now the alias `TWorkerHandlerOptions` internally; the public export name is unchanged. No behavior, public type or test changes.

## Test plan
- [x] lint, types, 872 unit/integration tests, build, size budgets, `test:core:no-optional`, docs build
- [x] template acceptance with Chromium checks and rollback runs
- [x] Playwright suites (9 tests), packed Worker suite in workerd, Worker hydration tests in Chromium
