### PR TITLE
docs: add agent skills for migrating a spa and creating a new app

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lomray",
+  "owner": {
+    "name": "Lomray Software"
+  },
+  "plugins": [
+    {
+      "name": "ssr-boost",
+      "source": "./",
+      "description": "Migrate a Vite SPA or create a new SSR Boost application."
+    }
+  ],
+  "metadata": {
+    "description": "Agent skills for Vite SSR Boost applications."
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "ssr-boost",
+  "description": "Skills for migrating Vite React Router SPAs to SSR Boost and creating new SSR applications.",
+  "version": "1.0.0",
+  "skills": [
+    "./skills/ssr-boost-migrate",
+    "./skills/ssr-boost-new-app"
+  ],
+  "repository": "https://github.com/Lomray-Software/vite-ssr-boost",
+  "license": "MIT",
+  "author": {
+    "name": "Lomray Software"
+  }
+}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check eslint
         run: npm run lint:check
 
+      - name: Validate agent skills and verification scripts
+        run: npm run test:skills
+
       - name: Typescript check
         run: npm run ts:check
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ Test SSR routes without a server with `@lomray/vite-ssr-boost/testing`; see the 
 - [Hydration order and streaming](./docs/reference/hydration-and-streaming.md).
 - API: [Plugin](./docs/api/plugin.md), [Browser entry](./docs/api/browser-entry.md), [Server entry](./docs/api/server-entry.md), [Node production](./docs/api/node-production.md), [Components and helpers](./docs/api/components-and-helpers.md) and [CLI](./docs/api/cli.md).
 
+## AI agents
+
+The repository includes `ssr-boost-migrate` and `ssr-boost-new-app` in the [Agent Skills format](https://agentskills.io/specification).
+
+Claude Code plugin:
+
+```sh
+claude plugin marketplace add Lomray-Software/vite-ssr-boost
+claude plugin install ssr-boost@lomray
+```
+
+Codex CLI, from this checkout:
+
+```sh
+mkdir -p ~/.codex/skills
+cp -R skills/ssr-boost-migrate skills/ssr-boost-new-app ~/.codex/skills/
+# Or use the target application's .codex/skills directory.
+```
+
+Current Codex versions document `.agents/skills` for discovery; use that destination or the symlinks in [AI usage and installation](./docs/ai-usage.md#ai-agents). That page also covers local Claude plugin testing before the files reach the default branch.
+
+For Cursor, copy the folders into the app's `skills/` directory and add a `.cursor/rules/ssr-boost.mdc` rule pointing to the relevant `SKILL.md`; see the [complete rule](./docs/ai-usage.md#ai-agents). Other agents can use [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt) or [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt).
+
 ## License
 
 Made with 💚

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -91,6 +91,7 @@ export default defineConfig({
         items: [
           { text: 'AI Usage', link: '/ai-usage' },
           { text: 'Support and versions', link: '/reference/support' },
+          { text: 'Benchmarks', link: '/reference/benchmarks' },
           { text: 'Talking Points', link: '/reference/talking-points' },
           { text: 'Hydration order and streaming', link: '/reference/hydration-and-streaming' },
           { text: 'FAQ', link: '/reference/faq' },

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -2,6 +2,57 @@
 
 Use this page as a grounding reference for tools working with the package.
 
+## AI agents
+
+Two [Agent Skills](https://agentskills.io/specification) are available: `ssr-boost-migrate` for an existing Vite SPA and `ssr-boost-new-app` for a new application. They include entry/data references and verification scripts.
+
+**Claude Code** — install the [plugin](https://code.claude.com/docs/en/plugins):
+
+```sh
+claude plugin marketplace add Lomray-Software/vite-ssr-boost
+claude plugin install ssr-boost@lomray
+```
+
+Invoke `/ssr-boost:ssr-boost-migrate` or `/ssr-boost:ssr-boost-new-app`. The GitHub install uses the repository's default branch; it requires the skill files to be present there. To try a checkout before release, run `claude --plugin-dir /absolute/path/to/vite-ssr-boost`.
+
+**Codex CLI** — from a clone of this repository, copy the complete folders (including references/scripts) into the personal skill directory:
+
+```sh
+mkdir -p ~/.codex/skills
+cp -R skills/ssr-boost-migrate skills/ssr-boost-new-app ~/.codex/skills/
+```
+
+Or copy them into the target repository:
+
+```sh
+mkdir -p /path/to/app/.codex/skills
+cp -R skills/ssr-boost-migrate skills/ssr-boost-new-app /path/to/app/.codex/skills/
+```
+
+The [current Codex documentation](https://developers.openai.com/codex/skills) specifies `.agents/skills` for discovery. For those versions, copy into `~/.agents/skills` or the application's `.agents/skills` instead, or expose the personal copies above with per-skill symlinks:
+
+```sh
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/skills/ssr-boost-migrate ~/.agents/skills/ssr-boost-migrate
+ln -s ~/.codex/skills/ssr-boost-new-app ~/.agents/skills/ssr-boost-new-app
+```
+
+Use one discovered copy of each skill. For repository copies, use the equivalent symlinks from `.agents/skills/<name>` to `../../.codex/skills/<name>`. Invoke `$ssr-boost-migrate` or `$ssr-boost-new-app`; check `/skills` and restart Codex if the skills do not appear. Review existing folders before copying updates.
+
+**Cursor** — copy the skill folders into the app's `skills/` directory, then add a [project rule](https://cursor.com/docs/context/rules) at `.cursor/rules/ssr-boost.mdc`:
+
+```md
+---
+description: SSR Boost migration and new application workflows
+alwaysApply: false
+---
+For a Vite SPA migration, read @skills/ssr-boost-migrate/SKILL.md.
+For a new SSR Boost app, read @skills/ssr-boost-new-app/SKILL.md.
+Follow the selected skill's references and verification procedure.
+```
+
+**Other agents** — start with [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt), or use [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt) for the documentation and both skill procedures. The [benchmark reference](/reference/benchmarks) points to current measurements without embedding result numbers.
+
 ## Package identity
 
 `@lomray/vite-ssr-boost` adds SSR to React Router apps in Data mode, without moving to Framework mode and without rewriting the app. Keep the Vite configuration, route objects and components; use the same application for SSR or SPA output.
@@ -60,7 +111,7 @@ For an existing Vite + React Router app, run `ssr-boost init --dry-run` first an
 
 ## Machine-readable documentation
 
-The docs build generates [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt) and [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt) from the Markdown sources. The short file includes the package identity, the resolved release version when available, the public entrypoints and data-loading contract from this page, and an absolute URL for every documentation page. The full file concatenates those pages with their source URLs.
+The docs build generates [llms.txt](https://lomray-software.github.io/vite-ssr-boost/llms.txt) and [llms-full.txt](https://lomray-software.github.io/vite-ssr-boost/llms-full.txt) from the Markdown sources. The short file includes the package identity, the resolved release version when available, the public entrypoints and data-loading contract from this page, and an absolute URL for every documentation page. The full file concatenates those pages and both `skills/*/SKILL.md` procedures with their source URLs; relative skill links become absolute repository links.
 
 Run `npm run docs:build` to regenerate both files in `docs/.vitepress/dist`. The version comes from `git describe --tags --match 'v*' --abbrev=0`, with the leading `v` removed. If tags are unavailable, the build falls back to `npm view @lomray/vite-ssr-boost version`; if that also fails, it omits the version line. The build reports which source it used. The docs workflow fetches full Git history and tags so CI can use the tag path. The source manifest's placeholder version is never used; semantic-release assigns the published package version in `lib/package.json` separately.
 

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -1,0 +1,32 @@
+# Benchmarks
+
+[Lomray-Software/ssr-benchmarks](https://github.com/Lomray-Software/ssr-benchmarks) runs the same three-route React application on vite-ssr-boost, React Router Framework mode, Vike, TanStack Start and Next.js. The routes cover static content with a counter, a list with delayed data, and a detail page with an immediate field and a deferred field. Shared content, styling and deterministic data keep the workload comparable; each implementation uses its framework's routing and rendering conventions.
+
+See the [repository README for current tables and methodology](https://github.com/Lomray-Software/ssr-benchmarks#results). The measurements describe that workload, not a general framework ranking. Lomray maintains both the benchmark and vite-ssr-boost.
+
+## What is measured
+
+- **Cold start:** fresh production process startup through its first completed successful response, including the npm launcher and first request. This does not measure serverless provisioning or an empty OS cache.
+- **RSS:** resident memory in the serving Node process after HTTP load, before browser measurements; not peak memory or the Chromium process.
+- **Emitted JavaScript:** all production JS and the client-output subset, excluding source maps and build caches. Emitted server code is not browser download cost.
+- **Fetched JavaScript:** actual external JavaScript fetched by a fresh browser for each route, plus inline executable scripts, reported with normalized gzip estimates. This includes hydration/bootstrap payloads.
+- **TTFB percentiles:** p50, p95 and p99 for each route under the documented warmup and request load. Raw results also contain full-response timings and response bytes.
+- **Browser milestones:** time to a counter that responds to a click and time until the deferred field is visible. These are application-specific observations, not a general Web Vitals score.
+
+Raw results include samples, settings, source/lockfile hashes, runtime versions and machine details. Compare complete runs on the same machine and mode; quick runs only check the harness.
+
+## Regenerate or reproduce
+
+The repository's [weekly GitHub Actions workflow](https://github.com/Lomray-Software/ssr-benchmarks/blob/prod/.github/workflows/bench.yml) runs the pinned applications, uploads results, and commits successful full `results/` output and regenerated README tables. It also supports manual dispatch. Failed or incomplete runs are not published as successful results; dependency updates require an app/lockfile change.
+
+Clone the benchmark repository and, from its root, run:
+
+```sh
+npm ci && npm run bench
+```
+
+Follow the [README prerequisites](https://github.com/Lomray-Software/ssr-benchmarks#reproduce) for Node, Chromium and Linux browser libraries. The runner builds and measures each app separately. Use its documented output option to keep an independent run without replacing the default results.
+
+## Challenge a number
+
+Open a [pull request in ssr-benchmarks](https://github.com/Lomray-Software/ssr-benchmarks/pulls) with the app diff that reproduces or corrects the concern. Preserve the [shared application contract](https://github.com/Lomray-Software/ssr-benchmarks/blob/prod/SPEC.md), include the exact command, raw JSON and environment, and provide before/after results from the same machine. Disclose changed defaults. Framework maintainers can propose a more idiomatic implementation through the same process.

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "vite": "^8.2.2",
         "vitepress": "^1.6.4",
         "vitest": "^5.0.0",
-        "wrangler": "^4.129.0"
+        "wrangler": "^4.129.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "prepare": "husky",
     "test:browser": "playwright test --config playwright.config.mjs",
     "test:worker:packed": "node scripts/test-packed-worker.mjs",
-    "test:worker:browser": "playwright test --config playwright.worker.config.mjs"
+    "test:worker:browser": "playwright test --config playwright.worker.config.mjs",
+    "test:skills": "node scripts/test-skills.mjs"
   },
   "dependencies": {
     "chalk": "^6.0.0",
@@ -169,7 +170,8 @@
     "vite": "^8.2.2",
     "vitepress": "^1.6.4",
     "vitest": "^5.0.0",
-    "wrangler": "^4.129.0"
+    "wrangler": "^4.129.0",
+    "yaml": "^2.9.0"
   },
   "peerDependencies": {
     "@babel/generator": ">=7.23.0",

--- a/scripts/build-llms.mjs
+++ b/scripts/build-llms.mjs
@@ -27,6 +27,18 @@ const files = (await readdir(docs, { recursive: true }))
   .filter((file) => file.endsWith('.md') && !file.split('/').some((part) => part.startsWith('.')))
   .sort();
 const pages = [];
+const skillNames = ['ssr-boost-migrate', 'ssr-boost-new-app'];
+const skills = await Promise.all(skillNames.map(async (name) => {
+  const file = `skills/${name}/SKILL.md`;
+  const url = `https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/${file}`;
+  const source = await readFile(new URL(file, root), 'utf8');
+
+  // Installed skills use relative supporting files; the concatenated document has no file base.
+  const absoluteSource = source.replace(/\]\((?![a-z]+:|#|\/)([^)]+)\)/g,
+    (_match, target) => `](${new URL(target, url).href})`);
+
+  return { title: name, url, source: absoluteSource };
+}));
 
 for (const file of files) {
   const source = await readFile(new URL(file, docs), 'utf8');
@@ -66,8 +78,10 @@ const introduction = [
 ].join('\n\n');
 const index = `${introduction}\n\n## Documentation\n\n${pages
   .map(({ title, url }) => `- [${title}](${url})`)
+  .join('\n')}\n\n## Agent skills\n\n${skills
+  .map(({ title, url }) => `- [${title}](${url})`)
   .join('\n')}\n`;
-const full = `${introduction}\n\n${pages
+const full = `${introduction}\n\n${[...pages, ...skills]
   .map(({ url, source }) => `---\n\nSource: ${url}\n\n${source.trim()}`)
   .join('\n\n')}\n`;
 
@@ -79,6 +93,6 @@ process.stdout.write(
     ? `Documentation version: ${version} (source: ${versionSource})\n`
     : 'Documentation version: omitted (git tags and npm registry unavailable)\n') +
     `llms.txt: ${pages.length} page links, ${Buffer.byteLength(index)} bytes\n` +
-    `llms-full.txt: ${pages.length} concatenated pages, ${Buffer.byteLength(full)} bytes\n` +
+    `llms-full.txt: ${pages.length} concatenated pages, ${skills.length} skills, ${Buffer.byteLength(full)} bytes\n` +
     `Verified ${pages.length}/${pages.length} page links resolve in ${fileURLToPath(dist)}\n`,
 );

--- a/scripts/test-skills.mjs
+++ b/scripts/test-skills.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { access, chmod, cp, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseDocument } from 'yaml';
+import ts from 'typescript';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const names = ['ssr-boost-migrate', 'ssr-boost-new-app'];
+const allowed = new Set(['name', 'description', 'license', 'compatibility', 'metadata', 'allowed-tools']);
+const frontmatter = (source, directory) => {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  assert.ok(match, `${directory}: missing YAML frontmatter`);
+  const document = parseDocument(match[1], { uniqueKeys: true });
+  assert.equal(document.errors.length, 0, `${directory}: ${document.errors.join('; ')}`);
+  const data = document.toJS();
+  assert.ok(data && typeof data === 'object' && !Array.isArray(data), `${directory}: expected mapping`);
+  for (const key of Object.keys(data)) assert.ok(allowed.has(key), `${directory}: unsupported ${key}`);
+  assert.equal(typeof data.name, 'string', 'name must be a string');
+  assert.ok(data.name.length <= 64 && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(data.name), 'invalid name');
+  assert.equal(data.name, directory, 'name must match its directory');
+  assert.equal(typeof data.description, 'string', 'description must be a string');
+  assert.ok(data.description.trim().length > 0 && data.description.length <= 1024, 'invalid description');
+  for (const key of ['license', 'compatibility', 'allowed-tools']) {
+    if (key in data) assert.equal(typeof data[key], 'string', `${key} must be a string`);
+  }
+  if ('compatibility' in data) assert.ok(data.compatibility.length > 0 && data.compatibility.length <= 500);
+  if ('metadata' in data) {
+    assert.ok(data.metadata && typeof data.metadata === 'object' && !Array.isArray(data.metadata));
+    assert.ok(Object.values(data.metadata).every((value) => typeof value === 'string'), 'metadata values must be strings');
+  }
+  assert.ok(source.slice(match[0].length).trim(), `${directory}: empty procedure`);
+  return data;
+};
+
+// Validate Markdown destinations, including reference-style definitions and autolinks.
+// Fenced code is excluded; code-font bundled file references are checked separately below.
+const destinations = (source) => {
+  const prose = source.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?^\1\s*$/gm, '');
+  return [
+    ...prose.matchAll(/\]\(<?([^\s)>]+)>?(?:\s+["'][^\n]*?["'])?\)/g),
+    ...prose.matchAll(/^\s*\[[^\]]+\]:\s*<?([^\s>]+)>?/gm),
+    ...prose.matchAll(/<(https?:\/\/[^>]+)>/g),
+  ].map((match) => match[1]);
+};
+const resolveTarget = (target, sourceFile) => {
+  const clean = decodeURIComponent(target.split(/[?#]/)[0]);
+  if (!clean || /^(?:mailto|app):/.test(clean)) return null;
+  if (/^https?:/.test(clean)) {
+    const repo = 'https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/';
+    const site = 'https://lomray-software.github.io/vite-ssr-boost/';
+    if (clean.startsWith(repo)) return path.join(root, clean.slice(repo.length));
+    if (clean.startsWith(site)) {
+      const route = clean.slice(site.length).replace(/\/$/, '/index') || 'index';
+      if (/^llms(?:-full)?\.txt$/.test(route)) return null; // Generated after docs build.
+      return path.join(root, 'docs', `${route}.md`);
+    }
+    return null;
+  }
+  if (clean.startsWith('/')) return path.join(root, 'docs', `${clean.slice(1).replace(/\/$/, '/index') || 'index'}.md`);
+  const file = path.resolve(path.dirname(sourceFile), clean);
+  if (path.extname(file)) return file;
+  return path.join(file, 'index.md');
+};
+const mustExist = async (file, from) => {
+  const relative = path.relative(root, file);
+  assert.ok(!relative.startsWith('..') && !path.isAbsolute(relative), `${from}: reference escapes repository: ${file}`);
+  try { await access(file); } catch { assert.fail(`${from}: missing referenced file ${relative}`); }
+};
+
+// Regression cases prove invalid metadata cannot pass through a permissive YAML parse.
+for (const [key, value] of [
+  ['name', 'Bad-Name'], ['name', '-bad'], ['name', 'bad--name'], ['name', 'a'.repeat(65)],
+  ['description', '""'], ['description', '42'], ['description', 'x'.repeat(1025)],
+]) {
+  const fields = { name: 'example', description: 'Use for an example task.', [key]: value };
+  assert.throws(() => frontmatter(`---\nname: ${fields.name}\ndescription: ${fields.description}\n---\nBody`, fields.name));
+}
+assert.throws(() => frontmatter('---\nname: example\nname: example\ndescription: ok\n---\nBody', 'example'));
+assert.throws(() => frontmatter('---\nname: example\ndescription: ok\nmetadata: { version: 1 }\n---\nBody', 'example'));
+frontmatter('---\nname: example\ndescription: >-\n  An example\n  task procedure.\n---\nBody', 'example');
+await assert.rejects(mustExist(path.join(root, 'docs/not-a-real-skill-page.md'), 'regression'));
+assert.deepEqual(destinations('[inline](references/a.md)\n[ref]: docs/guide/b.md\n<https://example.com>'),
+  ['references/a.md', 'docs/guide/b.md', 'https://example.com']);
+
+let links = 0;
+const skillMarkdown = [];
+for (const name of names) {
+  const folder = path.join(root, 'skills', name);
+  frontmatter(await readFile(path.join(folder, 'SKILL.md'), 'utf8'), name);
+  const files = await readdir(folder, { recursive: true });
+  for (const file of files.filter((name) => name.endsWith('.md'))) skillMarkdown.push(path.join(folder, file));
+  for (const file of files.filter((name) => name.endsWith('.mjs'))) {
+    execFileSync(process.execPath, ['--check', path.join(folder, file)], { stdio: 'pipe' });
+  }
+  for (const file of files.filter((name) => name.endsWith('.ts.txt'))) {
+    const result = ts.transpileModule(await readFile(path.join(folder, file), 'utf8'), {
+      fileName: file.replace(/\.txt$/, ''),
+      compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+      reportDiagnostics: true,
+    });
+    assert.equal(result.diagnostics.filter((item) => item.category === ts.DiagnosticCategory.Error).length,
+      0, `${name}/${file}: invalid TypeScript template`);
+  }
+  const verify = path.join(folder, 'scripts/verify.sh');
+  assert.ok((await stat(verify)).mode & 0o111, `${name}: verify.sh must be executable`);
+  execFileSync('bash', ['-n', verify]);
+  const temporary = await mkdtemp(path.join(tmpdir(), 'ssr skill validation '));
+  try {
+    await cp(folder, path.join(temporary, name), { recursive: true });
+    // Any Node/npm/CLI call in help/dry mode fails, even if an implementation swallows its exit.
+    const marker = path.join(temporary, 'unexpected-command');
+    for (const command of ['node', 'npm', 'npx', 'ssr-boost']) {
+      const trap = path.join(temporary, command);
+      await writeFile(trap, '#!/bin/sh\nprintf called > "$SKILL_TEST_MARKER"\nexit 91\n');
+      await chmod(trap, 0o755);
+    }
+    const options = {
+      cwd: temporary,
+      env: { ...process.env, PATH: `${temporary}:${process.env.PATH}`, SKILL_TEST_MARKER: marker },
+      encoding: 'utf8', stdio: 'pipe', timeout: 10_000,
+    };
+    const copied = path.join(temporary, name, 'scripts/verify.sh');
+    assert.match(execFileSync('bash', [copied, '--help'], options), /Usage:/);
+    const dry = execFileSync('bash', [copied, '--dry-run', 'nonexistent app'], options);
+    assert.match(dry, /doctor --json[\s\S]*build[\s\S]*size[\s\S]*smoke[\s\S]*build/);
+    assert.ok(!(await readdir(temporary)).includes('nonexistent app'), 'dry mode created a project');
+    await assert.rejects(access(marker), 'help/dry mode executed a project command');
+    assert.throws(() => execFileSync('bash', [copied, '--unknown'], options));
+    console.info(`${name}: frontmatter, standalone --help / --dry-run and shell syntax passed`);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+const docFiles = (await readdir(path.join(root, 'docs'), { recursive: true }))
+  .filter((file) => file.endsWith('.md') && !file.split('/').some((part) => part.startsWith('.')))
+  .map((file) => path.join(root, 'docs', file));
+for (const file of [...skillMarkdown, path.join(root, 'README.md'), ...docFiles]) {
+  const source = await readFile(file, 'utf8');
+  const isSkill = skillMarkdown.includes(file);
+  for (const target of destinations(source)) {
+    const resolved = resolveTarget(target, file);
+    if (!resolved) continue;
+    // All skill links must resolve; elsewhere this gate owns links into docs/.
+    if (isSkill || resolved.startsWith(`${path.join(root, 'docs')}${path.sep}`)) {
+      await mustExist(resolved, path.relative(root, file));
+      links++;
+    }
+  }
+  if (isSkill) {
+    const folder = path.join(root, 'skills', path.relative(path.join(root, 'skills'), file).split(path.sep)[0]);
+    for (const [, target] of source.matchAll(/`((?:references|scripts|assets)\/[\w./-]+\.(?:md|sh|mjs))`/g)) {
+      // Backticked scripts/*.mjs often describe the target app. Bundled files are Markdown links.
+      if (target.startsWith('references/')) await mustExist(path.join(folder, target), file);
+    }
+  }
+}
+const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+const plugin = JSON.parse(await readFile(path.join(root, '.claude-plugin/plugin.json'), 'utf8'));
+const marketplace = JSON.parse(await readFile(path.join(root, '.claude-plugin/marketplace.json'), 'utf8'));
+assert.equal(plugin.name, 'ssr-boost');
+assert.equal(plugin.version, pkg.version);
+assert.ok(plugin.description?.trim());
+assert.deepEqual(plugin.skills, names.map((name) => `./skills/${name}`));
+assert.equal(marketplace.name, 'lomray');
+assert.ok(marketplace.owner.name);
+assert.equal(marketplace.plugins.length, 1);
+assert.equal(marketplace.plugins[0].name, plugin.name);
+assert.equal(marketplace.plugins[0].source, './');
+console.info(`Validated ${names.length} skills, ${links} local/doc links, plugin version ${plugin.version} and ssr-boost@lomray marketplace.`);

--- a/skills/ssr-boost-migrate/SKILL.md
+++ b/skills/ssr-boost-migrate/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ssr-boost-migrate
+description: Migrate an existing Vite and React Router SPA to vite-ssr-boost SSR in Data mode, preserving route objects and checking streaming, hydration, bundle size, and deployment readiness.
+---
+
+# Migrate a Vite SPA
+
+Use this procedure in the application repository. Read its instructions and preserve its package manager, providers, routes and unrelated changes. The API examples target vite-ssr-boost 8.x; read the installed version before changing imports. Documentation links point to the upstream repository so they work when this skill is copied on its own.
+
+The testing kit, incremental SSR policy and Worker helper require a release containing those APIs; the stable 8.3.0 template dependency predates them. For a prerelease evaluation, the published `8.4.0-beta.4` was used for these workflows. Check installed exports and the project's release policy before adopting a prerelease; do not silently use one for a stable-only production rollout.
+
+## 1. Establish the baseline
+
+- Inspect `package.json`, the lockfile, Vite config, HTML module script, browser entry, route definitions and deployment target. Run existing checks and record the current client JavaScript size before editing.
+- The migration baseline is Vite **6/7**, matching React/React DOM **18/19**, and **react-router 7 Data mode**. Tested combinations include React 18.2.0 + Router 7.18.3 + Vite 6.4.3 and React 19.2.8 + Router 7.18.3 + Vite 7.3.6. Node must satisfy the installed packages' engines (SSR Boost requires >=22.12.0). See [compatibility](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/README.md#compatibility). Newer templates also use the separately tested React 19 / Router 8 / Vite 8 row; peer ranges alone are not proof of compatibility.
+- If the SPA uses JSX `BrowserRouter`/`Routes`, first migrate it to one `createBrowserRouter(routes)` and `RouterProvider`. Preserve nested layouts, error boundaries and provider order. [Route and loader shapes](references/routes.md) include a minimal before entry. Verify the SPA still works before adding SSR. Do not move to React Router Framework mode.
+- Record browser-only imports, module-scope state reads, custom router options, multiple roots and non-root Vite `base`. Automatic init deliberately refuses ambiguous startup code; preserve it with the [manual entry shapes](references/entries.md) and [migration guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/migrate-existing-spa.md).
+
+## 2. Preview, review, apply
+
+Run from the application root:
+
+```sh
+npx @lomray/vite-ssr-boost init --dry-run
+```
+
+With no flag, init also defaults to a dry run. Review the complete diff: existing Vite plugins remain, exactly one outlet is inside `#root`, client and server share routes and the same wrapper tree, and scripts/dependencies are correct. Then apply the reviewed plan:
+
+```sh
+npx @lomray/vite-ssr-boost init --apply
+npm install
+npx ssr-boost doctor --json
+```
+
+Init does not install packages. It preserves the original browser filename (often `src/main.tsx`), creates `src/server.ts`, and sets `clientFile`/`serverFile` relative to the Vite root. It can extract inline routes into `routes.ssr.tsx`. Do not rename files just to match examples. Review the changed build script: init replaces `tsc -b && vite build`, so retain type checking as a separate `ts:check` script. A second apply should report no changes.
+
+For explicit paths use `--root <project> --entry <browser-file> --routes <exported-route-module>`; the file overrides are relative to the project, not the Vite root. If analysis fails, use the reported file/line and the manual guide; do not repeatedly apply or delete custom code to force acceptance.
+
+## 3. Complete request state and data loading
+
+Read [entries and createHandler options](references/entries.md) before editing either entry. Use `browser/entry` and `adapters/express/entry`; `node/entry` was removed in v8. Keep the managed CLI unless the chosen target requires an application-owned transport.
+
+Move `getServerState` reads and store construction into the browser entry's async `init`, after SSR state is ready. Use `isSSRMode` for the SPA fallback. Create server stores and head managers per request in `onRequest`; return JSON snapshots from `getState`. Keep browser globals in effects or client-only boundaries, and preserve equivalent first-render data on both sides.
+
+Use [streamed loader/action shapes](references/routes.md): return an object with a slow promise, then consume it with Suspense and `<Await>` (or React 19 `use`). Keep Data mode loaders/actions browser-compatible for navigation; server-only I/O belongs behind an API. Forward `request.signal`. Keep footer hydration unless early shell interaction is required; early mode needs an async module script and all custom state at shell readiness. See [streaming](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/data-streaming.md).
+
+## 4. Diagnose until green
+
+Run `npx ssr-boost doctor --json` after dependency, entry, route, config or script changes. Fix every error and rerun until there are none. Inspect compatibility warnings against the tested matrix; an exit code of zero does not mean every check was `ok`. Robots and size checks are informational; doctor does not measure bundle size or execute hydration. It statically checks the managed Express entry even for apps with an additional Worker entry.
+
+| Diagnostic | Fix |
+| --- | --- |
+| `SSR_BOOST_LOADER_NOT_SERIALIZABLE` | Replace functions, unsupported classes and cycles with explicit route data. Streamed promises and documented rich router values are supported. |
+| `SSR_BOOST_STATE_NOT_SERIALIZABLE` | Return a plain JSON snapshot from `getState`; await custom state, convert dates and collections, rebuild stores inside client `init`. |
+| `SSR_BOOST_OUTLET_MISSING` | Preserve exactly one `<!--ssr-outlet-->` inside the root; validate Fetch shells with `loadHtmlShell`. |
+| `SSR_BOOST_HYDRATION_STATE_MISSING` | Preserve generated state scripts and flush retained footer HTML on the final `onResponse` call. |
+| `SSR_BOOST_DUPLICATE_OUTPUT` | Emit each retained chunk once; inject head contents into the existing head. |
+| `SSR_BOOST_ONRESPONSE_INVALID_RETURN` | Make the hook synchronous; return string, `undefined` (keep) or `''` (withhold), never a promise. |
+| `SSR_BOOST_STREAM_PROMISE_ABORTED` | Bound/cancel loader I/O, handle rejection UI, and review `abortDelay` for legitimately slow work. |
+| `SSR_BOOST_DEPRECATED_REQ_RES` | Use `context.request` and `context.response` in render hooks; early Express `onRequest(req, res)` is unchanged. |
+| `SSR_BOOST_SSR_POLICY` | Inspect the selected URL policy and pattern spelling when a page unexpectedly mounts as SPA. |
+| `SSR_BOOST_CACHE_PRIVATE_LEAK` | Restore private/no-store handling and bypass shared cache reads and writes for personalized pages. |
+
+See [diagnostics](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/reference/diagnostics.md) and [v8 upgrades](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/upgrade-v8.md). Hydration mismatches also require comparing dates, randomness, locale and browser-dependent branches in the initial render; do not suppress them.
+
+## 5. Verify and roll out
+
+Set up [HTTP smoke, size, SSR and browser checks](references/verification.md), then run this skill's [verification script](scripts/verify.sh) from the app root using its installed absolute path:
+
+```sh
+bash /path/to/ssr-boost-migrate/scripts/verify.sh --help
+bash /path/to/ssr-boost-migrate/scripts/verify.sh --dry-run .
+bash /path/to/ssr-boost-migrate/scripts/verify.sh .
+npm run test:ssr
+npm run test:browser
+```
+
+There is no `ssr-boost smoke` subcommand: `npm run smoke` is an application script. The verifier runs doctor, build, the application's enforced size budget and smoke checks, then restores the SSR build because the template smoke ends with SPA output. Compare the new gzip total to the pre-migration baseline; investigate changed chunks before intentionally setting the reviewed budget. Do not copy the library's own budget into an app or automatically raise a failing budget.
+
+For a large app, use [incremental SSR](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/incremental-ssr.md): add `ssr: { mode: 'include', routes: ['/', '/articles/:slug'] }` beside `init` in the managed entry (or beside `getHtml` for Fetch). Widen the allow-list after direct-load, client navigation and hydration checks. Crawlers receive SSR by default, even outside the allow-list; use `bots: 'policy'` only when intended. Restart with `SSR_BOOST_SSR_ROUTES='!/details'` for a route rollback. SPA-selected requests skip server loaders/actions, so keep authentication and HTTP redirects in `onRequest`.
+
+Read [deployment choices](references/deployment.md) for Docker/Node, Vercel, Amplify or Cloudflare Workers. Before declaring done, require green existing lint/types/tests, doctor review, enforced size budget, SSR and SPA smoke, streamed data and buffered bot checks, real browser hydration with a working counter, lazy CSS/navigation, redirects/404s, and a build/preview for the selected target. Record commands, outcomes and any unavailable checks explicitly; an unrun browser check is still outstanding.

--- a/skills/ssr-boost-migrate/assets/hydration.spec.ts.txt
+++ b/skills/ssr-boost-migrate/assets/hydration.spec.ts.txt
@@ -1,0 +1,16 @@
+// tests/browser/hydration.spec.ts
+import { expect, test } from '@playwright/test';
+import {
+  collectStreamTimeline, expectHydrated, expectStreamed,
+} from '@lomray/vite-ssr-boost/testing/playwright';
+
+test('streams, hydrates once and attaches the counter handler', async ({ page }) => {
+  const timeline = await collectStreamTimeline(page);
+  await page.goto('/deferred', { waitUntil: 'commit' });
+  await expectStreamed(page, '[data-resolved]');
+  await expectHydrated(page, { root: '#root', timeout: 10_000 });
+  await expect(page.locator('[data-resolved]')).toHaveCount(1);
+  await page.getByRole('button', { name: 'Count: 0', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Count: 1', exact: true })).toBeVisible();
+  console.info(await timeline.read());
+});

--- a/skills/ssr-boost-migrate/assets/playwright.config.ts.txt
+++ b/skills/ssr-boost-migrate/assets/playwright.config.ts.txt
@@ -1,0 +1,13 @@
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/browser',
+  use: { baseURL: 'http://127.0.0.1:4173', browserName: 'chromium' },
+  webServer: {
+    command: 'npm run start:ssr -- --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+});

--- a/skills/ssr-boost-migrate/assets/size-budget.mjs
+++ b/skills/ssr-boost-migrate/assets/size-budget.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const measure = process.argv[2] === '--measure';
+const config = measure
+  ? { assetsDir: process.argv[3] }
+  : JSON.parse(await readFile(new URL('./size-budget.json', import.meta.url), 'utf8'));
+assert.ok(config.assetsDir, 'Configure assetsDir or use --measure <assets-directory>.');
+if (!measure) assert.ok(Number.isSafeInteger(config.maxGzipBytes) && config.maxGzipBytes > 0,
+  'Configure a positive maxGzipBytes budget.');
+const directory = resolve(config.assetsDir);
+const files = (await readdir(directory, { recursive: true }))
+  .filter((file) => /\.(?:js|mjs|cjs)$/.test(file)).sort();
+assert.ok(files.length, 'No client JavaScript found; build the application first.');
+let total = 0;
+for (const file of files) {
+  const bytes = gzipSync(await readFile(join(directory, file))).length;
+  total += bytes;
+  console.info(`${file}: ${bytes} gzip bytes`);
+}
+console.info(`Client JavaScript: ${total} gzip bytes${measure ? ' (measurement only)' : ` / ${config.maxGzipBytes} budget`}`);
+if (!measure) assert.ok(total <= config.maxGzipBytes, 'Client JavaScript exceeds its size budget.');

--- a/skills/ssr-boost-migrate/assets/smoke.mjs
+++ b/skills/ssr-boost-migrate/assets/smoke.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import http from 'node:http';
+import net from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { createGunzip } from 'node:zlib';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const cli = fileURLToPath(
+  new URL('../node_modules/@lomray/vite-ssr-boost/cli.js', import.meta.url),
+);
+// Adapted from Lomray-Software/vite-template (MIT), commit 66da771d0e3b092e716378ede0952674448d3dbf.
+let buildDir = 'build';
+const children = new Set();
+let interrupted = false;
+
+// Keep the HTTP and process helpers self-contained, following scripts/test-template.mjs
+// in vite-ssr-boost. Count decoded HTML chunks so gzip headers cannot pass the stream check.
+const getPort = async () => {
+  const server = net.createServer();
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  const closed = once(server, 'close');
+
+  server.close();
+  await closed;
+
+  return port;
+};
+
+const startProcess = (command, args) => {
+  assert.ok(!interrupted, 'Smoke check interrupted.');
+  const child = spawn(command, args, { cwd: root, stdio: 'inherit', detached: true });
+  const processState = { child, result: null, done: null, stopping: null };
+
+  processState.done = new Promise((resolve) => {
+    const finish = (result) => {
+      processState.result = result;
+      resolve(result);
+    };
+
+    child.once('error', (error) => finish({ error }));
+    child.once('exit', (code, signal) => finish({ code, signal }));
+  });
+  children.add(processState);
+
+  return processState;
+};
+
+const stop = (state) => {
+  state.stopping ??= (async () => {
+    const signalGroup = (signal) => {
+      if (!state.child.pid) {
+        return;
+      }
+
+      try {
+        process.kill(-state.child.pid, signal);
+      } catch (error) {
+        if (error.code !== 'ESRCH') {
+          throw error;
+        }
+      }
+    };
+
+    signalGroup('SIGTERM');
+    const timeout = setTimeout(() => signalGroup('SIGKILL'), 3_000);
+
+    try {
+      await state.done;
+    } finally {
+      clearTimeout(timeout);
+      children.delete(state);
+    }
+  })();
+
+  return state.stopping;
+};
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, async () => {
+    interrupted = true;
+    console.error(`[smoke] Interrupted by ${signal}.`);
+    await Promise.all([...children].map(stop));
+    process.exit(1);
+  });
+}
+
+const build = async (args = []) => {
+  console.info(`[smoke] env -u NO_COLOR npx ssr-boost build ${args.join(' ')}`.trim());
+  const state = startProcess('env', ['-u', 'NO_COLOR', 'npx', 'ssr-boost', 'build', ...args]);
+  const { code, signal, error } = await state.done;
+
+  if (error) {
+    throw error;
+  }
+
+  assert.equal(code, 0, `ssr-boost build failed (${signal ?? code}).`);
+  children.delete(state);
+};
+
+const inspect = (origin, pathname, { method = 'GET', headers = {}, timeout = 30_000 } = {}) =>
+  new Promise((resolve, reject) => {
+    const request = http.request(
+      new URL(pathname, origin),
+      { method, headers, signal: AbortSignal.timeout(timeout) },
+      (response) => {
+        const chunks = [];
+        const decoded =
+          response.headers['content-encoding'] === 'gzip'
+            ? response.pipe(createGunzip())
+            : response;
+
+        decoded.on('data', (chunk) => chunks.push(chunk));
+        decoded.on('end', () => {
+          resolve({
+            status: response.statusCode,
+            html: Buffer.concat(chunks).toString('utf8'),
+            chunks: chunks.length,
+          });
+        });
+        response.on('error', reject);
+        decoded.on('error', reject);
+      },
+    );
+
+    request.on('error', (error) => reject(new Error(`${method} ${pathname}: ${error.message}`)));
+    request.end();
+  });
+
+const waitUntilReady = async (origin, state) => {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    assert.ok(!interrupted, 'Smoke check interrupted.');
+    assert.ok(
+      !state.result,
+      `Server exited before readiness (${state.result?.error?.message ?? state.result?.signal ?? state.result?.code}).`,
+    );
+
+    try {
+      await inspect(origin, '/', { timeout: 1_000 });
+
+      return;
+    } catch {
+      await delay(100);
+    }
+  }
+
+  throw new Error(`Server did not become ready within 30 seconds: ${origin}`);
+};
+
+const withServer = async (mode, args, verify) => {
+  const port = await getPort();
+  const origin = `http://127.0.0.1:${port}`;
+  const state = startProcess(process.execPath, [cli, 'start', '--build-dir', buildDir, ...args, '--port', String(port)]);
+
+  console.info(`[smoke] Starting ${mode} server on port ${port} (PID ${state.child.pid}).`);
+
+  try {
+    await waitUntilReady(origin, state);
+    await verify(origin);
+  } finally {
+    await stop(state);
+    console.info(`[smoke] Stopped ${mode} server (PID ${state.child.pid}).`);
+  }
+};
+
+try {
+  const config = JSON.parse(
+    await readFile(new URL('./smoke.config.json', import.meta.url), 'utf8'),
+  );
+  const { routes, streamPath, crawlerCookie, crawlerRoutes } = config;
+  buildDir = config.buildDir ?? 'build';
+
+  assert.ok(Array.isArray(routes) && routes.length > 0, 'Configure at least one smoke route.');
+  assert.ok(typeof streamPath === 'string' && streamPath.startsWith('/'), 'Configure streamPath.');
+  assert.ok(
+    typeof crawlerCookie === 'string' && crawlerCookie.length > 0,
+    'Configure crawlerCookie.',
+  );
+
+  await build();
+  await withServer('SSR', [], async (origin) => {
+    for (const { path, status, contains = [], containsAny = [], headers = {} } of routes) {
+      const response = await inspect(origin, path, { headers });
+
+      assert.equal(response.status, status, `SSR GET ${path}: expected status ${status}.`);
+      for (const marker of contains) {
+        assert.ok(
+          response.html.includes(marker),
+          `SSR GET ${path}: missing ${JSON.stringify(marker)}.`,
+        );
+      }
+
+      if (containsAny.length > 0) {
+        assert.ok(
+          containsAny.some((marker) => response.html.includes(marker)),
+          `SSR GET ${path}: expected one of ${JSON.stringify(containsAny)}.`,
+        );
+      }
+
+      console.info(`[smoke] SSR GET ${path}: ${status}; content checks passed.`);
+    }
+
+    const first = routes[0];
+    const head = await inspect(origin, first.path, { method: 'HEAD', headers: first.headers });
+
+    assert.equal(head.status, first.status, `SSR HEAD ${first.path}: unexpected status.`);
+    assert.equal(head.html, '', `SSR HEAD ${first.path}: expected an empty body.`);
+    console.info(`[smoke] SSR HEAD ${first.path}: ${head.status}; empty body.`);
+
+    const streamed = await inspect(origin, streamPath);
+
+    assert.equal(streamed.status, 200, `SSR stream ${streamPath}: expected status 200.`);
+    assert.ok(
+      streamed.chunks > 1,
+      `SSR stream ${streamPath}: expected more than one HTML chunk, got ${streamed.chunks}.`,
+    );
+    console.info(`[smoke] SSR stream ${streamPath}: ${streamed.chunks} HTML chunks.`);
+
+    const crawler = await inspect(origin, streamPath, { headers: { Cookie: crawlerCookie } });
+
+    assert.equal(crawler.status, 200, `SSR crawler ${streamPath}: expected status 200.`);
+    assert.ok(
+      !crawler.html.includes('<!--$?-->'),
+      `SSR crawler ${streamPath}: pending Suspense boundary.`,
+    );
+    console.info(`[smoke] SSR crawler ${streamPath}: 200; no pending Suspense boundaries.`);
+
+    for (const { path, contains } of crawlerRoutes) {
+      const response = await inspect(origin, path, { headers: { 'User-Agent': 'Googlebot' } });
+
+      assert.equal(response.status, 200, `SSR Googlebot ${path}: expected status 200.`);
+      for (const marker of contains) {
+        assert.ok(response.html.includes(marker), `SSR Googlebot ${path}: missing ${marker}.`);
+      }
+      assert.ok(
+        !response.html.includes('<!--$?-->'),
+        `SSR Googlebot ${path}: pending Suspense boundary.`,
+      );
+      console.info(`[smoke] SSR Googlebot ${path}: 200; resolved users; no pending boundaries.`);
+    }
+  });
+
+  await build(['--focus-only', 'client']);
+  await withServer('SPA', ['--focus-only', 'client'], async (origin) => {
+    for (const path of ['/', streamPath, '/deferred']) {
+      const response = await inspect(origin, path);
+
+      assert.equal(response.status, 200, `SPA GET ${path}: expected status 200.`);
+      assert.ok(
+        !response.html.includes('window.__staticRouterHydrationData'),
+        `SPA GET ${path}: unexpected hydration data.`,
+      );
+      console.info(`[smoke] SPA GET ${path}: 200; no hydration data.`);
+    }
+  });
+
+  console.info('[smoke] All checks passed.');
+} catch (error) {
+  console.error(`[smoke] FAILED: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  await Promise.all([...children].map(stop));
+}

--- a/skills/ssr-boost-migrate/references/deployment.md
+++ b/skills/ssr-boost-migrate/references/deployment.md
@@ -1,0 +1,16 @@
+# Deployment choices
+
+Choose the target from the user's requirements. Complete the target's local build and preview, verify its output paths and runtime dependencies, then publish only within the user's deployment authorization. See [deployment](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/deployment.md).
+
+| Target | Prepare and verify | Deployment integration |
+| --- | --- | --- |
+| Node / Docker | `npm run build`, then `npm run start:ssr`; a non-default output directory needs `--build-dir <dir>`. For an image: `npx ssr-boost build-docker --image-name my-app`. | Retain generated Dockerfile/runtime configuration if present, inspect it before image creation, expose the configured port, set runtime secrets in the host, and serve both client assets and server output. The managed runtime needs Express/compression even though they are optional package dependencies. |
+| Vercel | `npx ssr-boost build-vercel`; inspect the app's `vercel.json` and generated `.vercel/output` before using the Vercel deployment workflow. | This is Node/Express serverless output. It is not a Vercel Edge or Cloudflare bundle. Configure project environment values in Vercel and test routes/assets/streaming in a preview deployment when authorized. |
+| AWS Amplify | `npx ssr-boost build-amplify`; inspect `amplify.yml`, the deployment manifest and generated compute/static files. | Set the app's build command and environment variables in Amplify. Check the selected Node runtime, deep links, response statuses and proxy buffering. |
+| Cloudflare Workers | Keep the Express entry for development. Add the documented Worker entry, route manifest import, `ASSETS` binding and `wrangler.jsonc`; build with `npx ssr-boost build --focus-only all`, then `npx wrangler dev --local` and `npx wrangler deploy --dry-run`. | Deploy the Worker and static assets together with `npx wrangler deploy` when authorized. Bind runtime secrets through Wrangler/platform settings; never import Express or `node/production` into the Worker. |
+
+The full [Cloudflare guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/cloudflare.md) gives the exact `createWorkerHandler`, `getHtmlFromAssets`, manifest and Wrangler shapes. Import `build/client/assets-manifest.json`, not Vite's `.vite/manifest.json`. The CLI builds client/server before the extra Worker entry; a normal build omits extra entries. Use managed CLI development and built Wrangler preview for bindings. The Cloudflare Vite plugin integration is not a substitute for that documented path.
+
+For an application-owned Node transport, follow [runtime adapters](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/runtime-adapters.md) and [Node production helpers](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/node-production.md). Preserve lazy-route CSS and module preloads, root/base alignment, HTTP redirect/status behavior, separate Set-Cookie values and abort propagation.
+
+Check streaming through the actual host/proxy, since compression or buffering can delay the shell. Check [private cache handling](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/caching.md) before caching personalized HTML. Do not lift browser-only loader work into a server environment without providing a browser-compatible API path.

--- a/skills/ssr-boost-migrate/references/entries.md
+++ b/skills/ssr-boost-migrate/references/entries.md
@@ -1,0 +1,155 @@
+# Entry shapes (SSR Boost 8.x)
+
+Adapt import paths to the application's existing modules. Managed entry defaults are relative to the Vite root; `init` emits explicit options for a stock root-level Vite project. Keep its actual filenames. These examples use the minimal template's `src` root and routes module.
+
+## HTML and Vite
+
+```html
+<!-- src/index.html: keep the rest of the existing document -->
+<div id="root"><!--ssr-outlet--></div>
+<script type="module" src="/client.ts" async></script>
+```
+
+```ts
+// vite.config.ts; preserve other plugins and application settings.
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsrBoost from '@lomray/vite-ssr-boost/plugin';
+
+export default defineConfig({
+  root: 'src',
+  publicDir: '../public',
+  envDir: '..',
+  build: { outDir: '../build' },
+  plugins: [SsrBoost({ clientFile: 'client.ts', serverFile: 'server.ts' }), react()],
+});
+```
+
+For stock Vite with root `.` use `clientFile: 'src/main.tsx'`, `serverFile: 'src/server.ts'` and `/src/main.tsx` in HTML. Keep the existing outDir; configure smoke and size checks for it. A project without TypeScript aliases can set `tsconfigAliases: false`.
+
+## Shared wrapper and metadata
+
+The template already has `src/app.tsx`; retain it and its imports. When adding a wrapper to a stock Vite SPA, use a distinct name such as `src/ssr-app.tsx` below, because `App.tsx` is the original page and `app.tsx` can collide with it on case-insensitive filesystems. Preserve existing StrictMode/provider nesting in the shared wrapper.
+
+Install `@lomray/react-head-manager` and `isbot` if adding this integration to a SPA; init does not add them. Metadata state keys must match server and client.
+
+```tsx
+// src/ssr-app.tsx
+import { MetaManagerProvider } from '@lomray/react-head-manager';
+import type { Manager } from '@lomray/react-head-manager';
+import type { FC, PropsWithChildren } from 'react';
+import { StrictMode } from 'react';
+
+interface AppProps {
+  client?: { metaManager: Manager };
+  server?: { metaManager: Manager };
+}
+
+const App: FC<PropsWithChildren<AppProps>> = ({ children, client, server }) => (
+  <StrictMode>
+    <MetaManagerProvider manager={(client?.metaManager ?? server?.metaManager)!}>
+      {children}
+    </MetaManagerProvider>
+  </StrictMode>
+);
+export default App;
+```
+
+```ts
+// src/client.ts (or retain src/main.tsx from init)
+import { Manager } from '@lomray/react-head-manager';
+import entryClient from '@lomray/vite-ssr-boost/browser/entry';
+import getServerState from '@lomray/vite-ssr-boost/helpers/get-server-state';
+import App from './ssr-app';
+import routes from './routes';
+
+void entryClient(App, routes, {
+  init: async ({ isSSRMode }) => ({
+    metaManager: new Manager(
+      isSSRMode ? getServerState('metaManager', import.meta.env.PROD) : undefined,
+    ),
+  }),
+});
+```
+
+`init` returns a Promise; its result reaches `App` as `client`. Read other snapshots and construct client stores here, never at module scope. Server props reach the same wrapper as `server`.
+
+```ts
+// src/server.ts
+import { Manager } from '@lomray/react-head-manager';
+import MetaServer from '@lomray/react-head-manager/server';
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import { isbot } from 'isbot';
+import App from './ssr-app';
+import routes from './routes';
+
+export default entryServer(App, routes, {
+  // Optional staged rollout: ssr: { mode: 'include', routes: ['/', '/deferred'] },
+  init: () => ({
+    // Optional: hydration: 'early', with all custom state ready at shell time.
+    onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+    onRouterReady: ({ context: { request } }) => ({
+      isStream: !isbot(request.headers.get('user-agent') ?? '') &&
+        !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
+    }),
+    onShellReady: ({ context: { appProps, html } }) => ({
+      header: MetaServer.inject(html.header, appProps.metaManager),
+    }),
+    getState: ({ context: { appProps } }) => ({
+      metaManager: MetaServer.getState(appProps.metaManager),
+    }),
+  }),
+});
+```
+
+Use `<Meta><title>Page title</title><meta name="description" content="Page summary" /></Meta>` in route components (import `Meta` from `@lomray/react-head-manager`). Early mode collects metadata/custom state at shell readiness; slow-boundary mutations need a separate application strategy.
+
+## Fetch createHandler for an application-owned Node server
+
+The first argument contains renderer dependencies; the second contains lifecycle/options. Unlike managed entries, Fetch hooks are not wrapped in `init`. This factory accepts the built shell and route-asset preparation supplied by the transport; it does not start a server.
+
+```tsx
+// src/fetch-handler.tsx; keep outside the browser dependency graph.
+import type { ComponentProps } from 'react';
+import { createStaticHandler } from 'react-router';
+import { Manager } from '@lomray/react-head-manager';
+import MetaServer from '@lomray/react-head-manager/server';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import App from './ssr-app';
+import routes from './routes';
+
+type Props = NonNullable<ComponentProps<typeof App>['server']>;
+type Options = Parameters<typeof createHandler<Props>>[1];
+
+export function makeHandler(getHtml: Options['getHtml'], prepare: Options['prepare']) {
+  return createHandler<Props>(
+    {
+      handler: createStaticHandler(routes),
+      createApp: (children, { appProps }) => <App server={appProps}>{children}</App>,
+      renderToStream,
+    },
+    {
+      getHtml,
+      prepare,
+      hydration: 'footer',
+      abortDelay: 15_000,
+      ssr: { mode: 'all' },
+      onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+      onRouterReady: ({ context: { request } }) => ({
+        isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+      }),
+      onShellReady: ({ context: { appProps, html } }) => ({
+        header: MetaServer.inject(html.header, appProps.metaManager),
+      }),
+      getState: ({ context: { appProps } }) => ({
+        metaManager: MetaServer.getState(appProps.metaManager),
+      }),
+    },
+  );
+}
+```
+
+At Node startup, supply `await loadHtmlShell({ indexFile: 'build/client/index.html' })` and `createRouteAssetPreparer({ buildDir: 'build' })` from `@lomray/vite-ssr-boost/node/production`, resolving paths against the launcher. Serve built client files before the SSR handler and connect `adapters/node`, `adapters/fastify` or your transport. The built shell must contain its real browser JS entry. An inline shell without client assets only proves server HTML.
+
+For a basename, pass the same value to `createStaticHandler(routes, { basename })`, handler options, and browser `routerOptions`. Worker deployments use `cloudflare`/the edge renderer and bindings, not `node/production` or filesystem paths. See [runtime adapters](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/runtime-adapters.md), [server API](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/server-entry.md) and [browser API](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/browser-entry.md).

--- a/skills/ssr-boost-migrate/references/routes.md
+++ b/skills/ssr-boost-migrate/references/routes.md
@@ -1,0 +1,110 @@
+# Routes and streamed data
+
+## Before init: React Router Data mode
+
+For a fresh Vite react-ts SPA, install `react-router@7`, keep the existing App page, and replace the direct App mount with this bootstrap. Existing apps should map their current route tree instead.
+
+```tsx
+// src/routes.ts
+import type { RouteObject } from 'react-router';
+import App from './App';
+
+const routes = [
+  { id: 'home', path: '/', Component: App },
+] satisfies RouteObject[];
+export default routes;
+```
+
+```tsx
+// src/main.tsx BEFORE init
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router';
+import routes from './routes';
+import './index.css';
+
+const router = createBrowserRouter(routes);
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><RouterProvider router={router} /></StrictMode>,
+);
+```
+
+After init, the App **page** remains in the route array; the entry's App **wrapper** renders its `children`. Do not pass the page that ignores children as the entry wrapper.
+
+## Deferred route
+
+Add a literal lazy route to the existing array: `{ id: 'deferred', path: '/deferred', lazy: () => import('./pages/deferred') }`. In the minimal template the route already exists; preserve its content and add the browser observation marker to its resolved `<ul>` instead of replacing the page. The standalone example below gives a migrated SPA the same observable contract.
+
+```tsx
+// src/pages/deferred.tsx; use index.tsx if matching the template layout.
+import { Suspense, useState } from 'react';
+import { Await, useLoaderData } from 'react-router';
+
+export function loader() {
+  return {
+    title: 'Deferred data',
+    users: new Promise<string[]>((resolve) => {
+      setTimeout(() => resolve(['Ada Lovelace']), 1500);
+    }),
+  };
+}
+
+export function Component() {
+  const data = useLoaderData() as ReturnType<typeof loader>;
+  const [count, setCount] = useState(0);
+  return (
+    <main>
+      <h1>{data.title}</h1>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>Count: {count}</button>
+      <Suspense fallback={<p>Loading users</p>}>
+        <Await resolve={data.users} errorElement={<p role="alert">Could not load users.</p>}>
+          {(users: string[]) => <ul data-resolved>{users.map((name) => <li key={name}>{name}</li>)}</ul>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+}
+```
+
+Return `{ users: promise }`, not `await promise` as the entire loader result: React Router awaits the loader's outer promise before rendering. Timers above simulate I/O. For real work call a browser-accessible API with `fetch(new URL('/api/users', request.url), { signal: request.signal })` and check `response.ok` before decoding. If work may reject before the static query completes, attach an early rejection handler while retaining the original promise for error UI.
+
+Router data supports promises, Date, Map, Set, bigint, RegExp and undefined. Functions, custom classes and cycles are outside the supported contract. Custom `getState` uses JSON and has stricter rules. `<Await>` works on React 18/19; React 19 `use(promise)` needs a Suspense consumer and an error boundary.
+
+If the app's Fast Refresh lint rule rejects exporting a loader beside a component, move `loader` unchanged to `src/pages/deferred-loader.ts`. Import it as a type in the component (`import type { loader } from './deferred-loader'`) for `ReturnType`, and import it as a value in the route array:
+
+```ts
+import { loader as deferredLoader } from './pages/deferred-loader';
+// Inside the existing route array:
+{ id: 'deferred', path: '/deferred', loader: deferredLoader, lazy: () => import('./pages/deferred') },
+```
+
+The lazy file then exports only `Component`. Keep route arrays in `.ts` when they contain no JSX, and name the array before exporting it. This preserves the app's Fast Refresh checks without weakening lint rules.
+
+## Actions and statuses
+
+```tsx
+// A route module; its /api/profile endpoint must be implemented by your application.
+import { Form, redirect } from 'react-router';
+import type { ActionFunctionArgs } from 'react-router';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const result = await fetch(new URL('/api/profile', request.url), {
+    method: 'POST',
+    body: form,
+    signal: request.signal,
+  });
+  if (!result.ok) throw new Response('Could not save profile', { status: result.status });
+  return redirect('/profile');
+}
+
+export function Component() {
+  return <Form method="post"><input name="name" /><button type="submit">Save</button></Form>;
+}
+```
+
+The API must authenticate the request; an SSR same-origin fetch does not forward the incoming cookies automatically. Pass only credentials needed by your own API on the server, and keep secrets out of shared route modules. Stream noncritical action fields with an object containing promises and `useActionData`/`Await`, using the same loader contract.
+
+Use `throw new Response('Not found', { status: 404 })` for missing resources and `redirect('/target', 302)` for HTTP redirects. When adding a catch-all component, preserve the template's `ResponseStatus` behavior so the server does not turn missing pages into 200s. Keep static route IDs/arrays and literal lazy imports; do not generate routes with runtime factories or array spreads.
+
+See [routing](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/routing.md), [streaming](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/data-streaming.md), and [testing](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/testing.md).

--- a/skills/ssr-boost-migrate/references/verification.md
+++ b/skills/ssr-boost-migrate/references/verification.md
@@ -1,0 +1,152 @@
+# Verification recipes
+
+Run checks from the app root. Use the app's installed CLI and package manager. These are application checks; repository-only commands such as SSR Boost's own `test:browser` do not exist in a generated app until you add them.
+
+## HTTP smoke and size
+
+The generated templates ship `scripts/smoke.mjs`, `scripts/smoke.config.json`, and `scripts/size-budget.mjs`, with `smoke` and `size:check` package scripts. Keep them and adapt route expectations to your application. The smoke script starts/stops its own servers, checks SSR statuses/content, HEAD, multiple decoded HTML chunks, buffered crawlers and SPA responses, and ends with a SPA build. It does not launch a browser or prove event handlers work. Rebuild SSR afterward.
+
+An enforced application budget measures the generated **client** JS, not node_modules size or the SSR Boost package alone. Record the gzip total and chunks before and after changes. The minimal template's size script sets a numeric cap with headroom; review it deliberately when replacing sample pages. Missing output or an exceeded cap must fail. See [acceptance gates](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/reference/acceptance-gates.md).
+
+For a migrated SPA without these scripts, copy the bundled [smoke tool](../assets/smoke.mjs) and [size tool](../assets/size-budget.mjs) into the application's `scripts/` directory. They are user-editable tools; inspect them before running. The smoke tool is adapted from the official minimal template at `66da771d0e3b092e716378ede0952674448d3dbf` to accept `buildDir` in its config.
+
+Set package scripts `smoke` to `node scripts/smoke.mjs` and `size:check` to `node scripts/size-budget.mjs`. Set `start:ssr` to `ssr-boost start --build-dir dist` when preserving stock Vite output. Add the deferred route from the route reference and these route objects to the shared array:
+
+```tsx
+{ id: 'redirect', path: '/redirect', loader: () => redirect('/', 302) },
+{ id: 'missing', path: '/missing', loader: () => { throw new Response('Not found', { status: 404 }); } },
+```
+
+Import `redirect` from `react-router`; preserve existing app routes instead of adding duplicates. For a standalone Vite SPA, the entry reference's metadata wrapper replaces init's generated wrapper and the existing App remains the home **page**. Its server entry includes crawler buffering required by smoke.
+
+```json
+// scripts/smoke.config.json (remove this comment in JSON)
+{
+  "buildDir": "dist",
+  "routes": [
+    { "path": "/", "status": 200, "contains": ["window.__staticRouterHydrationData"] },
+    { "path": "/deferred", "status": 200, "contains": ["Deferred data", "Ada Lovelace"] },
+    { "path": "/redirect", "status": 302 },
+    { "path": "/missing", "status": 404 }
+  ],
+  "streamPath": "/deferred",
+  "crawlerCookie": "isCrawler=1",
+  "crawlerRoutes": [{ "path": "/deferred", "contains": ["<li>Ada Lovelace</li>"] }]
+}
+```
+
+The size tool takes `scripts/size-budget.json` with `assetsDir` relative to the app root and a positive `maxGzipBytes`. Measure the original SPA before migration with `node scripts/size-budget.mjs --measure dist/assets` after its existing build, and measure SSR output with `--measure dist/client/assets`. Set a reviewed cap from these baselines and required functionality; for an initial accepted baseline, 5% headroom is a starting policy, not an automatic pass.
+
+```json
+// scripts/size-budget.json (example shape; replace the cap with your measured decision)
+{ "assetsDir": "dist/client/assets", "maxGzipBytes": 120000 }
+```
+
+
+## SSR testing kit
+
+First check the installed package, not only its version range:
+
+```sh
+node --input-type=module -e "await import('@lomray/vite-ssr-boost/testing')"
+```
+
+Stable 8.3.0 does not ship this export. For a prerelease evaluation in a temporary app, install the explicitly tested release and rerun doctor/build/size/smoke:
+
+```sh
+npm install @lomray/vite-ssr-boost@8.4.0-beta.4
+```
+
+For a stable-only rollout, use a stable release that contains these APIs before claiming testing-kit or Worker acceptance. Check the [release channels](https://github.com/Lomray-Software/vite-ssr-boost/releases). Keep the exact evaluated version in the lockfile.
+
+```sh
+npm install -D vitest @playwright/test
+```
+
+Add `test:ssr: "vitest run --config vitest.config.ts"` and `test:browser: "playwright test --config playwright.config.ts"` to package scripts. Keep other tests. In an app with no Vitest config, start with:
+
+```ts
+// vitest.config.ts
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: { environment: 'node', include: ['tests/**/*.test.tsx'] },
+  // Reuse the application's resolve.alias if routes import aliases.
+});
+```
+
+The template's aliases are in `tsconfig.json`; Vitest needs those aliases too. With Vite 8, add `resolve: { tsconfigPaths: true }`. With Vite 6/7, use `vite-tsconfig-paths` (`npm install -D vite-tsconfig-paths`) and add `tsconfigPaths()` to the existing `plugins: [react()]` array with `import tsconfigPaths from 'vite-tsconfig-paths'`, or copy the app's explicit `resolve.alias`. Keep the React transform in this standalone config, especially when the root tsconfig only references tsconfig.app.json; otherwise JSX can fail with `React is not defined`. Do not load SsrBoost's build plugin into isolated Node tests. If the app changes filenames, adjust the two local imports below (the template uses `../src/routes/index` and `../src/app`; the migrated SPA wrapper is `../src/ssr-app`). This tests real routes and providers, not a replacement route fixture.
+
+For React Router 7 in standalone Vitest, if `useLoaderData` reports a missing Data router despite the kit providing one, inline the package and router into the same test module graph. Add this inside `test` (it fixes the ESM/CommonJS context split observed during migration dogfooding):
+
+```ts
+server: { deps: { inline: ['@lomray/vite-ssr-boost', 'react-router'] } },
+```
+
+The prerelease's published source maps can report missing original source files when inlined; check the actual test result separately from those map warnings.
+
+
+```tsx
+// tests/ssr.test.tsx
+import { Manager } from '@lomray/react-head-manager';
+import { createTestHandler, crawlerRequest } from '@lomray/vite-ssr-boost/testing';
+import { expect, it } from 'vitest';
+import App from '../src/app';
+import routes from '../src/routes';
+
+const app = createTestHandler({
+  routes,
+  App,
+  diagnostics: true,
+  onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+  onRouterReady: ({ context: { request } }) => ({
+    isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+  }),
+});
+
+it('streams the real deferred route and transports its loader data', async () => {
+  const response = await app.fetch('/deferred');
+  expect(response.status).toBe(200);
+  expect(await response.html()).toContain('Ada Lovelace');
+  expect(await response.pendingBoundaries()).toBeGreaterThan(0);
+  expect(JSON.stringify(await response.routerState())).toContain('Ada Lovelace');
+  const timeline = await response.timeline();
+  expect(timeline.some((event) => event.stage === 'shell.ready')).toBe(true);
+});
+
+it('buffers the same route for a crawler', async () => {
+  const response = await app.fetch(crawlerRequest('/deferred'));
+  expect(await response.html()).toContain('Ada Lovelace');
+  expect(await response.pendingBoundaries()).toBe(0);
+});
+
+it('preserves the app redirect and missing-route status', async () => {
+  const redirected = await app.fetch('/redirect');
+  expect([301, 302]).toContain(redirected.status);
+  expect(redirected.headers.get('location')).toBe('/');
+  expect((await app.fetch('/missing')).status).toBe(404);
+});
+```
+
+Adapt `/redirect`'s expected destination/status to the app. Add rejected deferred work, cancellation, actions and locale isolation tests when those paths are used. `routerState()` resolves rich values but never executes response scripts. In a controlled deferred test, resolve `createDeferred()` **after** streaming `app.fetch()` returns; for buffered requests, resolve it while fetch is pending. See the [testing kit](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/testing.md).
+
+## Browser hydration
+
+Mark the `/deferred` route's resolved `<ul>` with `data-resolved`. Keep its `Count: 0` button and deferred timer for this acceptance test, or change the selectors and expected text to match your application. Install Chromium on the machine running these tests:
+
+```sh
+npx playwright install chromium
+npm run build
+```
+
+Copy the bundled [playwright.config.ts template](../assets/playwright.config.ts.txt) to `playwright.config.ts` in the app (drop the `.txt` suffix).
+
+For a custom Fastify launcher use its supported port environment variable instead of CLI flags. If output is `dist`, the start script must include `--build-dir dist`.
+
+Copy the bundled [tests/browser/hydration.spec.ts template](../assets/hydration.spec.ts.txt) to `tests/browser/hydration.spec.ts` in the app (drop the `.txt` suffix).
+
+For `hydration: 'early'`, add a test that waits only for the shell, asserts `[data-resolved]` is absent, clicks the counter and asserts `Count: 1` while the deferred field is still absent; then await the field and hydration. Use a controlled slow API response when timing would otherwise be unreliable. Also exercise client navigation to a lazy route and assert its computed CSS, then reload its URL. Repeat the app's locale/head and rejection expectations in a browser.
+
+A browser executable being unavailable is an unrun acceptance check. `playwright test --list` can validate discovery without launching it, and the testing kit can still exercise Fetch SSR, but neither replaces the hydration test.

--- a/skills/ssr-boost-migrate/scripts/verify.sh
+++ b/skills/ssr-boost-migrate/scripts/verify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'HELP'
+Usage: verify.sh [--dry-run] [project-directory]
+Run installed SSR Boost doctor, build, app size budget, smoke, then restore SSR output.
+Requires Node, npm, installed project dependencies, build and smoke scripts, and
+size:check (or test:size). Does not install packages or run browser tests.
+--dry-run  Print the command plan without reading or changing the project.
+--help     Print this help without running any commands.
+Run the application's lint/types, test:ssr and test:browser separately.
+HELP
+}
+
+dry=false
+project=.
+project_set=false
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage; exit 0 ;;
+    --dry-run) dry=true ;;
+    -*) printf 'Unknown option: %s\n' "$arg" >&2; exit 2 ;;
+    *)
+      if "$project_set"; then usage >&2; exit 2; fi
+      project="$arg"
+      project_set=true
+      ;;
+  esac
+done
+
+if "$dry"; then
+  printf 'Project: %s\n' "$project"
+  cat <<'PLAN'
+./node_modules/.bin/ssr-boost doctor --json
+npm run build -- --throw-warnings
+npm run size:check (or npm run test:size)
+npm run smoke
+npm run build -- --throw-warnings
+PLAN
+  exit 0
+fi
+
+cd -- "$project"
+if [[ ! -x node_modules/.bin/ssr-boost ]]; then
+  printf '%s\n' 'Missing local ssr-boost. Install the application dependencies first.' >&2
+  exit 1
+fi
+size_script=$(node --input-type=module <<'NODE'
+import { readFileSync } from 'node:fs';
+const { scripts = {} } = JSON.parse(readFileSync('package.json', 'utf8'));
+for (const name of ['build', 'smoke']) {
+  if (!scripts[name]) throw new Error(`Missing ${name} script; follow references/verification.md.`);
+}
+const size = ['size:check', 'test:size'].find((name) => scripts[name]);
+if (!size) throw new Error('Missing enforced size:check or test:size script.');
+console.log(size);
+NODE
+)
+./node_modules/.bin/ssr-boost doctor --json
+npm run build -- --throw-warnings
+npm run "$size_script"
+npm run smoke
+# Template smoke builds SPA last; leave an SSR build for browser tests/deployment.
+npm run build -- --throw-warnings
+printf '%s\n' 'Doctor, build, size and smoke passed; SSR output restored. Review doctor warnings.'

--- a/skills/ssr-boost-new-app/SKILL.md
+++ b/skills/ssr-boost-new-app/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: ssr-boost-new-app
+description: Create and roll out a new Vite React Router Data mode application with the published create-ssr-app templates, including streamed data, request state, tests, CI, size checks, and target-specific deployment.
+---
+
+# Create an SSR Boost application
+
+Work in the user's chosen parent directory and follow its repository instructions. Use the published scaffolder and inspect the resulting files; template branches evolve independently of this skill. The reference APIs target vite-ssr-boost 8.x. Links to upstream docs remain usable when this folder is installed alone.
+
+The testing kit, incremental SSR policy and Worker helper require a release containing those APIs; the stable 8.3.0 template dependency predates them. For a prerelease evaluation, the published `8.4.0-beta.4` was used for these workflows. Check installed exports and the project's release policy before adopting a prerelease; do not silently use one for a stable-only production rollout.
+
+## 1. Choose and scaffold
+
+Check Node and the current template catalog:
+
+```sh
+node --version
+npm view @lomray/create-ssr-app version engines
+npm create @lomray/ssr-app@latest -- --help
+```
+
+SSR Boost requires Node >=22.12.0; satisfy the template dependencies' engines too (the template tooling uses Node 22.23.2). The published [create-ssr-app catalog](https://github.com/Lomray-Software/create-ssr-app#templates) has these five choices:
+
+| Template | Choose it for | Command |
+| --- | --- | --- |
+| `minimal` | Small app with metadata, loaders, lazy CSS, redirects, 404 and client-only routes | `npm create @lomray/ssr-app -- --template minimal` |
+| `full` | MobX, consistent Suspense and the full reference application | `npm create @lomray/ssr-app -- --template full` |
+| `custom-server` | Managed development and a Fastify production server owned by the app | `npm create @lomray/ssr-app -- --template custom-server` |
+| `tanstack-query` | Per-request QueryClient, dehydration and streamed pending queries | `npm create @lomray/ssr-app -- --template tanstack-query` |
+| `localization` | Per-request i18next, cookie/header language selection and restoration | `npm create @lomray/ssr-app -- --template localization` |
+
+Use `minimal` unless the requested app benefits from another template. Those commands prompt for a directory on a TTY; non-TTY defaults to `my-ssr-app`. Put npm flags after `--`. To choose a directory explicitly, suppress prompts and leave Git initialization to the user/repository workflow:
+
+```sh
+npm create @lomray/ssr-app@latest my-app -- --template minimal --no-git --yes
+cd my-app
+```
+
+Use `--no-install` when you need to inspect dependencies before installing. The normal command installs them already. `--no-git` also removes Husky and `scripts.prepare`; the generated CI workflow is still included. Do not use `--force` to scaffold over an existing application.
+
+## 2. Inspect the structure and establish checks
+
+Read `package.json`, the lockfile, `.nvmrc`, Vite config, `.env` examples, `src/app.tsx`, `src/client.ts`, `src/server.ts`, `src/routes/index.ts`, `src/pages/`, `scripts/` and `.github/workflows/ci.yml`. These templates use Vite `root: 'src'`, public assets outside it, and `build/client` plus `build/server` output. Keep the actual aliases and filenames. Review [entries](references/entries.md) for the wrapper prop contract and exact managed/Fetch API shapes.
+
+```sh
+npx ssr-boost doctor --json
+npm run develop
+```
+
+Review all doctor errors and version warnings; repeat until errors are fixed. Current templates also use the tested React 19 / Router 8 / Vite 8 combination. For Vite 6/7, React 18/19 and Router 7 compatibility choices, use the [tested matrix](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/README.md#compatibility), not just peer ranges. Keep matching React/React DOM versions and one physical copy of each.
+
+Inspect the homepage, direct nested routes and a lazy route during development, then stop the owned server. Keep the generated `size:check` budget as the starting baseline and the `smoke` script with its route expectations; update expectations when replacing sample pages. There is no package CLI `smoke` subcommand.
+
+## 3. Implement the requested application
+
+- Add static Data mode route objects, stable IDs, layouts, error boundaries and literal lazy imports using [routes, loaders and actions](references/routes.md). There is no automatic file-system router, RSC or Server Actions layer. Data mode loaders/actions also run in the browser on navigation; use APIs for secrets, database calls and Worker bindings.
+- Return an object with a slow promise and consume it in Suspense/`Await`; use React 19 `use()` only inside a boundary. Forward `request.signal` to I/O. Test success, rejection, redirect and 404 paths. See [streaming](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/data-streaming.md).
+- Preserve `@lomray/react-head-manager`: create a Manager per request, provide it through `App`, inject tags at shell readiness and transfer its JSON state to client `init`. Add route titles/descriptions with `<Meta>`. [Entry shapes](references/entries.md) show every import and hook.
+- For localization, use the `localization` template's per-request i18next instance. Choose language from the request cookie, then Accept-Language, then an app default; transfer chosen language/resources and initialize the client before hydration. Do not reuse a mutable server i18next instance across requests or choose a different browser language for the initial render. See the [localization example](https://github.com/Lomray-Software/vite-template/tree/example/localization).
+- Keep public config in `import.meta.env.VITE_*`; these values are embedded into browser code. Keep secrets in server runtime variables or platform secrets, never in `VITE_*`, route data, `getState`, HTML or tracked env files. Follow the configured Vite `envDir`, add a safe `.env.example`, and restart development after env changes. Worker bindings stay in server-only modules. See [environment guidance](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/migrate-existing-spa.md#environment-variables).
+- Restore state only inside the browser entry's async `init`. Default footer hydration is suitable unless early interaction is requested. Early mode requires `hydration: 'early'`, an async client script, and custom state ready at `onShellReady`. Keep browser globals in effects or client-only routes.
+
+## 4. Tests, size and CI
+
+Use [verification recipes](references/verification.md) to add Vitest tests through `@lomray/vite-ssr-boost/testing` and Playwright tests through the separate `testing/playwright` entry. Test real application routes and providers, streamed settlements, bot buffering, redirect/status behavior, hydration and a counter click. Browser assertions must observe the page before navigation. The testing kit does not execute the browser entry in Node.
+
+Retain the generated `.github/workflows/ci.yml`: it installs with `npm ci --ignore-scripts` and runs the available lint, types, styles, warning-failing build, size and smoke scripts. It has no deployment secrets/jobs. Extend it with `npm run test:ssr`, a restored SSR build after smoke, `npx playwright install --with-deps chromium` and `npm run test:browser`; defining new scripts alone does not add them to an already generated workflow.
+
+Run this skill's [verification script](scripts/verify.sh) by its installed path:
+
+```sh
+bash /path/to/ssr-boost-new-app/scripts/verify.sh --help
+bash /path/to/ssr-boost-new-app/scripts/verify.sh --dry-run .
+bash /path/to/ssr-boost-new-app/scripts/verify.sh .
+npm run test:ssr
+npm run test:browser
+```
+
+The verifier runs doctor, build, an enforced app size budget and `npm run smoke`, then restores SSR output because template smoke also builds SPA. Do not raise a failing size budget automatically: inspect emitted chunks and approve intentional app growth with a recorded baseline. Use [diagnostics](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/reference/diagnostics.md) to fix `SSR_BOOST_*` warnings, especially custom JSON state versus rich router data and malformed/duplicated hydration output.
+
+## 5. Prepare deployment and acceptance
+
+Read [deployment by target](references/deployment.md) and prepare the selected Node/Docker, Vercel, Amplify or Cloudflare build and local preview. For a custom transport, read the exact `createHandler` options in [entries](references/entries.md); the transport owns static files and route assets. Check private cache handling, secrets, redirects, 404s, lazy CSS and streaming through the selected adapter. Publish only within the user's deployment authorization.
+
+Before declaring done, run and record:
+
+- [ ] Generated lint, type and style scripts pass, along with the app's own tests.
+- [ ] Doctor has no errors and version/informational findings have been reviewed.
+- [ ] Build fails on warnings; the app's gzip size check passes against its reviewed budget.
+- [ ] HTTP smoke covers SSR and SPA, a streamed route, buffered crawlers, redirects, 404 and HEAD.
+- [ ] Testing-kit tests cover real routes and providers, deferred data, errors and statuses.
+- [ ] Playwright verifies hydration without mismatch/duplicate output, deferred content, a working counter, navigation and lazy CSS. If early hydration is selected, the counter works while data is pending.
+- [ ] Metadata and locale agree between server HTML and the first browser render; no secrets appear in browser output.
+- [ ] CI contains the checks above, SSR output is restored after smoke, and the target build/preview works.
+
+Report unrun checks as outstanding with their commands and reasons; do not treat HTTP-only tests as browser hydration evidence.

--- a/skills/ssr-boost-new-app/assets/hydration.spec.ts.txt
+++ b/skills/ssr-boost-new-app/assets/hydration.spec.ts.txt
@@ -1,0 +1,16 @@
+// tests/browser/hydration.spec.ts
+import { expect, test } from '@playwright/test';
+import {
+  collectStreamTimeline, expectHydrated, expectStreamed,
+} from '@lomray/vite-ssr-boost/testing/playwright';
+
+test('streams, hydrates once and attaches the counter handler', async ({ page }) => {
+  const timeline = await collectStreamTimeline(page);
+  await page.goto('/deferred', { waitUntil: 'commit' });
+  await expectStreamed(page, '[data-resolved]');
+  await expectHydrated(page, { root: '#root', timeout: 10_000 });
+  await expect(page.locator('[data-resolved]')).toHaveCount(1);
+  await page.getByRole('button', { name: 'Count: 0', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Count: 1', exact: true })).toBeVisible();
+  console.info(await timeline.read());
+});

--- a/skills/ssr-boost-new-app/assets/playwright.config.ts.txt
+++ b/skills/ssr-boost-new-app/assets/playwright.config.ts.txt
@@ -1,0 +1,13 @@
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/browser',
+  use: { baseURL: 'http://127.0.0.1:4173', browserName: 'chromium' },
+  webServer: {
+    command: 'npm run start:ssr -- --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+});

--- a/skills/ssr-boost-new-app/references/deployment.md
+++ b/skills/ssr-boost-new-app/references/deployment.md
@@ -1,0 +1,16 @@
+# Deployment choices
+
+Choose the target from the user's requirements. Complete the target's local build and preview, verify its output paths and runtime dependencies, then publish only within the user's deployment authorization. See [deployment](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/deployment.md).
+
+| Target | Prepare and verify | Deployment integration |
+| --- | --- | --- |
+| Node / Docker | `npm run build`, then `npm run start:ssr`; a non-default output directory needs `--build-dir <dir>`. For an image: `npx ssr-boost build-docker --image-name my-app`. | Retain generated Dockerfile/runtime configuration if present, inspect it before image creation, expose the configured port, set runtime secrets in the host, and serve both client assets and server output. The managed runtime needs Express/compression even though they are optional package dependencies. |
+| Vercel | `npx ssr-boost build-vercel`; inspect the app's `vercel.json` and generated `.vercel/output` before using the Vercel deployment workflow. | This is Node/Express serverless output. It is not a Vercel Edge or Cloudflare bundle. Configure project environment values in Vercel and test routes/assets/streaming in a preview deployment when authorized. |
+| AWS Amplify | `npx ssr-boost build-amplify`; inspect `amplify.yml`, the deployment manifest and generated compute/static files. | Set the app's build command and environment variables in Amplify. Check the selected Node runtime, deep links, response statuses and proxy buffering. |
+| Cloudflare Workers | Keep the Express entry for development. Add the documented Worker entry, route manifest import, `ASSETS` binding and `wrangler.jsonc`; build with `npx ssr-boost build --focus-only all`, then `npx wrangler dev --local` and `npx wrangler deploy --dry-run`. | Deploy the Worker and static assets together with `npx wrangler deploy` when authorized. Bind runtime secrets through Wrangler/platform settings; never import Express or `node/production` into the Worker. |
+
+The full [Cloudflare guide](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/cloudflare.md) gives the exact `createWorkerHandler`, `getHtmlFromAssets`, manifest and Wrangler shapes. Import `build/client/assets-manifest.json`, not Vite's `.vite/manifest.json`. The CLI builds client/server before the extra Worker entry; a normal build omits extra entries. Use managed CLI development and built Wrangler preview for bindings. The Cloudflare Vite plugin integration is not a substitute for that documented path.
+
+For an application-owned Node transport, follow [runtime adapters](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/runtime-adapters.md) and [Node production helpers](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/node-production.md). Preserve lazy-route CSS and module preloads, root/base alignment, HTTP redirect/status behavior, separate Set-Cookie values and abort propagation.
+
+Check streaming through the actual host/proxy, since compression or buffering can delay the shell. Check [private cache handling](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/caching.md) before caching personalized HTML. Do not lift browser-only loader work into a server environment without providing a browser-compatible API path.

--- a/skills/ssr-boost-new-app/references/entries.md
+++ b/skills/ssr-boost-new-app/references/entries.md
@@ -1,0 +1,155 @@
+# Entry shapes (SSR Boost 8.x)
+
+Adapt import paths to the application's existing modules. Managed entry defaults are relative to the Vite root; `init` emits explicit options for a stock root-level Vite project. Keep its actual filenames. These examples use the minimal template's `src` root and routes module.
+
+## HTML and Vite
+
+```html
+<!-- src/index.html: keep the rest of the existing document -->
+<div id="root"><!--ssr-outlet--></div>
+<script type="module" src="/client.ts" async></script>
+```
+
+```ts
+// vite.config.ts; preserve other plugins and application settings.
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsrBoost from '@lomray/vite-ssr-boost/plugin';
+
+export default defineConfig({
+  root: 'src',
+  publicDir: '../public',
+  envDir: '..',
+  build: { outDir: '../build' },
+  plugins: [SsrBoost({ clientFile: 'client.ts', serverFile: 'server.ts' }), react()],
+});
+```
+
+For stock Vite with root `.` use `clientFile: 'src/main.tsx'`, `serverFile: 'src/server.ts'` and `/src/main.tsx` in HTML. Keep the existing outDir; configure smoke and size checks for it. A project without TypeScript aliases can set `tsconfigAliases: false`.
+
+## Shared wrapper and metadata
+
+The template already has `src/app.tsx`; retain it and its imports. When adding a wrapper to a stock Vite SPA, use a distinct name such as `src/ssr-app.tsx` below, because `App.tsx` is the original page and `app.tsx` can collide with it on case-insensitive filesystems. Preserve existing StrictMode/provider nesting in the shared wrapper.
+
+Install `@lomray/react-head-manager` and `isbot` if adding this integration to a SPA; init does not add them. Metadata state keys must match server and client.
+
+```tsx
+// src/ssr-app.tsx
+import { MetaManagerProvider } from '@lomray/react-head-manager';
+import type { Manager } from '@lomray/react-head-manager';
+import type { FC, PropsWithChildren } from 'react';
+import { StrictMode } from 'react';
+
+interface AppProps {
+  client?: { metaManager: Manager };
+  server?: { metaManager: Manager };
+}
+
+const App: FC<PropsWithChildren<AppProps>> = ({ children, client, server }) => (
+  <StrictMode>
+    <MetaManagerProvider manager={(client?.metaManager ?? server?.metaManager)!}>
+      {children}
+    </MetaManagerProvider>
+  </StrictMode>
+);
+export default App;
+```
+
+```ts
+// src/client.ts (or retain src/main.tsx from init)
+import { Manager } from '@lomray/react-head-manager';
+import entryClient from '@lomray/vite-ssr-boost/browser/entry';
+import getServerState from '@lomray/vite-ssr-boost/helpers/get-server-state';
+import App from './ssr-app';
+import routes from './routes';
+
+void entryClient(App, routes, {
+  init: async ({ isSSRMode }) => ({
+    metaManager: new Manager(
+      isSSRMode ? getServerState('metaManager', import.meta.env.PROD) : undefined,
+    ),
+  }),
+});
+```
+
+`init` returns a Promise; its result reaches `App` as `client`. Read other snapshots and construct client stores here, never at module scope. Server props reach the same wrapper as `server`.
+
+```ts
+// src/server.ts
+import { Manager } from '@lomray/react-head-manager';
+import MetaServer from '@lomray/react-head-manager/server';
+import entryServer from '@lomray/vite-ssr-boost/adapters/express/entry';
+import { isbot } from 'isbot';
+import App from './ssr-app';
+import routes from './routes';
+
+export default entryServer(App, routes, {
+  // Optional staged rollout: ssr: { mode: 'include', routes: ['/', '/deferred'] },
+  init: () => ({
+    // Optional: hydration: 'early', with all custom state ready at shell time.
+    onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+    onRouterReady: ({ context: { request } }) => ({
+      isStream: !isbot(request.headers.get('user-agent') ?? '') &&
+        !/(?:^|;\s*)isCrawler=1(?:;|$)/.test(request.headers.get('cookie') ?? ''),
+    }),
+    onShellReady: ({ context: { appProps, html } }) => ({
+      header: MetaServer.inject(html.header, appProps.metaManager),
+    }),
+    getState: ({ context: { appProps } }) => ({
+      metaManager: MetaServer.getState(appProps.metaManager),
+    }),
+  }),
+});
+```
+
+Use `<Meta><title>Page title</title><meta name="description" content="Page summary" /></Meta>` in route components (import `Meta` from `@lomray/react-head-manager`). Early mode collects metadata/custom state at shell readiness; slow-boundary mutations need a separate application strategy.
+
+## Fetch createHandler for an application-owned Node server
+
+The first argument contains renderer dependencies; the second contains lifecycle/options. Unlike managed entries, Fetch hooks are not wrapped in `init`. This factory accepts the built shell and route-asset preparation supplied by the transport; it does not start a server.
+
+```tsx
+// src/fetch-handler.tsx; keep outside the browser dependency graph.
+import type { ComponentProps } from 'react';
+import { createStaticHandler } from 'react-router';
+import { Manager } from '@lomray/react-head-manager';
+import MetaServer from '@lomray/react-head-manager/server';
+import createHandler from '@lomray/vite-ssr-boost/core/handler';
+import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
+import App from './ssr-app';
+import routes from './routes';
+
+type Props = NonNullable<ComponentProps<typeof App>['server']>;
+type Options = Parameters<typeof createHandler<Props>>[1];
+
+export function makeHandler(getHtml: Options['getHtml'], prepare: Options['prepare']) {
+  return createHandler<Props>(
+    {
+      handler: createStaticHandler(routes),
+      createApp: (children, { appProps }) => <App server={appProps}>{children}</App>,
+      renderToStream,
+    },
+    {
+      getHtml,
+      prepare,
+      hydration: 'footer',
+      abortDelay: 15_000,
+      ssr: { mode: 'all' },
+      onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+      onRouterReady: ({ context: { request } }) => ({
+        isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+      }),
+      onShellReady: ({ context: { appProps, html } }) => ({
+        header: MetaServer.inject(html.header, appProps.metaManager),
+      }),
+      getState: ({ context: { appProps } }) => ({
+        metaManager: MetaServer.getState(appProps.metaManager),
+      }),
+    },
+  );
+}
+```
+
+At Node startup, supply `await loadHtmlShell({ indexFile: 'build/client/index.html' })` and `createRouteAssetPreparer({ buildDir: 'build' })` from `@lomray/vite-ssr-boost/node/production`, resolving paths against the launcher. Serve built client files before the SSR handler and connect `adapters/node`, `adapters/fastify` or your transport. The built shell must contain its real browser JS entry. An inline shell without client assets only proves server HTML.
+
+For a basename, pass the same value to `createStaticHandler(routes, { basename })`, handler options, and browser `routerOptions`. Worker deployments use `cloudflare`/the edge renderer and bindings, not `node/production` or filesystem paths. See [runtime adapters](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/runtime-adapters.md), [server API](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/server-entry.md) and [browser API](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/api/browser-entry.md).

--- a/skills/ssr-boost-new-app/references/routes.md
+++ b/skills/ssr-boost-new-app/references/routes.md
@@ -1,0 +1,110 @@
+# Routes and streamed data
+
+## Before init: React Router Data mode
+
+For a fresh Vite react-ts SPA, install `react-router@7`, keep the existing App page, and replace the direct App mount with this bootstrap. Existing apps should map their current route tree instead.
+
+```tsx
+// src/routes.ts
+import type { RouteObject } from 'react-router';
+import App from './App';
+
+const routes = [
+  { id: 'home', path: '/', Component: App },
+] satisfies RouteObject[];
+export default routes;
+```
+
+```tsx
+// src/main.tsx BEFORE init
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router';
+import routes from './routes';
+import './index.css';
+
+const router = createBrowserRouter(routes);
+createRoot(document.getElementById('root')!).render(
+  <StrictMode><RouterProvider router={router} /></StrictMode>,
+);
+```
+
+After init, the App **page** remains in the route array; the entry's App **wrapper** renders its `children`. Do not pass the page that ignores children as the entry wrapper.
+
+## Deferred route
+
+Add a literal lazy route to the existing array: `{ id: 'deferred', path: '/deferred', lazy: () => import('./pages/deferred') }`. In the minimal template the route already exists; preserve its content and add the browser observation marker to its resolved `<ul>` instead of replacing the page. The standalone example below gives a migrated SPA the same observable contract.
+
+```tsx
+// src/pages/deferred.tsx; use index.tsx if matching the template layout.
+import { Suspense, useState } from 'react';
+import { Await, useLoaderData } from 'react-router';
+
+export function loader() {
+  return {
+    title: 'Deferred data',
+    users: new Promise<string[]>((resolve) => {
+      setTimeout(() => resolve(['Ada Lovelace']), 1500);
+    }),
+  };
+}
+
+export function Component() {
+  const data = useLoaderData() as ReturnType<typeof loader>;
+  const [count, setCount] = useState(0);
+  return (
+    <main>
+      <h1>{data.title}</h1>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>Count: {count}</button>
+      <Suspense fallback={<p>Loading users</p>}>
+        <Await resolve={data.users} errorElement={<p role="alert">Could not load users.</p>}>
+          {(users: string[]) => <ul data-resolved>{users.map((name) => <li key={name}>{name}</li>)}</ul>}
+        </Await>
+      </Suspense>
+    </main>
+  );
+}
+```
+
+Return `{ users: promise }`, not `await promise` as the entire loader result: React Router awaits the loader's outer promise before rendering. Timers above simulate I/O. For real work call a browser-accessible API with `fetch(new URL('/api/users', request.url), { signal: request.signal })` and check `response.ok` before decoding. If work may reject before the static query completes, attach an early rejection handler while retaining the original promise for error UI.
+
+Router data supports promises, Date, Map, Set, bigint, RegExp and undefined. Functions, custom classes and cycles are outside the supported contract. Custom `getState` uses JSON and has stricter rules. `<Await>` works on React 18/19; React 19 `use(promise)` needs a Suspense consumer and an error boundary.
+
+If the app's Fast Refresh lint rule rejects exporting a loader beside a component, move `loader` unchanged to `src/pages/deferred-loader.ts`. Import it as a type in the component (`import type { loader } from './deferred-loader'`) for `ReturnType`, and import it as a value in the route array:
+
+```ts
+import { loader as deferredLoader } from './pages/deferred-loader';
+// Inside the existing route array:
+{ id: 'deferred', path: '/deferred', loader: deferredLoader, lazy: () => import('./pages/deferred') },
+```
+
+The lazy file then exports only `Component`. Keep route arrays in `.ts` when they contain no JSX, and name the array before exporting it. This preserves the app's Fast Refresh checks without weakening lint rules.
+
+## Actions and statuses
+
+```tsx
+// A route module; its /api/profile endpoint must be implemented by your application.
+import { Form, redirect } from 'react-router';
+import type { ActionFunctionArgs } from 'react-router';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const result = await fetch(new URL('/api/profile', request.url), {
+    method: 'POST',
+    body: form,
+    signal: request.signal,
+  });
+  if (!result.ok) throw new Response('Could not save profile', { status: result.status });
+  return redirect('/profile');
+}
+
+export function Component() {
+  return <Form method="post"><input name="name" /><button type="submit">Save</button></Form>;
+}
+```
+
+The API must authenticate the request; an SSR same-origin fetch does not forward the incoming cookies automatically. Pass only credentials needed by your own API on the server, and keep secrets out of shared route modules. Stream noncritical action fields with an object containing promises and `useActionData`/`Await`, using the same loader contract.
+
+Use `throw new Response('Not found', { status: 404 })` for missing resources and `redirect('/target', 302)` for HTTP redirects. When adding a catch-all component, preserve the template's `ResponseStatus` behavior so the server does not turn missing pages into 200s. Keep static route IDs/arrays and literal lazy imports; do not generate routes with runtime factories or array spreads.
+
+See [routing](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/routing.md), [streaming](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/data-streaming.md), and [testing](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/testing.md).

--- a/skills/ssr-boost-new-app/references/verification.md
+++ b/skills/ssr-boost-new-app/references/verification.md
@@ -1,0 +1,119 @@
+# Verification recipes
+
+Run checks from the app root. Use the app's installed CLI and package manager. These are application checks; repository-only commands such as SSR Boost's own `test:browser` do not exist in a generated app until you add them.
+
+## HTTP smoke and size
+
+The generated templates ship `scripts/smoke.mjs`, `scripts/smoke.config.json`, and `scripts/size-budget.mjs`, with `smoke` and `size:check` package scripts. Keep them and adapt route expectations to your application. The smoke script starts/stops its own servers, checks SSR statuses/content, HEAD, multiple decoded HTML chunks, buffered crawlers and SPA responses, and ends with a SPA build. It does not launch a browser or prove event handlers work. Rebuild SSR afterward.
+
+An enforced application budget measures the generated **client** JS, not node_modules size or the SSR Boost package alone. Record the gzip total and chunks before and after changes. The minimal template's size script sets a numeric cap with headroom; review it deliberately when replacing sample pages. Missing output or an exceeded cap must fail. See [acceptance gates](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/reference/acceptance-gates.md).
+
+
+
+## SSR testing kit
+
+First check the installed package, not only its version range:
+
+```sh
+node --input-type=module -e "await import('@lomray/vite-ssr-boost/testing')"
+```
+
+Stable 8.3.0 does not ship this export. For a prerelease evaluation in a temporary app, install the explicitly tested release and rerun doctor/build/size/smoke:
+
+```sh
+npm install @lomray/vite-ssr-boost@8.4.0-beta.4
+```
+
+For a stable-only rollout, use a stable release that contains these APIs before claiming testing-kit or Worker acceptance. Check the [release channels](https://github.com/Lomray-Software/vite-ssr-boost/releases). Keep the exact evaluated version in the lockfile.
+
+```sh
+npm install -D vitest @playwright/test
+```
+
+Add `test:ssr: "vitest run --config vitest.config.ts"` and `test:browser: "playwright test --config playwright.config.ts"` to package scripts. Keep other tests. In an app with no Vitest config, start with:
+
+```ts
+// vitest.config.ts
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: { environment: 'node', include: ['tests/**/*.test.tsx'] },
+  // Reuse the application's resolve.alias if routes import aliases.
+});
+```
+
+The template's aliases are in `tsconfig.json`; Vitest needs those aliases too. With Vite 8, add `resolve: { tsconfigPaths: true }`. With Vite 6/7, use `vite-tsconfig-paths` (`npm install -D vite-tsconfig-paths`) and add `tsconfigPaths()` to the existing `plugins: [react()]` array with `import tsconfigPaths from 'vite-tsconfig-paths'`, or copy the app's explicit `resolve.alias`. Keep the React transform in this standalone config, especially when the root tsconfig only references tsconfig.app.json; otherwise JSX can fail with `React is not defined`. Do not load SsrBoost's build plugin into isolated Node tests. If the app changes filenames, adjust the two local imports below (the template uses `../src/routes/index` and `../src/app`; the migrated SPA wrapper is `../src/ssr-app`). This tests real routes and providers, not a replacement route fixture.
+
+For React Router 7 in standalone Vitest, if `useLoaderData` reports a missing Data router despite the kit providing one, inline the package and router into the same test module graph. Add this inside `test` (it fixes the ESM/CommonJS context split observed during migration dogfooding):
+
+```ts
+server: { deps: { inline: ['@lomray/vite-ssr-boost', 'react-router'] } },
+```
+
+The prerelease's published source maps can report missing original source files when inlined; check the actual test result separately from those map warnings.
+
+
+```tsx
+// tests/ssr.test.tsx
+import { Manager } from '@lomray/react-head-manager';
+import { createTestHandler, crawlerRequest } from '@lomray/vite-ssr-boost/testing';
+import { expect, it } from 'vitest';
+import App from '../src/app';
+import routes from '../src/routes';
+
+const app = createTestHandler({
+  routes,
+  App,
+  diagnostics: true,
+  onRequest: () => ({ appProps: { metaManager: new Manager() } }),
+  onRouterReady: ({ context: { request } }) => ({
+    isStream: !request.headers.get('user-agent')?.includes('Googlebot'),
+  }),
+});
+
+it('streams the real deferred route and transports its loader data', async () => {
+  const response = await app.fetch('/deferred');
+  expect(response.status).toBe(200);
+  expect(await response.html()).toContain('Ada Lovelace');
+  expect(await response.pendingBoundaries()).toBeGreaterThan(0);
+  expect(JSON.stringify(await response.routerState())).toContain('Ada Lovelace');
+  const timeline = await response.timeline();
+  expect(timeline.some((event) => event.stage === 'shell.ready')).toBe(true);
+});
+
+it('buffers the same route for a crawler', async () => {
+  const response = await app.fetch(crawlerRequest('/deferred'));
+  expect(await response.html()).toContain('Ada Lovelace');
+  expect(await response.pendingBoundaries()).toBe(0);
+});
+
+it('preserves the app redirect and missing-route status', async () => {
+  const redirected = await app.fetch('/redirect');
+  expect([301, 302]).toContain(redirected.status);
+  expect(redirected.headers.get('location')).toBe('/');
+  expect((await app.fetch('/missing')).status).toBe(404);
+});
+```
+
+Adapt `/redirect`'s expected destination/status to the app. Add rejected deferred work, cancellation, actions and locale isolation tests when those paths are used. `routerState()` resolves rich values but never executes response scripts. In a controlled deferred test, resolve `createDeferred()` **after** streaming `app.fetch()` returns; for buffered requests, resolve it while fetch is pending. See the [testing kit](https://github.com/Lomray-Software/vite-ssr-boost/blob/prod/docs/guide/testing.md).
+
+## Browser hydration
+
+Mark the `/deferred` route's resolved `<ul>` with `data-resolved`. Keep its `Count: 0` button and deferred timer for this acceptance test, or change the selectors and expected text to match your application. Install Chromium on the machine running these tests:
+
+```sh
+npx playwright install chromium
+npm run build
+```
+
+Copy the bundled [playwright.config.ts template](../assets/playwright.config.ts.txt) to `playwright.config.ts` in the app (drop the `.txt` suffix).
+
+For a custom Fastify launcher use its supported port environment variable instead of CLI flags. If output is `dist`, the start script must include `--build-dir dist`.
+
+Copy the bundled [tests/browser/hydration.spec.ts template](../assets/hydration.spec.ts.txt) to `tests/browser/hydration.spec.ts` in the app (drop the `.txt` suffix).
+
+For `hydration: 'early'`, add a test that waits only for the shell, asserts `[data-resolved]` is absent, clicks the counter and asserts `Count: 1` while the deferred field is still absent; then await the field and hydration. Use a controlled slow API response when timing would otherwise be unreliable. Also exercise client navigation to a lazy route and assert its computed CSS, then reload its URL. Repeat the app's locale/head and rejection expectations in a browser.
+
+A browser executable being unavailable is an unrun acceptance check. `playwright test --list` can validate discovery without launching it, and the testing kit can still exercise Fetch SSR, but neither replaces the hydration test.

--- a/skills/ssr-boost-new-app/scripts/verify.sh
+++ b/skills/ssr-boost-new-app/scripts/verify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'HELP'
+Usage: verify.sh [--dry-run] [project-directory]
+Run installed SSR Boost doctor, build, app size budget, smoke, then restore SSR output.
+Requires Node, npm, installed project dependencies, build and smoke scripts, and
+size:check (or test:size). Does not install packages or run browser tests.
+--dry-run  Print the command plan without reading or changing the project.
+--help     Print this help without running any commands.
+Run the application's lint/types, test:ssr and test:browser separately.
+HELP
+}
+
+dry=false
+project=.
+project_set=false
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h) usage; exit 0 ;;
+    --dry-run) dry=true ;;
+    -*) printf 'Unknown option: %s\n' "$arg" >&2; exit 2 ;;
+    *)
+      if "$project_set"; then usage >&2; exit 2; fi
+      project="$arg"
+      project_set=true
+      ;;
+  esac
+done
+
+if "$dry"; then
+  printf 'Project: %s\n' "$project"
+  cat <<'PLAN'
+./node_modules/.bin/ssr-boost doctor --json
+npm run build -- --throw-warnings
+npm run size:check (or npm run test:size)
+npm run smoke
+npm run build -- --throw-warnings
+PLAN
+  exit 0
+fi
+
+cd -- "$project"
+if [[ ! -x node_modules/.bin/ssr-boost ]]; then
+  printf '%s\n' 'Missing local ssr-boost. Install the application dependencies first.' >&2
+  exit 1
+fi
+size_script=$(node --input-type=module <<'NODE'
+import { readFileSync } from 'node:fs';
+const { scripts = {} } = JSON.parse(readFileSync('package.json', 'utf8'));
+for (const name of ['build', 'smoke']) {
+  if (!scripts[name]) throw new Error(`Missing ${name} script; follow references/verification.md.`);
+}
+const size = ['size:check', 'test:size'].find((name) => scripts[name]);
+if (!size) throw new Error('Missing enforced size:check or test:size script.');
+console.log(size);
+NODE
+)
+./node_modules/.bin/ssr-boost doctor --json
+npm run build -- --throw-warnings
+npm run "$size_script"
+npm run smoke
+# Template smoke builds SPA last; leave an SSR build for browser tests/deployment.
+npm run build -- --throw-warnings
+printf '%s\n' 'Doctor, build, size and smoke passed; SSR output restored. Review doctor warnings.'


### PR DESCRIPTION
## Summary
- Two skills in the Agent Skills format: `skills/ssr-boost-migrate` (existing Vite + React Router SPA to SSR Boost: baseline, `init` dry run/apply, request state, streamed loaders, diagnostics table, incremental SSR, verification, deployment) and `skills/ssr-boost-new-app` (rollout from zero with the five published templates, tests, CI, deployment); each with `references/`, copyable Playwright assets and a `scripts/verify.sh`.
- Claude Code plugin manifests (`ssr-boost@lomray` marketplace), install notes for Claude Code, Codex CLI (`~/.codex/skills` and the newer `.agents/skills` discovery) and Cursor, in the README and `docs/ai-usage.md`.
- `npm run test:skills` in PR CI validates frontmatter, 191 local and doc links, the manifests and the scripts' `--help`/`--dry-run`; `llms-full.txt` now embeds both skills.
- `docs/reference/benchmarks.md` describes what the public benchmark measures and how to reproduce or challenge it, linking to the repository tables instead of copying numbers.

## Test plan
- [x] `test:skills`, lint, types, docs build with 33/33 links verified, before and after rebasing onto staging
- [x] Codex dogfooded both skills on a fresh `create-ssr-app` minimal app and a fresh Vite SPA (summaries in the task log)
