### PR TITLE
perf: cut per-request cpu on the server render path

### DIFF
--- a/__fixtures__/browser-template/routes.jsx
+++ b/__fixtures__/browser-template/routes.jsx
@@ -34,6 +34,10 @@ const Deferred = () => {
 };
 export const routes = [
   {
+    path: '/footer',
+    Component: () => <Shell><p>Footer hydration</p></Shell>,
+  },
+  {
     path: '/spa',
     loader: () => {
       if (typeof window === 'undefined') throw new Error('SPA loader executed on server');

--- a/__fixtures__/browser-template/server.jsx
+++ b/__fixtures__/browser-template/server.jsx
@@ -4,7 +4,9 @@ import renderToStream from '@lomray/vite-ssr-boost/node/render-to-stream';
 import { cacheControl } from '@lomray/vite-ssr-boost/http';
 import { App, routes } from './routes.jsx';
 import React from 'react';
-export const handler = (html) =>
+
+/** Build both hydration modes for browser coverage of router state. */
+const createRequestHandler = (html, hydration) =>
   createHandler(
     {
       handler: createStaticHandler(routes),
@@ -12,7 +14,7 @@ export const handler = (html) =>
       renderToStream,
     },
     {
-      hydration: 'early',
+      hydration,
       ssr: { mode: 'exclude', routes: ['/spa', '/spa-redirect'] },
       diagnostics: false,
       getHtml: () => html,
@@ -21,3 +23,11 @@ export const handler = (html) =>
       documentHeaders: [{ when: () => true, set: { 'Cache-Control': cacheControl({ public: true, maxAge: 0, sMaxAge: 30 }) } }],
     },
   );
+
+/** Use footer hydration on the page without route data and early hydration elsewhere. */
+export const handler = (html) => {
+  const footer = createRequestHandler(html, 'footer');
+  const early = createRequestHandler(html, 'early');
+
+  return (request) => (new URL(request.url).pathname === '/footer' ? footer : early)(request);
+};

--- a/__helpers__/data-stream.tsx
+++ b/__helpers__/data-stream.tsx
@@ -64,6 +64,28 @@ const chunks = async (response: Response) => {
 
 const testDataStream = (name: string, renderer: TRenderToStream): void => {
   describe(`real React loader/action streaming (${name})`, () => {
+    it('uses ordinary footer hydration when the route has no data', async () => {
+      const handler = createHandler(
+        {
+          createApp: (children) => children,
+          handler: createStaticHandler([{ path: '/', Component: () => <p>Static home</p> }]),
+          renderToStream: renderer,
+        },
+        {
+          diagnostics: false,
+          nonce: 'static-nonce',
+          getHtml: () => ({ header: '<main>', footer: '</main>' }),
+        },
+      );
+      const html = await (await handler(new Request('http://test/'))).text();
+
+      expect(html).toContain('<p>Static home</p>');
+      expect(html).toContain('window.__staticRouterHydrationData = JSON.parse(');
+      expect(html).toContain('nonce="static-nonce"');
+      expect(html).not.toContain('__ssrBoostStream');
+      expect(html.indexOf('__staticRouterHydrationData')).toBeGreaterThan(html.indexOf('Static home'));
+    });
+
     it.each(['GET', 'POST'])(
       'streams fallback and settlements before footer initialization for %s',
       async (method) => {

--- a/__tests__/adapters/express/prepare-server.ts
+++ b/__tests__/adapters/express/prepare-server.ts
@@ -99,6 +99,17 @@ describe('PrepareServer', () => {
     expect(footer).toContain('<footer');
   });
 
+  it('reuses the production shell while keeping returned tuples isolated', async () => {
+    const config = createConfig(true);
+    const read = vi.spyOn(fs, 'readFileSync').mockReturnValue('header<!--ssr-outlet-->footer');
+    const service = PrepareServer.init(config as never);
+    const first = await service.loadHtml({ originalUrl: '/' } as never);
+    first[0] = 'request-specific';
+
+    expect(await service.loadHtml({ originalUrl: '/items' } as never)).toEqual(['header', 'footer']);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
   it('should call app created hook', async () => {
     const config = createConfig(false);
     const onServerCreated = vi.fn();

--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -324,7 +324,7 @@ describe('legacy Express render adapter', () => {
       expect(getBody).toHaveBeenCalledTimes(method === 'POST' ? 1 : 0);
       expect(requests).toHaveLength(6);
       expect(new Set(requests).size).toBe(1);
-      expect(injectAssetsMock).toHaveBeenCalledWith(context);
+      expect(injectAssetsMock).toHaveBeenCalledWith(context, false);
       expect(onRouterReady).toHaveBeenCalledWith({ context });
       expect(onShellReady).toHaveBeenCalledWith({ context });
       expect(onShellError).toHaveBeenCalledWith({ context, error: shellError });

--- a/__tests__/adapters/express/static-files.ts
+++ b/__tests__/adapters/express/static-files.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import type { Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import staticFiles from '@adapters/express/static-files';
+
+describe('production static prefixes', () => {
+  let root: string;
+  let server: Server | undefined;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'ssr-static-'));
+    await mkdir(path.join(root, 'assets'));
+    await writeFile(path.join(root, 'assets', 'app.js'), 'built-script');
+    await writeFile(path.join(root, 'robots.txt'), 'public-file');
+    await writeFile(path.join(root, 'health'), 'extensionless');
+    await writeFile(path.join(root, 'about.html'), 'extension-fallback');
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    server?.closeAllConnections();
+    if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /** Start a mounted static handler with an observable SSR fallback. */
+  const start = async (options = {}): Promise<string> => {
+    const app = express();
+    app.use('/base', staticFiles(root, { index: false, ...options }));
+    app.use((_, response) => response.send('SSR'));
+    server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+    });
+    const address = server.address();
+
+    return `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}/base`;
+  };
+
+  it('does no filesystem stats for HTML routes, including query strings', async () => {
+    const origin = await start();
+    const stat = vi.spyOn(fs, 'stat');
+
+    for (const pathname of ['/', '/items', '/items/1?sort=name']) {
+      expect(await (await fetch(origin + pathname)).text()).toBe('SSR');
+    }
+
+    expect(stat).not.toHaveBeenCalled();
+  });
+
+  it('retains built assets, public files, encoded URLs, HEAD, ranges and validators', async () => {
+    const origin = await start();
+    const asset = await fetch(`${origin}/%61ssets/app.js?v=1`);
+    expect(await asset.text()).toBe('built-script');
+    expect(await (await fetch(`${origin}/robots.txt`)).text()).toBe('public-file');
+    expect(await (await fetch(`${origin}/health`)).text()).toBe('extensionless');
+    const head = await fetch(`${origin}/health`, { method: 'HEAD' });
+    expect(head.headers.get('content-length')).toBe('13');
+    expect(await head.text()).toBe('');
+    const partial = await fetch(`${origin}/assets/app.js`, { headers: { Range: 'bytes=0-4' } });
+    expect(partial.status).toBe(206);
+    expect(await partial.text()).toBe('built');
+    const cached = await fetch(`${origin}/assets/app.js`, {
+      headers: { 'If-None-Match': asset.headers.get('etag')!, 'Cache-Control': 'max-age=0' },
+    });
+    expect(cached.status).toBe(304);
+    const redirect = await fetch(`${origin}/assets`, { redirect: 'manual' });
+    expect(redirect.status).toBe(301);
+    expect(await (await fetch(`${origin}/assets/missing.js`)).text()).toBe('SSR');
+  });
+
+  it('preserves extension fallbacks and explicit static 404 handling', async () => {
+    const origin = await start({ extensions: ['html'], fallthrough: false });
+    expect(await (await fetch(`${origin}/about`)).text()).toBe('extension-fallback');
+    expect((await fetch(`${origin}/missing`)).status).toBe(404);
+  });
+});

--- a/__tests__/core/compose-html.ts
+++ b/__tests__/core/compose-html.ts
@@ -2,6 +2,24 @@ import { describe, expect, it, vi } from 'vitest';
 import composeHtml from '@core/compose-html';
 
 describe('composeHtml', () => {
+  it('queues the prepared shell without pulling React before the next body read', async () => {
+    const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+      controller.enqueue(new TextEncoder().encode('body'));
+    });
+    const cancel = vi.fn();
+    const source = new ReadableStream<Uint8Array>({ pull, cancel }, { highWaterMark: 0 });
+    const reader = composeHtml('shell', source, 'footer').getReader();
+
+    await Promise.resolve();
+    expect(pull).not.toHaveBeenCalled();
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe('shell');
+    await Promise.resolve();
+    expect(pull).not.toHaveBeenCalled();
+    await reader.cancel('shell only');
+    expect(cancel).toHaveBeenCalledWith('shell only');
+    expect(pull).not.toHaveBeenCalled();
+  });
+
   it('streams header, body and footer without dropping chunks', async () => {
     const encoder = new TextEncoder();
     const body = new ReadableStream<Uint8Array>({

--- a/__tests__/integration/express-adversarial.tsx
+++ b/__tests__/integration/express-adversarial.tsx
@@ -87,6 +87,9 @@ const fixture = vi.hoisted(() => ({
 
 vi.mock('react-dom/server', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-dom/server')>()),
+
+  /** Keep these injected pipe failures on the React 18 bridge. */
+  renderToReadableStream: undefined,
   renderToPipeableStream: fixture.renderToPipeableStream,
 }));
 

--- a/__tests__/node/render-to-stream.tsx
+++ b/__tests__/node/render-to-stream.tsx
@@ -8,6 +8,8 @@ import renderToStream from '@node/render-to-stream';
 const fixture = vi.hoisted(() => ({ written: 0 }));
 
 vi.mock('react-dom/server', () => ({
+  /** Exercise the React 18 bridge independently of the installed React version. */
+  renderToReadableStream: undefined,
   renderToPipeableStream: vi.fn((_, callbacks) => ({
     abort: vi.fn(),
     pipe: (destination: Writable) => {

--- a/__tests__/node/write-fetch-response.ts
+++ b/__tests__/node/write-fetch-response.ts
@@ -32,6 +32,7 @@ describe('writeFetchResponse', () => {
       setHeader: vi.fn(),
       statusCode: 0,
       writableEnded: false,
+      flush: vi.fn(),
       write: vi.fn((chunk: Uint8Array) => {
         chunks.push(chunk);
 
@@ -42,6 +43,7 @@ describe('writeFetchResponse', () => {
 
     await vi.waitFor(() => expect(res.write).toHaveBeenCalledOnce());
     expect(pullCount).toBe(1);
+    expect(res.flush).toHaveBeenCalledOnce();
 
     res.emit('drain');
     await pending;

--- a/browser-tests/footer-hydration.spec.mjs
+++ b/browser-tests/footer-hydration.spec.mjs
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+import { collectStreamTimeline, expectHydrated } from '../lib/testing/playwright.js';
+
+/** Preserve ordinary footer hydration alongside deferred stream hydration. */
+test('hydrates footer and deferred router state with the bundled decoder', async ({ page }) => {
+  // The hydration helpers observe the document from navigation onwards.
+  await collectStreamTimeline(page);
+  await page.goto('http://127.0.0.1:4179/footer');
+  await page.getByRole('button', { name: 'Count 0' }).click();
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  await expectHydrated(page);
+
+  await page.goto('http://127.0.0.1:4179/deferred');
+  await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+  await expectHydrated(page);
+});

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -73,6 +73,75 @@ samples `process.memoryUsage()` in the listening server after TTFB, without forc
 compared with a plain ESM Express + `renderToPipeableStream` process using the same installed
 dependencies. See [acceptance gates](/reference/acceptance-gates) for the enforced budgets.
 
+## Streamed HTML and compression
+
+In production, the managed Express server records the built client directory's top-level
+file and directory names at startup. URLs outside those prefixes go straight to SSR without
+a filesystem lookup. Built assets and public files retain Express's validators, ranges, HEAD
+responses and directory redirects. Add new top-level public files before starting the server;
+restart after changing the build. Custom extension fallbacks and `fallthrough: false` retain
+the unrestricted static middleware.
+
+On React versions that expose `renderToReadableStream`, the Node renderer uses that native
+Web stream directly. React 18 retains the pipeable renderer and its bounded Node-to-Web bridge.
+Both paths preserve cancellation, shell hooks and downstream demand.
+
+The managed Express server keeps gzip enabled for HTML. The response writer flushes compression
+after each HTML chunk, before waiting for transport capacity. This delivers the shell while
+Suspense data is pending and preserves backpressure for later chunks. Buffered responses remain
+compressible. The Fetch core queues the prepared document header once React's shell is ready;
+it does not read later React chunks until the consumer requests them.
+
+Compression's default threshold is 1 KB, but a response without a known length is treated as
+exceeding that threshold. Flushing headers alone does not flush compressed HTML. If you add
+another compression layer or a reverse proxy, preserve incremental delivery and measure the
+first decoded HTML byte. See the [compression middleware documentation](https://expressjs.com/en/resources/middleware/compression/).
+
+To compare the managed adapter, Node/edge Fetch renderers and raw React on a local checkout, run:
+
+```bash
+npm run build
+NODE_ENV=production SSR_BOOST_TIMELINE=1 CONCURRENCY=1 node scripts/profile-stream.mjs
+```
+
+The in-process report includes router-query completion, preparation, shell readiness, the first
+adapter write, the first socket write, headers received and decoded HTML received. Times are p50
+milliseconds from Express middleware entry. These are elapsed stages, not CPU measurements.
+`SAMPLES`, `WARMUP`, `WARMUP_CONCURRENCY`, `CONCURRENCY`, `RUNTIMES=raw,managed,node,edge` and
+`ENCODINGS=identity,gzip` control the run.
+
+For service cost, run the actual production application in a separate process with the local
+profiling preload. It handles the profiler's control requests and records process CPU usage
+between measured batches. Run the client separately with one connection:
+
+```bash
+NODE_ENV=production node --import /path/to/vite-ssr-boost/scripts/profile-server.mjs server.mjs
+PROFILE_URL=http://127.0.0.1:3000 CONCURRENCY=1 SAMPLES=50 WARMUP=100 WARMUP_CONCURRENCY=10 ENCODINGS=identity \
+  node scripts/profile-stream.mjs > service.jsonl
+```
+
+The warm-up can use ten connections to exercise the same hot paths as a throughput run;
+measured requests still use the requested concurrency. `ROUTES=/,/items,/items/1` selects the production paths. Every measured response must return 200.
+The report separates client TTFB from mean CPU microseconds per complete response. On Node
+22.19 and newer, `mainThreadCpuUsPerRequest` uses `process.threadCpuUsage()` to measure the
+event-loop thread independently of background workers. `cpuUsPerRequest` also includes those
+workers. Loader timers contribute elapsed time but do not count as CPU. See the
+[Node CPU accounting API](https://nodejs.org/api/process.html#processthreadcpuusagepreviousvalue). Keep the server isolated from
+other traffic, builds and tests.
+
+For stage attribution, add `--cpu-prof --cpu-prof-interval=100 --cpu-prof-name=server.cpuprofile`
+to the server command, then run the client and stop the server with SIGTERM. The preload exits
+normally so Node writes the profile. Summarize only the marked measurement windows:
+
+```bash
+node scripts/summarize-cpu.mjs server.cpuprofile service.jsonl
+```
+
+The summary reports time-weighted active samples in microseconds per request, excluding idle,
+startup and warm-up. These are sampling estimates. The process CPU counter in a profiled run
+also includes profiler overhead, so use a separate run without `--cpu-prof` for that counter.
+Gzip's first socket write can contain only its header; decoded HTML arrival is reported separately.
+
 ## Preview mode
 
 `ssr-boost preview` runs watch builds and starts the production server after the output is ready.

--- a/docs/guide/server-lifecycle.md
+++ b/docs/guide/server-lifecycle.md
@@ -89,6 +89,14 @@ This is the place to switch between streaming and full-document rendering based 
 
 Loader/action promises stream by default. Set `hydration: 'early'` in the lifecycle configuration (or Fetch handler options) to hydrate the parsed shell while boundaries are pending. The early block contains `getState` custom state before router state, so custom state must be available at `onShellReady`. Default footer ordering remains custom state, router state, footer. `nonce` applies to React and all generated scripts; `bootstrapScriptContent` is forwarded with the early shell marker prepended when enabled. See [Stream loader data](/guide/data-streaming).
 
+Default footer responses without loader/action data or errors use ordinary router hydration
+state. The stream decoder remains part of the browser entry for streamed responses.
+
+The prepared document header is available immediately after shell hooks and response metadata
+are finalized. Later React/data chunks remain pull-based, including with `onResponse` and
+diagnostics. Managed Express flushes each compressed chunk; see
+[streamed HTML and compression](/guide/deployment#streamed-html-and-compression).
+
 ## `onShellReady`
 
 Replaces the template header or footer around the React stream. Generated hydration state is

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -34,7 +34,10 @@ page in Chromium in all three SSR modes. This checks shell interactivity, both A
 init/resolve frames and hydration/console errors. Browser failures fail this opt-in gate.
 
 PR and release CI run the full suite on React/React DOM 18.2.0 and 19.2.8. The release waits for
-both versions. Template TTFB comparisons are advisory; early-stream checks retry up to three times
+both versions. Template TTFB comparisons are advisory, including the streamed/home ratio.
+The ratio compares 11 alternating pairs after three warm-up pairs, using the first decoded
+HTML chunk with the same browser user agent and identity encoding. A ratio above 1.5 is printed
+without failing acceptance; early-stream checks retry up to three times
 to tolerate shared-runner scheduling. Crawler rendering is checked through Suspense completion
 markers instead of comparing timings between separate requests.
 
@@ -80,14 +83,15 @@ Each entry is bundled and minified with esbuild as browser ESM. React, React DOM
 `react-dom/client` and `react/jsx-runtime`) and React Router stay external. All other dependencies,
 including the client HOCs' `hoist-non-react-statics`, count toward size. The combined bundle imports
 and re-exports every entry's namespace to retain all public APIs while sharing dependencies.
-Any import of `node:`, `express`, `chalk`, `commander` or `json5` (including package subpaths) fails
+Any import of `node:`, `express`, `compression`, `isbot`, `chalk`, `commander` or `json5` (including package subpaths) fails
 the gate, even when the size is within budget.
 
 All sizes below use gzip level 9 and **KB = 1024 bytes**. Comparisons use unrounded byte counts.
 
 | Browser entry | Measured gzip KB | Budget KB |
 | --- | ---: | ---: |
-| `browser/entry` | 0.669 | 1.00 |
+| `browser/entry` | 3.125 | 3.669 |
+| `browser/stream` | 2.469 | 3.25 |
 | `components/navigate` | 0.334 | 0.50 |
 | `components/only-client` | 0.324 | 0.50 |
 | `components/render-client` | 1.705 | 2.25 |
@@ -99,8 +103,8 @@ All sizes below use gzip level 9 and **KB = 1024 bytes**. Comparisons use unroun
 | `helpers/get-server-state` | 0.101 | 0.25 |
 | `helpers/import-route` | 1.937 | 2.50 |
 | `interfaces/fc-route` | 0.091 | 0.25 |
-| Combined | 3.307 (3386 bytes) | 4.307 (4410 bytes) |
-| Template client total | 141.770 | 154 |
+| Combined | 5.727 (5864 bytes) | 6.657 (6817 bytes) |
+| Template client total | 141.839 | 154 |
 
 The template gate sums the gzip size of each `build/client/assets/*.js` file after the candidate's
 production SSR build, including lazy chunks and framework/application dependencies. It excludes

--- a/scripts/profile-server.mjs
+++ b/scripts/profile-server.mjs
@@ -1,0 +1,51 @@
+import { Server } from 'node:http';
+
+const emit = Server.prototype.emit;
+let started;
+let requests = 0;
+
+/** Exit normally so --cpu-prof writes its profile after the client finishes. */
+process.once('SIGTERM', () => process.exit(0));
+
+/** Put an identifiable window boundary in V8's clock domain. */
+const startProfileWindow = () => {
+  const end = performance.now() + 3;
+  while (performance.now() < end) {}
+};
+
+/** Keep the closing marker outside the measured CPU interval. */
+const endProfileWindow = () => {
+  const end = performance.now() + 3;
+  while (performance.now() < end) {}
+};
+
+/** Measure an isolated production server between the profiler client's control requests. */
+Server.prototype.emit = function (event, ...args) {
+  if (event === 'request') {
+    const [request, response] = args;
+    const command = request.headers['x-ssr-profile'];
+
+    if (command === 'start' || command === 'end') {
+      if (command === 'start') startProfileWindow();
+      const cpu = process.cpuUsage();
+      const thread = process.threadCpuUsage?.();
+      const threadCpu = thread ? thread.user + thread.system : undefined;
+      const at = Number(process.hrtime.bigint() / 1000n);
+      const result = command === 'end' && started
+        ? { start: started.at, end: at, requests, cpuUs: cpu.user + cpu.system - started.cpu, ...(threadCpu === undefined || started.threadCpu === undefined ? {} : { mainThreadCpuUs: threadCpu - started.threadCpu }) }
+        : { start: at };
+
+      started = { at, cpu: cpu.user + cpu.system, threadCpu };
+      requests = 0;
+      if (command === 'end') endProfileWindow();
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify(result));
+
+      return true;
+    }
+
+    requests += 1;
+  }
+
+  return emit.call(this, event, ...args);
+};

--- a/scripts/profile-stream.mjs
+++ b/scripts/profile-stream.mjs
@@ -1,0 +1,193 @@
+import http from 'node:http';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createGunzip } from 'node:zlib';
+import express from 'express';
+import compression from 'compression';
+import React, { Suspense } from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { Await, createStaticHandler, useLoaderData } from 'react-router';
+import entry from '../lib/adapters/express/entry.js';
+import createHandler from '../lib/core/handler.js';
+import adapterExpress from '../lib/adapters/express.js';
+import nodeRenderer from '../lib/node/render-to-stream.js';
+import edgeRenderer from '../lib/edge/render-to-stream.js';
+
+const { createElement: element } = React;
+const samples = Number(process.env.SAMPLES ?? 30);
+const concurrency = Number(process.env.CONCURRENCY ?? 10);
+const targetUrl = process.env.PROFILE_URL;
+const warmup = Number(process.env.WARMUP ?? concurrency * 2);
+const warmupConcurrency = Number(process.env.WARMUP_CONCURRENCY ?? concurrency);
+const runtimes = (process.env.RUNTIMES ?? 'raw,managed,node,edge').split(',');
+const encodings = (process.env.ENCODINGS ?? 'identity,gzip').split(',');
+const html = { header: '<!doctype html><html><head><title>Profile</title></head><body><div id="root">', footer: '</div></body></html>' };
+const records = new Map();
+const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36';
+
+assert.ok(Number.isInteger(samples) && samples > 0, 'SAMPLES must be a positive integer.');
+assert.ok(Number.isInteger(concurrency) && concurrency > 0, 'CONCURRENCY must be a positive integer.');
+assert.ok(Number.isInteger(warmup) && warmup >= 0, 'WARMUP must be a nonnegative integer.');
+assert.ok(Number.isInteger(warmupConcurrency) && warmupConcurrency > 0, 'WARMUP_CONCURRENCY must be a positive integer.');
+assert.ok(runtimes.every((runtime) => ['raw', 'managed', 'node', 'edge'].includes(runtime)), 'Unknown RUNTIMES entry.');
+assert.ok(encodings.every((encoding) => ['identity', 'gzip'].includes(encoding)), 'Unknown ENCODINGS entry.');
+
+/** Keep the shell independent of the deliberately slow route data. */
+const load = () => ({ slow: new Promise((resolve) => setTimeout(() => resolve('ready'), 800)) });
+
+/** Render the same suspended content in every runtime. */
+const Content = ({ slow }) => element(Suspense, { fallback: element('p', null, 'loading') }, element(Await, { resolve: slow }, (value) => element('p', null, value)));
+
+/** Read router data without adding application work. */
+const Page = () => element(Content, useLoaderData());
+
+/** Keep application markup identical across transports. */
+const App = ({ children }) => element('main', null, children);
+const routes = [
+  { path: '/:runtime/home', Component: () => element('p', null, 'home') },
+  { path: '/:runtime/deferred', loader: load, Component: Page },
+];
+const prepared = entry(App, routes);
+const config = { isProd: process.env.NODE_ENV === 'production', getLogger: () => ({ error: console.error, info: () => undefined }), getParams: () => ({ root: process.cwd() }), getVite: () => undefined, isModulePreload: false };
+
+/** Keep the request timeline available after response completion. */
+const onShellReady = ({ context }) => {
+  records.get(context.request.headers.get('x-profile-id')).timeline = context.timeline;
+};
+
+/** Match the buffered home and streamed deferred acceptance cases. */
+const onRouterReady = ({ context }) => ({ isStream: context.request.url.endsWith('/deferred') });
+const options = { diagnostics: false, getHtml: () => html, onShellReady, onRouterReady };
+const nodeHandler = createHandler({ handler: createStaticHandler(routes), createApp: (children) => element(App, null, children), renderToStream: nodeRenderer }, options);
+const edgeHandler = createHandler({ handler: createStaticHandler(routes), createApp: (children) => element(App, null, children), renderToStream: edgeRenderer }, options);
+const app = express();
+
+/** Mark transport entry and the first actual socket write independently of headers. */
+app.use((request, response, next) => {
+  const record = { started: performance.now() };
+  records.set(request.headers['x-profile-id'], record);
+  const { socket } = response;
+  const socketWrite = socket.write;
+  socket.write = function (...args) {
+    record.socketWrite ??= performance.now() - record.started;
+
+    return socketWrite.apply(this, args);
+  };
+  response.once('finish', () => { socket.write = socketWrite; });
+  next();
+});
+app.use(compression());
+
+/** Measure when the adapter hands HTML to compression or the native response. */
+app.use((request, response, next) => {
+  const record = records.get(request.headers['x-profile-id']);
+  const write = response.write;
+  response.write = function (...args) {
+    record.adapterWrite ??= performance.now() - record.started;
+
+    return write.apply(this, args);
+  };
+  next();
+});
+app.use('/node', adapterExpress(nodeHandler));
+app.use('/edge', adapterExpress(edgeHandler));
+
+/** Compare the managed entry with raw React piping on the same Express server. */
+app.use((request, response) => {
+  if (request.path.startsWith('/managed/')) {
+    void prepared.render(config, { req: request, res: response, html, appProps: {} }, { onShellReady, onRouterReady });
+
+    return;
+  }
+  const record = records.get(request.headers['x-profile-id']);
+  const content = request.path.endsWith('/deferred') ? element(Content, load()) : element('p', null, 'home');
+  const rendered = renderToPipeableStream(element(App, null, content), {
+    /** Start raw piping at the earliest React shell callback. */
+    onShellReady() {
+      record.shellReady = performance.now() - record.started;
+      response.setHeader('Content-Type', 'text/html');
+      response.write(html.header);
+      response.flush?.();
+      rendered.pipe(response);
+    },
+    onError: console.error,
+  });
+});
+const server = targetUrl ? undefined : app.listen(0, '127.0.0.1');
+if (server) await once(server, 'listening');
+const origin = targetUrl ?? `http://127.0.0.1:${server.address().port}`;
+let requestId = 0;
+
+/** Measure first decoded HTML as well as the benchmark's header timestamp. */
+const request = (pathname, encoding, agent) => new Promise((resolve, reject) => {
+  const id = String(requestId++);
+  const started = performance.now();
+  const pending = http.get(origin + pathname, { agent, headers: { 'user-agent': userAgent, 'accept-encoding': encoding, 'x-profile-id': id } }, (response) => {
+    const headers = performance.now() - started;
+    const decoded = response.headers['content-encoding'] === 'gzip' ? response.pipe(createGunzip()) : response;
+    let firstHtml;
+    decoded.on('data', () => { firstHtml ??= performance.now() - started; });
+    decoded.on('error', reject);
+    response.on('error', reject);
+    decoded.on('end', () => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`HTTP ${response.statusCode}: ${pathname}`));
+
+        return;
+      }
+
+      const record = records.get(id) ?? {};
+      const stages = Object.fromEntries((record.timeline?.events ?? []).map(({ stage, at }) => [stage, at + record.timeline.started - record.started]));
+      records.delete(id);
+      resolve({ headers, firstHtml, 'router.query': stages['router.query'], prepare: stages.prepare, 'shell.ready': stages['shell.ready'] ?? record.shellReady, 'adapter.write': record.adapterWrite, 'socket.write': record.socketWrite, 'shell-to-write': record.adapterWrite - (stages['shell.ready'] ?? record.shellReady) });
+    });
+  }).on('error', reject);
+  pending.setTimeout(10_000, () => pending.destroy(new Error(`Timed out: ${pathname}`)));
+});
+
+/** Use fixed batches and keep-alive sockets like the public benchmark. */
+const batch = async (pathname, encoding, count, connections = concurrency) => {
+  const agent = new http.Agent({ keepAlive: true, maxSockets: connections });
+  const results = [];
+  try {
+    for (let index = 0; index < count; index += connections) {
+      results.push(...await Promise.all(Array.from({ length: Math.min(connections, count - index) }, () => request(pathname, encoding, agent))));
+    }
+
+    return results;
+  } finally {
+    agent.destroy();
+  }
+};
+
+/** Summarize stage completion with warm p50 measurements. */
+const median = (values) => values.sort((left, right) => left - right)[Math.floor(values.length / 2)];
+
+/** Mark sampling windows and read CPU usage from the opt-in production preload. */
+const control = async (command) => {
+  const response = await fetch(origin, { headers: { 'x-ssr-profile': command } });
+  assert.equal(response.headers.get('content-type'), 'application/json', 'Start the target with --import scripts/profile-server.mjs.');
+
+  return response.json();
+};
+
+try {
+  for (const encoding of encodings) {
+    for (const runtime of targetUrl ? ['production'] : runtimes) {
+      for (const route of targetUrl ? (process.env.ROUTES ?? '/,/items,/items/1').split(',') : ['home', 'deferred']) {
+        const pathname = targetUrl ? route : `/${runtime}/${route}`;
+        await batch(pathname, encoding, warmup, warmupConcurrency);
+        if (targetUrl) await control('start');
+        const results = await batch(pathname, encoding, samples);
+        const usage = targetUrl ? await control('end') : undefined;
+        const medians = Object.fromEntries(Object.keys(results[0]).filter((key) => results.every((result) => Number.isFinite(result[key]))).map((key) => [key, Number(median(results.map((result) => result[key])).toFixed(3))]));
+        console.info(JSON.stringify({ pathname, encoding, samples, concurrency, warmup, warmupConcurrency, ...medians, ...(usage ? { ...usage, cpuUsPerRequest: usage.cpuUs / usage.requests, mainThreadCpuUsPerRequest: usage.mainThreadCpuUs === undefined ? undefined : usage.mainThreadCpuUs / usage.requests } : {}) }));
+      }
+    }
+  }
+} finally {
+  if (server) {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}

--- a/scripts/summarize-cpu.mjs
+++ b/scripts/summarize-cpu.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [profileFile, windowsFile] = process.argv.slice(2);
+assert.ok(profileFile && windowsFile, 'Usage: node scripts/summarize-cpu.mjs profile.cpuprofile profile-stream.jsonl');
+const profile = JSON.parse(await readFile(profileFile, 'utf8'));
+const windows = (await readFile(windowsFile, 'utf8')).trim().split('\n').map((line) => JSON.parse(line));
+const nodes = new Map(profile.nodes.map((node) => [node.id, node]));
+const parents = new Map(profile.nodes.flatMap(({ id, children = [] }) => children.map((child) => [child, id])));
+const categories = new Map();
+const markers = [];
+let sampleTime = profile.startTime;
+let previousMarker;
+
+/** Use sampled markers because V8 and Node can expose different monotonic clocks. */
+for (let index = 0; index < profile.samples.length; index += 1) {
+  sampleTime += profile.timeDeltas[index];
+  let marker;
+  for (let current = profile.samples[index]; current; current = parents.get(current)) {
+    const { functionName } = nodes.get(current).callFrame;
+    if (functionName === 'startProfileWindow' || functionName === 'endProfileWindow') marker = functionName;
+  }
+  if (marker && marker !== previousMarker) markers.push({ marker, at: sampleTime });
+  if (marker) previousMarker = marker;
+}
+
+assert.equal(markers.length, windows.length * 2, 'Profile must contain start/end markers for every measured window.');
+
+/** Attribute native work to its closest identifiable caller without double counting. */
+const category = (id) => {
+  if (categories.has(id)) return categories.get(id);
+  const frames = [];
+  for (let current = id; current; current = parents.get(current)) frames.push(nodes.get(current).callFrame);
+  const leaf = frames[0];
+  let result = 'Node / other';
+
+  if (leaf.functionName === '(idle)') result = 'Idle';
+  else if (leaf.functionName === '(garbage collector)') result = 'GC';
+  else if (frames.some(({ url }) => /react-dom/.test(url))) result = 'React rendering';
+  else {
+    for (const { url, functionName } of frames) {
+      if (/profile-server\.mjs/.test(url)) { result = 'Profiler control'; break; }
+      if (/react-dom/.test(url)) { result = 'React rendering'; break; }
+      if (/devalue|core\/data-stream|helpers\/(?:build-router-state|serialize-errors|try-json)/.test(url)) { result = 'Data / serialization'; break; }
+      if (/core\/(?:compose-html|transform-html|html-boundary)/.test(url)) { result = 'HTML chunk pipeline'; break; }
+      if (/route-assets|ssr-manifest/.test(url)) { result = 'Asset preparation'; break; }
+      if (/core\/(?:spa-shell|spa-html|ssr-policy)|node_modules\/isbot\//.test(url)) { result = 'SPA / policy'; break; }
+      if (/diagnostics|request-timeline/.test(url)) { result = 'Diagnostics / timeline'; break; }
+      if (/core\/headers|node\/(?:create-headers|write-fetch-response)|internal\/deps\/undici/.test(url) && /[Hh]eader|headers/.test(functionName + url)) { result = 'Headers'; break; }
+      if (/node_modules\/(?:serve-static|send)\//.test(url)) { result = 'Static middleware'; break; }
+      if (/node_modules\/compression\/|node:zlib/.test(url)) { result = 'Compression'; break; }
+      if (/cookie-parser|body-parser/.test(url)) { result = 'Cookie / body parsing'; break; }
+      if (/react-router/.test(url)) { result = 'Router query / matching'; break; }
+      if (/vite-ssr-boost\//.test(url)) { result = 'Other boost / bridge'; break; }
+      if (/node_modules\/(?:express|router)\//.test(url)) { result = 'Express dispatch'; break; }
+      if (/node:_http|node:net|internal\/stream_base_commons/.test(url)) { result = 'Node HTTP / socket'; break; }
+    }
+  }
+
+  categories.set(id, result);
+
+  return result;
+};
+
+/** Restrict samples to measured requests, excluding module loading and warm-up. */
+for (const [windowIndex, window] of windows.entries()) {
+  const start = markers[windowIndex * 2].at + 3000;
+  const end = markers[windowIndex * 2 + 1].at;
+  const stages = {};
+  let at = profile.startTime;
+
+  for (let index = 0; index < profile.samples.length; index += 1) {
+    const elapsed = profile.timeDeltas[index];
+    at += elapsed;
+    if (at < start || at > end) continue;
+    const stage = category(profile.samples[index]);
+    stages[stage] = (stages[stage] ?? 0) + elapsed;
+  }
+
+  const perRequest = Object.fromEntries(Object.entries(stages).filter(([name]) => name !== 'Idle' && name !== 'Profiler control').map(([name, total]) => [name, Number((total / window.requests).toFixed(1))]));
+  console.info(JSON.stringify({ pathname: window.pathname, encoding: window.encoding, requests: window.requests, sampledUsPerRequest: perRequest }));
+}

--- a/scripts/test-browser-size.mjs
+++ b/scripts/test-browser-size.mjs
@@ -80,7 +80,7 @@ const options = {
   plugins: [{
     name: 'reject-server-dependencies',
     setup(builder) {
-      builder.onResolve({ filter: /^(?:node:|(?:express|chalk|commander|json5)(?:\/|$))/ }, ({ path, importer }) => ({
+      builder.onResolve({ filter: /^(?:node:|(?:express|compression|isbot|chalk|commander|json5)(?:\/|$))/ }, ({ path, importer }) => ({
         errors: [{ text: `Forbidden browser dependency ${path} imported by ${importer}` }],
       }));
     },

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -15,6 +15,7 @@ import { createProductionMemoryProbe, configureProductionMeasurements, startProd
 // set this to Math.ceil(measured gzip KB * 1.05); document the reason and new size.
 const TEMPLATE_CLIENT_GZIP_BUDGET_KB = 154;
 const TEMPLATE_HOME_MARKER = 'SPA, SSR, Mobx, Consistent Suspense, Meta tags';
+const BROWSER_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36';
 
 const projectRoot = process.cwd();
 const source = resolve(process.argv[2] ?? join(projectRoot, '..', 'vite-template'));
@@ -29,6 +30,8 @@ const acceptance = {
   candidateRss: undefined,
   baselineTtfb: undefined,
   candidateTtfb: undefined,
+  baselineDeferredTtfb: undefined,
+  candidateDeferredTtfb: undefined,
   chunks: [],
   deferred: [],
   policyInfo: 0,
@@ -180,19 +183,28 @@ const inspectStream = (origin, pathname, headers = {}) =>
     request.on('error', reject);
   });
 
+/** Compare warmed routes in alternating order with the same browser headers and socket policy. */
 const measureTtfb = async (origin) => {
-  await inspectStream(origin, '/');
-  await inspectStream(origin, '/');
+  const samples = { '/': [], '/deferred': [] };
+  const headers = { 'User-Agent': BROWSER_USER_AGENT, 'Accept-Encoding': 'identity' };
 
-  const samples = [];
+  for (let sample = -3; sample < 11; sample += 1) {
+    const paths = sample % 2 === 0 ? ['/', '/deferred'] : ['/deferred', '/'];
 
-  for (let sample = 0; sample < 7; sample += 1) {
-    samples.push((await inspectStream(origin, '/')).firstChunkMs);
+    for (const pathname of paths) {
+      const { status, firstChunkMs } = await inspectStream(origin, pathname, headers);
+
+      assert.equal(status, 200, `TTFB ${pathname} status`);
+      assert.ok(Number.isFinite(firstChunkMs), `TTFB ${pathname} must contain HTML`);
+
+      if (sample >= 0) samples[pathname].push(firstChunkMs);
+    }
   }
 
-  samples.sort((left, right) => left - right);
+  /** Keep unrounded medians for the advisory latency comparison. */
+  const median = (values) => values.sort((left, right) => left - right)[Math.floor(values.length / 2)];
 
-  return samples[Math.floor(samples.length / 2)];
+  return { home: median(samples['/']), deferred: median(samples['/deferred']) };
 };
 
 const inspectEarlyStream = async (origin, pathname, mode, headers = {}) => {
@@ -341,7 +353,7 @@ const measureClientGzip = async () => {
 };
 
 const reportAcceptance = async () => {
-  const milliseconds = (value) => value === undefined ? 'not measured' : `${Math.round(value)} ms`;
+  const milliseconds = (value) => value === undefined ? 'not measured' : `${value.toFixed(3)} ms`;
 
   /** Format resident memory independently of heap size. */
   const memory = (value) => value === undefined ? 'not measured' : `${(value / 1024 ** 2).toFixed(2)} MiB`;
@@ -358,6 +370,8 @@ const reportAcceptance = async () => {
     `| Production server RSS after TTFB | ${memory(acceptance.candidateRss)} | ≤ 1.6 × baseline |`,
     `| Baseline median TTFB | ${milliseconds(acceptance.baselineTtfb)} | advisory |`,
     `| Candidate median TTFB | ${milliseconds(acceptance.candidateTtfb)} | advisory |`,
+    `| Baseline /deferred median HTML TTFB | ${milliseconds(acceptance.baselineDeferredTtfb)} | advisory |`,
+    `| Candidate /deferred median HTML TTFB | ${milliseconds(acceptance.candidateDeferredTtfb)} | advisory: <= 1.5 × candidate / |`,
     ...acceptance.chunks.map(({ mode, streamed, buffered, gzip }) =>
       `| ${mode} chunks (streamed / buffered / decoded gzip) | ${streamed} / ${buffered} / ${gzip ?? 'n/a'} | — |`),
     ...acceptance.deferred.map(({ mode, settleMs }) =>
@@ -734,8 +748,9 @@ try {
 
     await waitUntilReady(origin, baseline);
     baselineTtfb = await measureTtfb(origin);
-    acceptance.baselineTtfb = baselineTtfb;
-    console.info(`baseline production median TTFB: ${Math.round(baselineTtfb)}ms`);
+    acceptance.baselineTtfb = baselineTtfb.home;
+    acceptance.baselineDeferredTtfb = baselineTtfb.deferred;
+    console.info(`baseline production median HTML TTFB: / ${baselineTtfb.home.toFixed(3)}ms; /deferred ${baselineTtfb.deferred.toFixed(3)}ms`);
   } finally {
     await stop(baseline);
   }
@@ -779,16 +794,18 @@ try {
     await verify(origin, 'production');
 
     const candidateTtfb = await measureTtfb(origin);
-    acceptance.candidateTtfb = candidateTtfb;
+    acceptance.candidateTtfb = candidateTtfb.home;
+    acceptance.candidateDeferredTtfb = candidateTtfb.deferred;
     acceptance.candidateRss = (await memory()).rss;
-    const allowedTtfb = baselineTtfb + Math.max(35, baselineTtfb * 0.5);
+    const allowedTtfb = baselineTtfb.home + Math.max(35, baselineTtfb.home * 0.5);
 
-    if (candidateTtfb > allowedTtfb) {
+    if (candidateTtfb.home > allowedTtfb) {
       console.warn(`Advisory: production TTFB exceeded ${Math.round(allowedTtfb)}ms; shared-runner timing does not block release.`);
     }
     console.info(
-      `production median TTFB: ${Math.round(baselineTtfb)}ms -> ${Math.round(candidateTtfb)}ms`,
+      `production median HTML TTFB: / ${baselineTtfb.home.toFixed(3)}ms -> ${candidateTtfb.home.toFixed(3)}ms; /deferred ${baselineTtfb.deferred.toFixed(3)}ms -> ${candidateTtfb.deferred.toFixed(3)}ms`,
     );
+    console.info(`Advisory: streamed shell ratio: ${(candidateTtfb.deferred / candidateTtfb.home).toFixed(3)}x / 1.5x target`);
   } finally {
     await stop(prod);
     await dispose();

--- a/src/adapters/express/prepare-server.ts
+++ b/src/adapters/express/prepare-server.ts
@@ -56,6 +56,11 @@ class PrepareServer {
   protected html: string;
 
   /**
+   * Retain the validated production shell without sharing its mutable tuple.
+   */
+  protected htmlParts?: [string, string];
+
+  /**
    * Middlewares configs
    */
   protected middlewaresConfigs?: NonNullable<IPrepareRenderOut['middlewares']>;
@@ -163,6 +168,10 @@ class PrepareServer {
    * Load and return html shell
    */
   public async loadHtml(req: Request): Promise<[string, string]> {
+    if (this.config.isProd && this.htmlParts) {
+      return [...this.htmlParts];
+    }
+
     const { isProd, root, indexFile, clientFile } = this.config.getParams();
 
     if (!this.html || !isProd) {
@@ -190,7 +199,13 @@ class PrepareServer {
       );
     }
 
-    return splitHtmlShell(modifiedHtml, path.resolve(`${root}/${indexFile}`));
+    const parts = splitHtmlShell(modifiedHtml, path.resolve(`${root}/${indexFile}`));
+
+    if (isProd) {
+      this.htmlParts = parts;
+    }
+
+    return [...parts];
   }
 
   /**

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -404,7 +404,7 @@ async function render(
           const legacyContext = syncContext(updated);
           const { matches, isSpa } = updated;
           const manifest = await getRouteAssets(config, matches, isSpa);
-          const hints = manifest.injectAssets(legacyContext);
+          const hints = manifest.injectAssets(legacyContext, Boolean(legacyContext.hasEarlyHints));
 
           if (legacyContext.hasEarlyHints) {
             await emitEarlyHints(executionContext, hints);

--- a/src/adapters/express/server.ts
+++ b/src/adapters/express/server.ts
@@ -7,6 +7,7 @@ import type { Express } from 'express';
 import express from 'express';
 import PrepareServer from '@adapters/express/prepare-server';
 import type { TRender } from '@adapters/express/render';
+import staticFiles from '@adapters/express/static-files';
 import printServerInfo from '@helpers/print-server-info';
 import ServerApi from '@services/server-api';
 import type ServerConfig from '@services/server-config';
@@ -96,7 +97,7 @@ async function createServer(config: ServerConfig): Promise<ICreateServerOut> {
 
       app.use(
         basename!,
-        express.static(path.resolve(`${root}/${publicDir}`), {
+        (isSPA ? express.static : staticFiles)(path.resolve(`${root}/${publicDir}`), {
           ...expressStaticOpts,
           index: isSPA ? undefined : false,
         }),
@@ -116,7 +117,7 @@ async function createServer(config: ServerConfig): Promise<ICreateServerOut> {
             prepareServer.loadHtml(req),
           ]);
           const { appProps, hasEarlyHints, shouldSkip, shouldCancel } =
-            (await onRequest?.(req, res)) ?? {};
+            (onRequest ? await onRequest(req, res) : undefined) ?? {};
           const [header, footer] = clientHtml;
 
           if (shouldCancel || res.writableEnded || res.headersSent) {

--- a/src/adapters/express/static-files.ts
+++ b/src/adapters/express/static-files.ts
@@ -1,0 +1,57 @@
+import { readdirSync } from 'node:fs';
+import type { RequestHandler } from 'express';
+import express from 'express';
+import type { ServeStaticOptions } from 'serve-static';
+
+/**
+ * Send HTML routes directly to SSR while retaining static handling for built file prefixes.
+ */
+const staticFiles = (root: string, options: ServeStaticOptions): RequestHandler => {
+  const serve = express.static(root, options);
+
+  if (options.fallthrough === false || options.extensions) {
+    return serve;
+  }
+
+  let prefixes: Set<string>;
+
+  try {
+    prefixes = new Set(readdirSync(root).map((name) => name.toLowerCase()));
+  } catch {
+    return serve;
+  }
+
+  /**
+   * Keep URL validation, file metadata, ranges and redirects in serve-static.
+   */
+  return (request, response, next) => {
+    let pathname: string;
+
+    try {
+      pathname = decodeURIComponent(request.url.split('?', 1)[0]);
+    } catch {
+      serve(request, response, next);
+
+      return;
+    }
+
+    const separator = pathname.indexOf('/', 1);
+    const prefix = pathname.slice(1, separator < 0 ? undefined : separator).toLowerCase();
+
+    if (
+      prefixes.has(prefix) ||
+      pathname.includes('/.') ||
+      pathname.includes('\\') ||
+      pathname.includes('\0') ||
+      pathname.startsWith('//')
+    ) {
+      serve(request, response, next);
+
+      return;
+    }
+
+    next();
+  };
+};
+
+export default staticFiles;

--- a/src/core/compose-html.ts
+++ b/src/core/compose-html.ts
@@ -2,7 +2,7 @@ import type DataStream from '@core/data-stream';
 import htmlBoundary from '@core/html-boundary';
 import type RequestTimeline from '@services/request-timeline';
 
-/** Stream shell, data frames, React bytes and footer only under downstream demand. */
+/** Queue the prepared shell immediately and pull later bytes only under downstream demand. */
 const composeHtml = (
   header: string,
   body: ReadableStream<Uint8Array>,
@@ -15,11 +15,11 @@ const composeHtml = (
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder();
   const reader = body.getReader();
-  let phase: 'body' | 'footer' | 'header' = 'header';
+  let phase: 'body' | 'footer' = 'body';
   let isStopped = false;
   let isReleased = false;
   let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | undefined;
-  const observe = htmlBoundary();
+  let observe = data && !data.isDone ? htmlBoundary() : undefined;
   let canInject = true;
   let heldChunk: Uint8Array | undefined;
 
@@ -33,6 +33,17 @@ const composeHtml = (
 
   return new ReadableStream<Uint8Array>(
     {
+      /** Make the already-rendered shell available without reading any React bytes. */
+      start(controller) {
+        if (header) {
+          if (isEarly) {
+            timeline?.record('state.emitted', { placement: 'early' });
+          }
+
+          controller.enqueue(encoder.encode(header));
+        }
+      },
+
       /** Cancel immediately; a disconnected consumer cannot receive abort scripts. */
       cancel: async (reason) => {
         isStopped = true;
@@ -52,22 +63,12 @@ const composeHtml = (
       /** Keep at most the one React read requested by the current downstream pull. */
       async pull(controller) {
         try {
-          if (phase === 'header') {
-            phase = 'body';
-
-            if (header) {
-              if (isEarly) {
-                timeline?.record('state.emitted', { placement: 'early' });
-              }
-
-              controller.enqueue(encoder.encode(header));
-
-              return;
-            }
-          }
-
           while (!isStopped) {
             const frames = canInject ? data?.take() : undefined;
+
+            if (canInject && data?.isDone) {
+              observe = undefined;
+            }
 
             if (isStopped) {
               return;
@@ -80,7 +81,7 @@ const composeHtml = (
             }
 
             if (heldChunk) {
-              canInject = observe(heldChunk);
+              canInject = observe?.(heldChunk) ?? true;
               controller.enqueue(heldChunk);
               heldChunk = undefined;
 

--- a/src/core/data-stream.ts
+++ b/src/core/data-stream.ts
@@ -217,7 +217,7 @@ class DataStream {
 
   /** Drain completed value frames before delivering a React boundary chunk. */
   public take(): string {
-    return this.frames.splice(0).join('');
+    return this.frames.length ? this.frames.splice(0).join('') : '';
   }
 
   /** Publish initialization in the selected shell/footer block to unblock hydration. */

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -75,7 +75,7 @@ const createHandler = <TAppProps = Record<string, any>>(
     const timeline = createTimeline(request, isEnabled);
 
     try {
-      const requestInit = await onRequest?.({ executionContext, request });
+      const requestInit = onRequest ? await onRequest({ executionContext, request }) : undefined;
       const isBypass = requestInit instanceof Response;
       const metadata = isBypass ? undefined : requestInit;
       const context: ISsrRequestContext<TAppProps> = {

--- a/src/core/render.tsx
+++ b/src/core/render.tsx
@@ -16,6 +16,7 @@ import type SsrPolicy from '@core/ssr-policy';
 import transformHtml from '@core/transform-html';
 import type { ISsrExecutionContext } from '@core/types';
 import buildCustomState from '@helpers/build-custom-state';
+import buildRouterState from '@helpers/build-router-state';
 import type { IObtainStreamErrorOut } from '@helpers/obtain-stream-error';
 import obtainStreamError from '@helpers/obtain-stream-error';
 import type Diagnostics from '@services/diagnostics';
@@ -191,7 +192,7 @@ const prepareHtmlResponse = <TAppProps,>(
     sessionCookie,
     protectPrivate,
   }: ICoreRenderOptions<TAppProps>,
-  dataStream: DataStream,
+  dataStream?: DataStream,
 ): IHtmlResponse => {
   const serverResponse = context.serverContext!.response;
 
@@ -220,9 +221,13 @@ const prepareHtmlResponse = <TAppProps,>(
   let footer = shellFooter;
 
   if (isEarly) {
-    header += customState + dataStream.state(true);
+    header += customState + dataStream!.state(true);
   } else {
-    footer = customState + dataStream.state(false) + dataStream.take() + footer;
+    const state = dataStream
+      ? dataStream.state(false) + dataStream.take()
+      : buildRouterState(context.routerContext!, undefined, nonce);
+
+    footer = customState + state + footer;
   }
 
   if (rules) {
@@ -272,7 +277,9 @@ const renderResponse = async <TAppProps,>(
       matchRoutes(handler.dataRoutes, new URL(context.request.url), policy?.basename) ?? [];
     context.html = spaShell!(context.html);
 
-    await prepare?.({ context, executionContext });
+    if (prepare) {
+      await prepare({ context, executionContext });
+    }
 
     // Document policies apply to SPA shells too; the no-store default above is their baseline.
     if (rules) {
@@ -300,17 +307,26 @@ const renderResponse = async <TAppProps,>(
 
   context.routerContext = queried;
   context.matches = queried.matches;
-  const dataStream = new DataStream(queried, context.diagnostics, nonce, context.timeline);
+  const { loaderData, actionData, errors } = queried;
+  const hasRouterData =
+    Object.keys(loaderData).length > 0 || actionData !== null || errors !== null;
+  const dataStream =
+    hydration === 'early' || hasRouterData
+      ? new DataStream(queried, context.diagnostics, nonce, context.timeline)
+      : undefined;
 
   try {
-    await prepare?.({ context, executionContext });
+    if (prepare) {
+      await prepare({ context, executionContext });
+    }
+
     context.timeline?.record('prepare');
   } catch (error) {
-    dataStream.cancel();
+    dataStream?.cancel();
     throw error;
   }
 
-  const { isStream = true } = (await onRouterReady?.({ context })) ?? {};
+  const { isStream = true } = (onRouterReady ? await onRouterReady({ context }) : undefined) ?? {};
 
   context.isStream = isStream;
   context.serverContext = {
@@ -368,7 +384,7 @@ const renderResponse = async <TAppProps,>(
     context.timeline?.abort(reason);
     cleanup();
     context.didError ??= StreamError.RenderCancel;
-    dataStream.abort();
+    dataStream?.abort();
     renderController.abort(reason);
     output?.abort(reason);
   };
@@ -424,13 +440,13 @@ const renderResponse = async <TAppProps,>(
       output.abort(abortReason);
     }
 
-    void Promise.all([output.allReady, dataStream.done]).then(clearAbortTimer, clearAbortTimer);
+    void Promise.all([output.allReady, dataStream?.done]).then(clearAbortTimer, clearAbortTimer);
 
     await output.shellReady;
     context.timeline?.record('shell.ready');
 
     if (!isStream) {
-      await Promise.all([output.allReady, dataStream.done]);
+      await Promise.all([output.allReady, dataStream?.done]);
     }
   } catch (error) {
     abort(error);

--- a/src/node/render-to-stream.ts
+++ b/src/node/render-to-stream.ts
@@ -1,11 +1,12 @@
 import { PassThrough, Readable } from 'node:stream';
-import { renderToPipeableStream } from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import type { TRenderToStream } from '@core/render';
+import renderWebStream from '@edge/render-to-stream';
 
 /**
  * Adapt React pipeable rendering to Fetch streams with byte-based backpressure.
  */
-const renderToStream: TRenderToStream = (node, options) => {
+const renderPipeableStream: TRenderToStream = (node, options) => {
   const destination = new PassThrough();
   const stream = Readable.toWeb(destination, {
     strategy: {
@@ -43,7 +44,7 @@ const renderToStream: TRenderToStream = (node, options) => {
 
   let hasShellSettled = false;
   let hasAborted = false;
-  const rendered = renderToPipeableStream(node, {
+  const rendered = ReactDOMServer.renderToPipeableStream(node, {
     nonce: options.nonce,
     bootstrapScriptContent: options.bootstrapScriptContent,
     onAllReady: resolveAll,
@@ -130,5 +131,11 @@ const renderToStream: TRenderToStream = (node, options) => {
     stream,
   };
 };
+
+/** Use React's native Web stream when available, retaining the React 18 bridge. */
+const renderToStream: TRenderToStream =
+  typeof ReactDOMServer.renderToReadableStream === 'function'
+    ? renderWebStream
+    : renderPipeableStream;
 
 export default renderToStream;

--- a/src/node/write-fetch-response.ts
+++ b/src/node/write-fetch-response.ts
@@ -115,14 +115,16 @@ const writeFetchResponse = async (res: TServerResponse, response: Response): Pro
         return;
       }
 
-      if (!res.write(chunk.value)) {
-        await waitForDrain(res);
-      }
+      const hasCapacity = res.write(chunk.value);
 
       /**
        * Express compression buffers otherwise: a gzip header alone is not a usable SSR shell.
        */
       (res as TServerResponse & { flush?: () => void }).flush?.();
+
+      if (!hasCapacity) {
+        await waitForDrain(res);
+      }
     }
 
     if (!res.destroyed && !res.writableEnded) {


### PR DESCRIPTION
## Summary
- Server work per request is lower on the managed Express path and the Fetch core, for buffered and streamed responses: on React versions that expose `renderToReadableStream` (19.2+) the Node renderer uses React's native Web stream instead of the pipeable-to-Web bridge (React 18 keeps the bridge); the validated production HTML shell is split once and reused per request; HTML boundary scanning stops once no data frames can arrive; routes without loader/action data or errors in footer mode emit the plain router state script instead of building a data stream; unused hooks are not awaited; Early Hints are skipped when no transport supports them; the prepared document header is queued as soon as React's shell is ready and compression is flushed before waiting for transport capacity.
- Production static dispatch: the managed server records the built client directory's top-level names at startup and sends other URLs straight to SSR without a `serve-static` filesystem lookup per HTML request; built assets and public files keep validators, ranges, HEAD and redirects (extension fallbacks and `fallthrough: false` keep the unrestricted middleware; add new top-level public files before starting).
- Profiling tools: `scripts/profile-stream.mjs` (raw React, managed Express, Node and edge Fetch cases with request timelines and socket-write marks), `scripts/profile-server.mjs` and `scripts/summarize-cpu.mjs` for CPU profiles of a built app; the template acceptance prints the streamed `/deferred` vs buffered `/` HTML TTFB ratio (advisory) and the browser size checks reject `isbot`/`compression` in browser bundles.

Public benchmark app measured locally with its normal settings (2,000 requests per route, 10 keep-alive connections, headers-received TTFB), same session for every framework:

| Route | boost before | boost after | React Router Framework | Next.js |
| --- | ---: | ---: | ---: | ---: |
| `/` p50 | 2.49 ms | 1.88 ms | 3.83 ms | 7.42 ms |
| `/items` p50 (100 ms loader) | 111.02 ms | 107.74 ms | 112.81 ms | 107.17 ms |
| `/items/1` p50 (streamed shell) | 2.94 ms | 2.42 ms | 3.01 ms | 8.19 ms |

Sampled active CPU per request fell 15 % / 19 % / 6 % on managed Express and 15 % / 21 % / 15 % on the Fetch core for the three routes. Fetched client JavaScript is unchanged: a control build with only `hydrateRoot` + `createBrowserRouter` already measures 89 KB, so with React Router in the bundle boost stays ahead of the React Router-based frameworks (91 vs 100–102 KB) and cannot reach Vike's router-less 85 KB.

## Test plan
- [x] lint, types, unit/integration tests, build, size budgets, `test:core:no-optional`, docs build
- [x] Playwright suite (10 tests incl. the new footer + deferred hydration case), packed Worker and edge suites
- [x] template acceptance with Chromium checks, rollback runs and the cold start / RSS gates, after rebasing onto the cold start change
- [ ] React 18 matrix and Bun boot in CI
