### PR TITLE
docs: link the benchmark repository and describe the runtime matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Deferred router data needs no additional state library. Keep footer hydration by
 
 **Fetch handler.** Import `createHandler` from `@lomray/vite-ssr-boost/core/handler` and connect it through `adapters/node`, `adapters/express`, `adapters/fastify`, `adapters/hono` or `adapters/edge`. Your transport owns the development server, static assets and route-asset injection; follow [Runtime adapters](./docs/guide/runtime-adapters.md) when you need this control.
 
+Both paths are measured weekly in the public [ssr-benchmarks](https://github.com/Lomray-Software/ssr-benchmarks) repository: the same application on vite-ssr-boost, React Router Framework mode, Vike, TanStack Start and Next.js, and a runtime matrix that serves the boost build through Express, `node:http`, Fastify, Hono and Bun. See [Benchmarks](./docs/reference/benchmarks.md) for what is measured and how to reproduce it.
+
 ## Not a fit when
 
 - You need an implementation of React Server Components and Server Actions.
@@ -158,7 +160,7 @@ The [example projects guide](./docs/examples/index.md) explains the wiring in ea
 Test SSR routes without a server with `@lomray/vite-ssr-boost/testing`; see the [Vitest and Playwright guide](https://lomray-software.github.io/vite-ssr-boost/guide/testing).
 
 - [Documentation site](https://lomray-software.github.io/vite-ssr-boost/), [comparison guide](./docs/guide/choosing.md) and [FAQ](./docs/reference/faq.md).
-- [Hydration order and streaming](./docs/reference/hydration-and-streaming.md).
+- [Hydration order and streaming](./docs/reference/hydration-and-streaming.md) and [Benchmarks](./docs/reference/benchmarks.md).
 - API: [Plugin](./docs/api/plugin.md), [Browser entry](./docs/api/browser-entry.md), [Server entry](./docs/api/server-entry.md), [Node production](./docs/api/node-production.md), [Components and helpers](./docs/api/components-and-helpers.md) and [CLI](./docs/api/cli.md).
 
 ## AI agents

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -15,6 +15,14 @@ See the [repository README for current tables and methodology](https://github.co
 
 Raw results include samples, settings, source/lockfile hashes, runtime versions and machine details. Compare complete runs on the same machine and mode; quick runs only check the harness.
 
+## Runtimes
+
+The repository's [Runtimes section](https://github.com/Lomray-Software/ssr-benchmarks#runtimes) serves the same built boost application through seven servers: the managed Express server (`ssr-boost start`), the Fetch core on `node:http`, Fastify, Hono on Node, Hono on Bun, Elysia on Bun and `Bun.serve`. Every variant shares one Fetch handler and one static-file policy, and a parity check proves the HTML, static files, cache validators and status codes are identical before anything is measured.
+
+Per variant, and separately for identity and gzip responses, it records TTFB and full-response percentiles at 10 connections, requests per second with the p99 at 50 and 100 connections, cold start, RSS after the load and after 10,000 further requests (a leak indicator), and CPU per completed request sampled inside the server process. The methodology names which variants compress and how; workerd and Deno are not in the table because they need a different bundle and accounting environment.
+
+Use it to choose a transport for an existing boost application: the managed server is the convenient default, the Fetch adapters remove its overhead, and the Bun variants trade the managed CLI for the highest throughput and lowest memory in that workload.
+
 ## Regenerate or reproduce
 
 The repository's [weekly GitHub Actions workflow](https://github.com/Lomray-Software/ssr-benchmarks/blob/prod/.github/workflows/bench.yml) runs the pinned applications, uploads results, and commits successful full `results/` output and regenerated README tables. It also supports manual dispatch. Failed or incomplete runs are not published as successful results; dependency updates require an app/lockfile change.


### PR DESCRIPTION
## Summary
- Docs-only promotion: README and the Benchmarks reference page link the public benchmark repository and describe the runtime matrix (#56). No package release.

## Test plan
- [x] PR CI on #56 (docs build with link verification)
- [ ] Docs deploy after merge
