### PR TITLE
fix: release per-request memory in the managed express server

### DIFF
--- a/__tests__/adapters/express/render.tsx
+++ b/__tests__/adapters/express/render.tsx
@@ -169,6 +169,43 @@ describe('legacy Express render adapter', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  /**
+   * Preserve reusable hook headers while emitting each response's cookies independently.
+   */
+  it('does not consume cookies from Headers shared by a shell hook', async () => {
+    const sharedHeaders = new Headers({ 'X-Shared': 'yes' });
+
+    sharedHeaders.append('Set-Cookie', 'one=1; Path=/');
+    sharedHeaders.append('Set-Cookie', 'two=2; Path=/');
+
+    const { default: coreRender } =
+      await vi.importActual<typeof import('@core/render')>('@core/render');
+    const handler = createStaticHandler([{ path: '*', Component: () => 'BODY' }]);
+
+    for (let index = 0; index < 2; index += 1) {
+      const { config, context, res } = createContext();
+
+      coreRenderMock.mockImplementationOnce(coreRender);
+      writeFetchResponseMock.mockImplementationOnce(async (_, response: Response) => {
+        await response.text();
+      });
+      await render({ App, handler }, config as never, context as never, {
+
+        /**
+         * Reuse application-owned metadata across otherwise independent requests.
+         */
+        onShellReady: ({ context: hookContext }) => {
+          hookContext.response.headers = sharedHeaders;
+
+          return {};
+        },
+      });
+
+      expect(res.getHeaders()['set-cookie']).toEqual(['one=1; Path=/', 'two=2; Path=/']);
+      expect(sharedHeaders.getSetCookie()).toEqual(['one=1; Path=/', 'two=2; Path=/']);
+    }
+  });
+
   it('supports Fetch request and response metadata without a deprecation warning', async () => {
     const { config, context, logger, res } = createContext();
     const { default: coreRender } =

--- a/__tests__/node/request-signal.ts
+++ b/__tests__/node/request-signal.ts
@@ -1,9 +1,34 @@
 // @vitest-environment node
-import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { EventEmitter, getEventListeners } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
 import createRequestSignal from '@node/request-signal';
 
 describe('request signal', () => {
+
+  /**
+   * Complete the signal lifetime without relying on a future garbage collection cycle.
+   */
+  it('releases Fetch signal followers when a completed request is disposed', () => {
+    const req = new EventEmitter();
+    const res = Object.assign(new EventEmitter(), { writableEnded: true });
+    const { signal, dispose } = createRequestSignal(req as never, res as never);
+    const request = new Request('http://localhost/', { signal });
+    const onAbort = vi.fn();
+
+    request.signal.addEventListener('abort', onAbort, { once: true });
+    expect(getEventListeners(signal, 'abort')).toHaveLength(1);
+
+    dispose();
+    dispose();
+
+    expect(request.signal.aborted).toBe(true);
+    expect(request.signal.reason).toBeNull();
+    expect(onAbort).toHaveBeenCalledOnce();
+    expect(getEventListeners(signal, 'abort')).toHaveLength(0);
+    expect(req.listenerCount('aborted')).toBe(0);
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
   it('recognizes disconnects that happened before rendering started', () => {
     const req = Object.assign(new EventEmitter(), { aborted: true });
     const res = Object.assign(new EventEmitter(), { destroyed: true });
@@ -23,6 +48,7 @@ describe('request signal', () => {
 
     requestSignal.dispose();
 
+    expect(requestSignal.signal.reason).toBeInstanceOf(DOMException);
     expect(req.listenerCount('aborted')).toBe(0);
     expect(res.listenerCount('close')).toBe(0);
   });

--- a/__tests__/scripts/production-budget.js
+++ b/__tests__/scripts/production-budget.js
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { assertProductionBudgets } from '../../scripts/helpers/production-budget.mjs';
+
+const MIB = 1024 ** 2;
+
+/**
+ * Isolate the retained-heap budget from the startup and initial RSS gates.
+ */
+const measurements = (growth) => ({
+  coldStart: { baselineMs: 100, candidateMs: 150 },
+  baselineRss: 100 * MIB,
+  candidateRss: 120 * MIB,
+  baselineRetained: 10 * MIB,
+  baselineLoadRetained: 11 * MIB,
+  candidateRetained: 20 * MIB,
+  candidateLoadRetained: 20 * MIB + growth,
+});
+
+describe('production retained heap budget', () => {
+  /**
+   * Accept the exact allowance and reject even a one-byte excess.
+   */
+  it('compares retained deltas without rounding', () => {
+    expect(() => assertProductionBudgets(measurements(9 * MIB))).not.toThrow();
+    expect(() => assertProductionBudgets(measurements(9 * MIB + 1))).toThrow(
+      /retained heap growth after 10,000 additional requests/,
+    );
+  });
+
+  /**
+   * Require both retained samples before accepting a run.
+   */
+  it('rejects missing retained samples', () => {
+    expect(() => assertProductionBudgets({ ...measurements(0), baselineLoadRetained: undefined })).toThrow();
+    expect(() => assertProductionBudgets({ ...measurements(0), candidateRetained: undefined })).toThrow();
+  });
+});

--- a/__tests__/scripts/production-load.js
+++ b/__tests__/scripts/production-load.js
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import http from 'node:http';
+import { once } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import measureProductionLoad from '../../scripts/helpers/production-load.mjs';
+
+describe('production load measurement', () => {
+
+  /**
+   * Verify the fixed workload consumes bodies and reuses no more than ten connections.
+   */
+  it('completes exactly 10,000 home responses', async () => {
+    let requests = 0;
+    let connections = 0;
+    const server = http.createServer((request, response) => {
+      const { url, headers } = request;
+
+      expect(url).toBe('/');
+      expect(headers['accept-encoding']).toBe('identity');
+      expect(headers['user-agent']).toBe('acceptance-browser');
+      requests += 1;
+      response.end('home');
+    });
+
+    server.on('connection', () => { connections += 1; });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+      await measureProductionLoad(`http://127.0.0.1:${server.address().port}`, 'acceptance-browser');
+      expect(requests).toBe(10_000);
+      expect(connections).toBe(10);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  /**
+   * Stop the load and report an error page instead of recording a misleading RSS sample.
+   */
+  it('rejects HTTP failures and stops scheduling requests', async () => {
+    let requests = 0;
+    const server = http.createServer((_, response) => {
+      requests += 1;
+      response.writeHead(500).end('failure');
+    });
+
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+      await expect(measureProductionLoad(`http://127.0.0.1:${server.address().port}`, 'acceptance-browser')).rejects.toThrow(
+        /Production load must return HTTP 200/,
+      );
+      expect(requests).toBeLessThanOrEqual(10);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/browser-tests/request-lifetime.spec.mjs
+++ b/browser-tests/request-lifetime.spec.mjs
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+import { collectStreamTimeline, expectHydrated } from '../lib/testing/playwright.js';
+
+/**
+ * Keep deferred hydration and subsequent documents intact after completed-request cleanup.
+ */
+test('completed requests do not cancel a later deferred response', async ({ page, request }) => {
+  await collectStreamTimeline(page);
+
+  for (let index = 0; index < 20; index += 1) {
+    const response = await request.get('http://127.0.0.1:4179/footer');
+
+    expect(response.status()).toBe(200);
+    await response.body();
+    await response.dispose();
+  }
+
+  await page.goto('http://127.0.0.1:4179/deferred');
+  await expect(page.locator('[data-resolved]')).toHaveText('Users: 3');
+  await expectHydrated(page);
+  await page.goto('http://127.0.0.1:4179/footer');
+  await page.getByRole('button', { name: 'Count 0' }).click();
+  await expect(page.getByRole('button', { name: 'Count 1' })).toBeVisible();
+  await expectHydrated(page);
+});

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -12,6 +12,24 @@ The package CLI covers the main operational flows:
 - `ssr-boost build-amplify`
 - `ssr-boost build-vercel`
 
+### Choosing a runtime
+
+The managed Express server (`ssr-boost start`) is the convenient default: it supplies the
+production launcher, lifecycle hooks, static files and compression, with opt-in Early Hints.
+
+The [public benchmark's Runtimes section](https://github.com/Lomray-Software/ssr-benchmarks#runtimes)
+serves the same built app through every transport. In that benchmark, the Fetch adapters on
+`node:http`, Fastify and Hono have less overhead than the managed Express server; Bun with
+`Bun.serve`, Hono or Elysia achieves the highest throughput and lowest memory. Compare variants
+within the same run; application work and compression affect the tradeoff.
+
+Custom transports own production startup, static delivery and compression setup, and give up
+the managed production CLI lifecycle and live Express `req`/`res` hooks. You can still use the
+managed CLI for development and builds. The Node and Fastify adapters retain Early Hints when
+the transport supports them and offer opt-in streaming compression. The Hono and Bun Fetch
+paths do not emit Early Hints through these adapters; configure compression in the adapter,
+framework or hosting layer. See [runtime adapters](/guide/runtime-adapters) for integration examples.
+
 ## Build output shape
 
 A normal build creates separate client and server outputs under your Vite `outDir`.
@@ -69,7 +87,9 @@ from timing runs because tracing changes startup costs.
 For repeatable acceptance measurements, run `node scripts/test-template.mjs /path/to/vite-template`
 from the library checkout after `npm run build`. Its cold-start measurement includes the npm
 launcher and waits for a complete HTTP 200, with five fresh processes and 25 ms polling. It also
-samples `process.memoryUsage()` in the listening server after TTFB, without forced GC. Both are
+samples `process.memoryUsage()` in the listening server after TTFB and again after 10,000 additional
+home requests, recording resident memory first and the retained heap after two forced collections.
+Startup, RSS and retained-heap growth are
 compared with a plain ESM Express + `renderToPipeableStream` process using the same installed
 dependencies. See [acceptance gates](/reference/acceptance-gates) for the enforced budgets.
 

--- a/docs/guide/runtime-adapters.md
+++ b/docs/guide/runtime-adapters.md
@@ -308,7 +308,10 @@ receives chunks in either mode; a chunk is not guaranteed to contain a complete 
 `abortDelay` limits React rendering, starting after loaders and request hooks finish. Pass
 `request.signal` to loader fetches to cancel their work on disconnect. Node, Express and Fastify
 stop quietly if a loader rejects after the client disconnects; other handler errors still reach
-the framework's error handler. Shell failures return 500;
+the framework's error handler. Once the handler finishes writing or cancelling its response,
+these adapters abort the request signal and remove transport listeners, releasing Fetch signal
+followers without waiting for garbage collection. Cleanup uses a `null` abort reason; an earlier
+disconnect keeps its original abort reason. Shell failures return 500;
 errors after the shell has been sent keep the committed status and let React recover on the client.
 HEAD and 204/205/304 responses have no body. Set redirects and statuses before the shell is sent;
 components inside a suspended boundary cannot change headers after that point.

--- a/docs/reference/acceptance-gates.md
+++ b/docs/reference/acceptance-gates.md
@@ -49,6 +49,7 @@ Both pinned and `SSR_BOOST_TEMPLATE_CURRENT=1` acceptance enforce these limits i
 | --- | --- |
 | Production cold start | At most **2 ×** the plain baseline median measured in the same run |
 | Production server RSS after TTFB | At most **1.6 ×** the plain baseline RSS measured in the same run |
+| Production retained heap growth after 10,000 additional requests | At most the plain baseline's retained-heap delta **+ 8 MiB**, both measured after forced GC |
 
 The plain baseline is an ESM Express server rendering one React element with
 `react-dom/server`'s `renderToPipeableStream`, using the template's installed Express/React versions.
@@ -60,7 +61,17 @@ caches stay warm, matching the public benchmark's process-cold methodology.
 RSS comes from `process.memoryUsage()` in the listening Node process, immediately after the
 existing TTFB run (two warm-up requests and seven samples). The candidate also exercises the
 existing production HTTP checks before TTFB. The runner records the listening PID and requests a
-sample by signal; it does not measure npm's RSS, add an application endpoint or force GC.
+sample by signal; it does not measure npm's RSS or add an application endpoint, and it records RSS before the forced collections used for the retained-heap rows.
+
+After each server's TTFB sample, the runner completes exactly 10,000 additional `/` requests
+with the TTFB run's browser user agent, identity encoding and ten HTTP/1.1 keep-alive connections,
+consumes every body, then samples memory again in the same process. Every response must be HTTP
+200. Both servers run with `--expose-gc`; each memory sample records resident memory as-is and
+then the heap in use after two forced collections. The budget compares the retained-heap deltas
+(after load minus after TTFB) because resident memory also grows with GC timing and allocator
+high-water marks: a plain Express server gains tens of MiB of RSS over 10,000 requests while its
+retained heap stays flat. The RSS rows after load stay in the summary as advisory values;
+**1 MiB = 1,048,576 bytes**. Use heap snapshots to attribute a retained-heap regression.
 
 The step summary prints both candidate/baseline cold-start medians and RSS values alongside the
 existing advisory **Production server ready** line, which retains the direct CLI spawn and its

--- a/scripts/helpers/production-budget.mjs
+++ b/scripts/helpers/production-budget.mjs
@@ -18,6 +18,12 @@ const COLD_START_RATIO = 2;
 const RSS_RATIO = 1.6;
 
 /**
+ * Allow eight MiB of retained heap growth beyond the plain baseline after sustained load;
+ * resident memory is reported but not budgeted because V8 keeps freed pages resident.
+ */
+const RETAINED_GROWTH_ALLOWANCE = 8 * 1024 ** 2;
+
+/**
  * Compare the middle sample without rounding away budget failures.
  */
 const median = (samples) => [...samples].sort((left, right) => left - right)[Math.floor(samples.length / 2)];
@@ -76,7 +82,7 @@ const createProductionMemoryProbe = async (port) => {
       SSR_BOOST_ACCEPTANCE_PORT: String(port),
       SSR_BOOST_ACCEPTANCE_PID: pidFile,
       SSR_BOOST_ACCEPTANCE_MEMORY: memoryFile,
-      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --require ${JSON.stringify(hook)}`,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --expose-gc --require ${JSON.stringify(hook)}`,
     },
 
     /** Remove the private PID and memory samples after the server stops. */
@@ -204,13 +210,28 @@ const measureProductionColdStart = async ({ directory, getPort }) => {
 /**
  * Fail independently on startup latency and resident memory overhead.
  */
-const assertProductionBudgets = ({ coldStart, baselineRss, candidateRss }) => {
+const assertProductionBudgets = ({
+  coldStart,
+  baselineRss,
+  candidateRss,
+  baselineRetained,
+  candidateRetained,
+  baselineLoadRetained,
+  candidateLoadRetained,
+}) => {
   const { candidateMs, baselineMs } = coldStart;
 
   assert.ok(candidateMs <= baselineMs * COLD_START_RATIO,
     `Production cold start ${candidateMs.toFixed(1)} ms exceeds ${COLD_START_RATIO} × plain baseline ${baselineMs.toFixed(1)} ms.`);
   assert.ok(candidateRss <= baselineRss * RSS_RATIO,
     `Production RSS ${(candidateRss / 1024 ** 2).toFixed(2)} MiB exceeds ${RSS_RATIO} × plain baseline ${(baselineRss / 1024 ** 2).toFixed(2)} MiB.`);
+
+  const baselineGrowth = baselineLoadRetained - baselineRetained;
+  const candidateGrowth = candidateLoadRetained - candidateRetained;
+
+  assert.ok(Number.isFinite(baselineGrowth) && Number.isFinite(candidateGrowth), 'Retained heap samples are missing.');
+  assert.ok(candidateGrowth <= baselineGrowth + RETAINED_GROWTH_ALLOWANCE,
+    `Production retained heap growth after 10,000 additional requests ${(candidateGrowth / 1024 ** 2).toFixed(2)} MiB exceeds plain baseline growth ${(baselineGrowth / 1024 ** 2).toFixed(2)} MiB + 8 MiB.`);
 };
 
 export { createProductionMemoryProbe, configureProductionMeasurements, startProductionMeasurement, measureProductionColdStart, assertProductionBudgets };

--- a/scripts/helpers/production-load.mjs
+++ b/scripts/helpers/production-load.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+/**
+ * Consume a complete identity response before reusing its connection.
+ */
+const requestHome = (origin, agent, userAgent) => new Promise((resolve, reject) => {
+  const request = http.get(origin, {
+    agent,
+    headers: { 'Accept-Encoding': 'identity', 'User-Agent': userAgent },
+  });
+  const timer = setTimeout(() => request.destroy(new Error('Production load request timed out.')), 10_000);
+
+  /**
+   * Stop the deadline when the transport fails or the response is truncated.
+   */
+  const onError = (error) => {
+    clearTimeout(timer);
+    reject(error);
+  };
+
+  request.once('error', onError);
+
+  /**
+   * Reject error pages and encoded bodies instead of accepting an invalid load sample.
+   */
+  request.once('response', (response) => {
+    const { statusCode, headers } = response;
+
+    response.once('error', onError);
+    response.once('end', () => {
+      clearTimeout(timer);
+
+      try {
+        assert.equal(statusCode, 200, 'Production load must return HTTP 200.');
+        assert.equal(headers['content-encoding'] ?? 'identity', 'identity');
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    });
+    response.resume();
+  });
+});
+
+/**
+ * Exercise exactly 10,000 additional home requests at ten keep-alive connections.
+ */
+const measureProductionLoad = async (origin, userAgent) => {
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 10 });
+  let requests = 0;
+  let failure;
+
+  /**
+   * Stop scheduling on failure while allowing the other in-flight requests to settle.
+   */
+  const consume = async () => {
+    while (requests < 10_000 && !failure) {
+      requests += 1;
+
+      try {
+        await requestHome(origin, agent, userAgent);
+      } catch (error) {
+        failure = error;
+      }
+    }
+  };
+
+  try {
+    await Promise.all(Array.from({ length: 10 }, consume));
+
+    if (failure) {
+      throw failure;
+    }
+  } finally {
+    agent.destroy();
+  }
+};
+
+export default measureProductionLoad;

--- a/scripts/helpers/production-memory.cjs
+++ b/scripts/helpers/production-memory.cjs
@@ -22,10 +22,18 @@ net.Server.prototype.listen = function (...args) {
     fs.writeFileSync(SSR_BOOST_ACCEPTANCE_PID, JSON.stringify({ pid: process.pid }));
 
     /**
-     * Report the server's resident memory without forcing garbage collection.
+     * Report resident memory as-is, then the retained heap after forced collections when GC is exposed.
      */
     process.on('SIGUSR2', () => {
-      fs.writeFileSync(SSR_BOOST_ACCEPTANCE_MEMORY, JSON.stringify({ pid: process.pid, ...process.memoryUsage() }));
+      const sample = { pid: process.pid, ...process.memoryUsage() };
+
+      if (typeof global.gc === 'function') {
+        global.gc();
+        global.gc();
+        sample.afterGc = process.memoryUsage();
+      }
+
+      fs.writeFileSync(SSR_BOOST_ACCEPTANCE_MEMORY, JSON.stringify(sample));
     });
   });
 

--- a/scripts/test-template.mjs
+++ b/scripts/test-template.mjs
@@ -10,6 +10,7 @@ import { createGunzip, gzipSync } from 'node:zlib';
 import { stripVTControlCharacters } from 'node:util';
 import { parse } from '@babel/parser';
 import { createProductionMemoryProbe, configureProductionMeasurements, startProductionMeasurement, measureProductionColdStart, assertProductionBudgets } from './helpers/production-budget.mjs';
+import measureProductionLoad from './helpers/production-load.mjs';
 
 // KB = 1024 bytes. For intentional growth, measure the pinned template again and
 // set this to Math.ceil(measured gzip KB * 1.05); document the reason and new size.
@@ -28,6 +29,12 @@ const acceptance = {
   coldStart: undefined,
   baselineRss: undefined,
   candidateRss: undefined,
+  baselineLoadRss: undefined,
+  candidateLoadRss: undefined,
+  baselineRetained: undefined,
+  candidateRetained: undefined,
+  baselineLoadRetained: undefined,
+  candidateLoadRetained: undefined,
   baselineTtfb: undefined,
   candidateTtfb: undefined,
   baselineDeferredTtfb: undefined,
@@ -368,6 +375,10 @@ const reportAcceptance = async () => {
     `| Production cold start (npm, median of 5) | ${milliseconds(acceptance.coldStart?.candidateMs)} | ≤ 2 × baseline |`,
     `| Plain server RSS after TTFB | ${memory(acceptance.baselineRss)} | baseline |`,
     `| Production server RSS after TTFB | ${memory(acceptance.candidateRss)} | ≤ 1.6 × baseline |`,
+    `| Plain server RSS after 10,000 additional requests | ${memory(acceptance.baselineLoadRss)} | advisory |`,
+    `| Production server RSS after 10,000 additional requests | ${memory(acceptance.candidateLoadRss)} | advisory |`,
+    `| Plain retained heap after GC (after TTFB / after 10,000 requests / delta) | ${memory(acceptance.baselineRetained)} / ${memory(acceptance.baselineLoadRetained)} / ${memory(acceptance.baselineLoadRetained === undefined ? undefined : acceptance.baselineLoadRetained - acceptance.baselineRetained)} | baseline delta |`,
+    `| Production retained heap after GC (after TTFB / after 10,000 requests / delta) | ${memory(acceptance.candidateRetained)} / ${memory(acceptance.candidateLoadRetained)} / ${memory(acceptance.candidateLoadRetained === undefined ? undefined : acceptance.candidateLoadRetained - acceptance.candidateRetained)} | ≤ baseline delta + 8 MiB |`,
     `| Baseline median TTFB | ${milliseconds(acceptance.baselineTtfb)} | advisory |`,
     `| Candidate median TTFB | ${milliseconds(acceptance.candidateTtfb)} | advisory |`,
     `| Baseline /deferred median HTML TTFB | ${milliseconds(acceptance.baselineDeferredTtfb)} | advisory |`,
@@ -796,7 +807,15 @@ try {
     const candidateTtfb = await measureTtfb(origin);
     acceptance.candidateTtfb = candidateTtfb.home;
     acceptance.candidateDeferredTtfb = candidateTtfb.deferred;
-    acceptance.candidateRss = (await memory()).rss;
+    const candidateSample = await memory();
+
+    acceptance.candidateRss = candidateSample.rss;
+    acceptance.candidateRetained = candidateSample.afterGc?.heapUsed;
+    await measureProductionLoad(origin, BROWSER_USER_AGENT);
+    const candidateLoadSample = await memory();
+
+    acceptance.candidateLoadRss = candidateLoadSample.rss;
+    acceptance.candidateLoadRetained = candidateLoadSample.afterGc?.heapUsed;
     const allowedTtfb = baselineTtfb.home + Math.max(35, baselineTtfb.home * 0.5);
 
     if (candidateTtfb.home > allowedTtfb) {
@@ -815,7 +834,15 @@ try {
 
   try {
     await measureTtfb(plain.origin);
-    acceptance.baselineRss = (await plain.memory()).rss;
+    const baselineSample = await plain.memory();
+
+    acceptance.baselineRss = baselineSample.rss;
+    acceptance.baselineRetained = baselineSample.afterGc?.heapUsed;
+    await measureProductionLoad(plain.origin, BROWSER_USER_AGENT);
+    const baselineLoadSample = await plain.memory();
+
+    acceptance.baselineLoadRss = baselineLoadSample.rss;
+    acceptance.baselineLoadRetained = baselineLoadSample.afterGc?.heapUsed;
   } finally {
     await plain.stop();
   }

--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -49,8 +49,11 @@ const adapterExpress = (
         .catch(onError)
         .finally(requestSignal.dispose);
     } catch (error) {
-      requestSignal.dispose();
-      onError(error);
+      try {
+        onError(error);
+      } finally {
+        requestSignal.dispose();
+      }
     }
   };
 };

--- a/src/adapters/express/render.tsx
+++ b/src/adapters/express/render.tsx
@@ -131,11 +131,12 @@ const prepareResponse = (context: ISsrRequestContext, res: ExpressResponse): voi
 const syncResponse = (
   context: ISsrRequestContext,
   res: ExpressResponse,
-  previous: ISsrRequestContext['response'],
+  previous?: ISsrRequestContext['response'],
 ): void => {
-  // Apply Fetch metadata edits before reading legacy metadata back. Unchanged
-  // Fetch values must not overwrite edits made through the live Express response.
-  if (!res.headersSent && !res.writableEnded) {
+  /**
+   * Preserve live Express edits when the shell hook leaves Fetch metadata unchanged.
+   */
+  if (previous && !res.headersSent && !res.writableEnded) {
     if (context.response.status !== previous.status) {
       res.status(context.response.status ?? 200);
     }
@@ -230,28 +231,28 @@ async function render(
     abortDelay = 15000,
   }: IRenderOptions,
 ): Promise<void> {
-  const { appProps, html: shellHtml, req, res } = initialContext;
+  const { req, res } = initialContext;
   const Logger = config.getLogger();
   const requestSignal = createRequestSignal(req, res);
+
   try {
-    const context: IRequestContext = Object.assign(initialContext, {
-      request: createRenderRequest(req, requestSignal.signal, getBody),
+    const request = createRenderRequest(req, requestSignal.signal, getBody);
+
+    /**
+     * Share mutable request state with the core so legacy hooks need no field copies.
+     */
+    const context: IRequestContext & ISsrRequestContext = Object.assign(initialContext, {
+      request,
       response: { headers: new Headers() },
-    });
-    const coreContext: ISsrRequestContext = {
-      appProps,
       diagnostics: isDiagnosticsEnabled(!config.isProd)
-        ? new Diagnostics(new URL(context.request.url).pathname, Logger)
+        ? new Diagnostics(new URL(request.url).pathname, Logger)
         : undefined,
-      html: shellHtml,
-      request: context.request,
-      response: context.response,
-    };
+    });
 
     // Keep plain data properties in production, even with diagnostics forced on.
     // Adapter internals retain req/res locals so only consumer reads warn.
-    if (!config.isProd && coreContext.diagnostics) {
-      const { diagnostics } = coreContext;
+    if (!config.isProd && context.diagnostics) {
+      const { diagnostics } = context;
 
       for (const name of ['req', 'res'] as const) {
         let value = context[name];
@@ -271,34 +272,14 @@ async function render(
       }
     }
 
-    const { response: initialResponse } = coreContext;
+    const { response: initialResponse } = context;
 
-    syncResponse(coreContext, res, {
-      headers: new Headers(initialResponse.headers),
-      status: initialResponse.status,
-    });
+    syncResponse(context, res);
 
     if (initialResponse.status === 200) {
       initialResponse.status = undefined;
     }
 
-    /**
-     * Keep legacy hooks attached to their original mutable request context.
-     */
-    const syncContext = (updated: ISsrRequestContext): IRequestContext => {
-      context.request = updated.request;
-      context.response = updated.response;
-      context.didError = updated.didError;
-      context.html = updated.html;
-      context.isStream = updated.isStream;
-      context.isSpa = updated.isSpa;
-      context.matches = updated.matches;
-      context.routerContext = updated.routerContext;
-      context.serverContext = updated.serverContext;
-      context.timeline = updated.timeline;
-
-      return context;
-    };
     const response = await coreRender(
       {
         /**
@@ -312,7 +293,7 @@ async function render(
         spaShell,
         renderToStream,
       },
-      coreContext,
+      context,
       {
         abortDelay,
         hydration,
@@ -325,17 +306,15 @@ async function render(
         /**
          * Read custom state through the legacy request context.
          */
-        getState: getState
-          ? ({ context: updated }) => getState({ context: syncContext(updated) })
-          : undefined,
+        getState: getState ? () => getState({ context }) : undefined,
 
         /**
          * Preserve legacy error hooks and keep expected aborts at info level.
          */
-        onError: ({ context: updated, error }) => {
+        onError: ({ error }) => {
           const { code, message } = error;
 
-          onError?.({ context: syncContext(updated), error });
+          onError?.({ context, error });
           Logger.info(chalk.red(`Stream error. Code: ${code}`));
 
           if (
@@ -359,40 +338,32 @@ async function render(
          * Forward HTML chunks and the end signal through the legacy request context.
          */
         onResponse: onResponse
-          ? ({ context: updated, html, isEnd }) =>
-              onResponse({ context: syncContext(updated), html, isEnd })
+          ? ({ html, isEnd }) => onResponse({ context, html, isEnd })
           : undefined,
 
         /**
          * Expose router state before the legacy hook chooses a rendering mode.
          */
-        onRouterReady: onRouterReady
-          ? ({ context: updated }) => onRouterReady({ context: syncContext(updated) })
-          : undefined,
+        onRouterReady: onRouterReady ? () => onRouterReady({ context }) : undefined,
 
         /**
          * Let the legacy hook replace the default shell-error response.
          */
-        onShellError: onShellError
-          ? ({ context: updated, error }) => onShellError({ context: syncContext(updated), error })
-          : undefined,
+        onShellError: onShellError ? ({ error }) => onShellError({ context, error }) : undefined,
 
         /**
          * Synchronize response metadata around the legacy shell hook.
          */
-        onShellReady: ({ context: updated }) => {
-          const legacyContext = syncContext(updated);
+        onShellReady: () => {
+          prepareResponse(context, res);
 
-          prepareResponse(updated, res);
+          const { response: shellResponse } = context;
+          const { headers, status } = shellResponse;
+          const previous = onShellReady ? { headers: new Headers(headers), status } : undefined;
 
-          const previous = {
-            headers: new Headers(updated.response.headers),
-            status: updated.response.status,
-          };
+          const shell = onShellReady?.({ context });
 
-          const shell = onShellReady?.({ context: legacyContext });
-
-          syncResponse(updated, res, previous);
+          syncResponse(context, res, previous);
 
           return shell ?? {};
         },
@@ -400,13 +371,12 @@ async function render(
         /**
          * Prepare Vite assets and send requested early hints before rendering.
          */
-        prepare: async ({ context: updated, executionContext }) => {
-          const legacyContext = syncContext(updated);
-          const { matches, isSpa } = updated;
+        prepare: async ({ executionContext }) => {
+          const { matches, isSpa, hasEarlyHints } = context;
           const manifest = await getRouteAssets(config, matches, isSpa);
-          const hints = manifest.injectAssets(legacyContext, Boolean(legacyContext.hasEarlyHints));
+          const hints = manifest.injectAssets(context, Boolean(hasEarlyHints));
 
-          if (legacyContext.hasEarlyHints) {
+          if (hasEarlyHints) {
             await emitEarlyHints(executionContext, hints);
           }
         },
@@ -419,8 +389,6 @@ async function render(
         onEarlyHints: (headers) => writeEarlyHints(res, headers),
       },
     );
-
-    syncContext(coreContext);
 
     await writeResponse(res, response);
   } finally {

--- a/src/node/request-signal.ts
+++ b/src/node/request-signal.ts
@@ -26,11 +26,16 @@ const createRequestSignal = (req: TIncomingMessage, res: TServerResponse): IRequ
   };
 
   /**
-   * Remove transport listeners after the handler finishes.
+   * Release transport listeners and Fetch signal followers when the handler finishes.
    */
   const dispose = (): void => {
     req.off('aborted', abort);
     res.off('close', onClose);
+
+    /**
+     * Completion is not a transport failure and needs no per-request error stack.
+     */
+    controller.abort(null);
   };
 
   req.once('aborted', abort);


### PR DESCRIPTION
## Summary
- The benchmark's runtime matrix showed the managed Express server's RSS growing by +61 MiB over 10,000 extra requests while the other variants grew by 5–14 MiB. Heap snapshots with forced GC show no unbounded leak (retained heap grows ~1 MiB per 10,000 requests; the rest is GC timing and V8 keeping freed pages resident, which a plain Express + React process also shows), but they did show avoidable temporary retention: completed requests kept their `AbortSignal`, listeners and Undici follower bookkeeping alive until finalizers ran (signal count 956 → 2,706 over the load).
- Request disposal in the Express, Node and Fastify adapters now removes the transport listeners and aborts the source signal with a `null` reason once the response is written or cancelled, releasing Fetch followers immediately; an earlier disconnect keeps its original reason, and conversion errors reach the error handler before disposal.
- The managed render bridge shares one mutable context with the core instead of copying fields between two contexts on every hook and snapshots response headers only when a shell hook needs the comparison: +1.5 % requests/s and −3 % CPU per request on the benchmark app with identical output.
- Template acceptance measures memory after 10,000 additional home requests: both servers run with `--expose-gc`, each sample records RSS as-is and the retained heap after two forced collections; the gate compares retained-heap deltas (candidate ≤ plain baseline delta + 8 MiB) and reports the RSS rows as advisory. Docs: acceptance gates, request-signal lifetime in the adapters guide, and a "Choosing a runtime" subsection linking the benchmark's Runtimes section.

Measured locally on the pinned template: retained heap after GC 20.6 → 21.9 MiB over 10,000 requests (plain baseline 8.5 → 9.4 MiB); RSS 103 → 215 MiB (plain 71 → 129 MiB), which is why RSS growth is not budgeted.

## Test plan
- [x] lint, types, 903 unit/integration tests (new: deterministic signal cleanup, repeated disposal, disconnect reason preservation, shared-context header/cookie behaviour, exact retained-heap budget), build, size budgets, `test:core:no-optional`, docs build
- [x] template acceptance with Chromium checks, cold start/RSS/retained-heap gates and rollback runs; Playwright suite (11 incl. the new request-lifetime hydration case), packed Worker and edge suites, Worker hydration in Chromium
- [ ] React 18 matrix and Bun boot in CI
